### PR TITLE
WINDUP-159: Added GraphService tests

### DIFF
--- a/graph/tests/src/test/java/org/jboss/windup/graph/typedgraph/TestFooSubModel.java
+++ b/graph/tests/src/test/java/org/jboss/windup/graph/typedgraph/TestFooSubModel.java
@@ -1,5 +1,6 @@
 package org.jboss.windup.graph.typedgraph;
 
+import com.tinkerpop.frames.Property;
 import com.tinkerpop.frames.modules.typedgraph.TypeValue;
 
 /**
@@ -10,4 +11,10 @@ import com.tinkerpop.frames.modules.typedgraph.TypeValue;
 public interface TestFooSubModel extends TestFooModel
 {
 
+    @Property("fooProperty")
+    public String getFoo();
+
+    @Property("fooProperty")
+    public void setFoo(String foo);
+    
 }// class


### PR DESCRIPTION
Added tests for GraphService, since I have not found any other than the one here.

Also 2 notes:
1. Shouldn't GraphService be in the graph-impl module instead of graph-api?
2. Shouldn't Service contain method to remove the vertex? Specifically
`void remove(T model);`
