### PR TITLE
add dependency for log4j

### DIFF
--- a/windup-grapher/pom.xml
+++ b/windup-grapher/pom.xml
@@ -30,6 +30,11 @@
                 <version>1.7.5</version>
           </dependency>
           <dependency>
+                <groupId>log4j</groupId>
+                <artifactId>log4j</artifactId>
+                <version>1.2.16</version>
+          </dependency>
+          <dependency>
           	<groupId>org.slf4j</groupId>
           	<artifactId>slf4j-log4j12</artifactId>
           	<version>1.7.5</version>


### PR DESCRIPTION
Compilation error since org/jboss/windup/graph/renderer/graphlib/GraphlibWriter.java uses log4j but dependency isn't specified.
