### PR TITLE
Fix NPE when parsing source that uses default package

### DIFF
--- a/windup-engine/src/main/java/org/jboss/windup/decorator/java/JavaASTDecorator.java
+++ b/windup-engine/src/main/java/org/jboss/windup/decorator/java/JavaASTDecorator.java
@@ -61,7 +61,8 @@ public class JavaASTDecorator extends ChainingDecorator<JavaMetadata> {
 		
 		for (Object o : cu.types()) {
 			TypeDeclaration td = (TypeDeclaration) o;
-			String qualifiedTemp = cu.getPackage().getName() + "." + td.getName().toString();
+			String pkg = cu.getPackage() != null ? cu.getPackage().getName() + "." : "";
+			String qualifiedTemp = pkg + td.getName().toString();
 
 			if (StringUtils.equals(qualifiedTemp, meta.getQualifiedClassName())) {
 				LOG.debug("Matched: " + qualifiedTemp);


### PR DESCRIPTION
Should fix the following NPE:

Exception in thread "main" java.lang.NullPointerException
    at org.jboss.windup.decorator.java.JavaASTDecorator.processMeta(JavaASTDecorator.java:64)
    at org.jboss.windup.decorator.java.JavaASTDecorator.processMeta(JavaASTDecorator.java:32)
    at org.jboss.windup.decorator.ChainingDecorator.chainDecorators(ChainingDecorator.java:47)
    at org.jboss.windup.interrogator.impl.DecoratorPipeline.processMeta(DecoratorPipeline.java:21)
    at org.jboss.windup.interrogator.impl.ExtensionInterrogator.processMeta(ExtensionInterrogator.java:49)
    at org.jboss.windup.interrogator.impl.ExtensionInterrogator.processFile(ExtensionInterrogator.java:79)
    at org.jboss.windup.interrogator.DirectoryInterrogationEngine.process(DirectoryInterrogationEngine.java:71)
    at org.jboss.windup.WindupMetaEngine.processSourceDirectory(WindupMetaEngine.java:190)
    at org.jboss.windup.WindupMetaEngine.getArchiveMeta(WindupMetaEngine.java:156)
    at org.jboss.windup.WindupReportEngine.generateReport(WindupReportEngine.java:121)
    at org.jboss.windup.WindupMain.processInput(WindupMain.java:144)
    at org.jboss.windup.WindupMain.main(WindupMain.java:71)
