### PR TITLE
Changed file formatting from Dos to Unix for jboss-windup.sh

### DIFF
--- a/windup-cli/src/main/assembly/assembly.xml
+++ b/windup-cli/src/main/assembly/assembly.xml
@@ -20,7 +20,9 @@
             <outputDirectory></outputDirectory>
             <includes>
                 <include>jboss-windup.sh</include>
+                <include>jboss-windup.bat</include>
             </includes>
+            <fileMode>0755</fileMode>
         </fileSet>
         <fileSet>
             <directory>src/main/assembly/extensions</directory>


### PR DESCRIPTION
Modified assembly for windup-cli to copy jboss-windup.bat to target
directory during a build.  Added fileMode attribute with a value of 0755
for the scripts.
