### PR TITLE
WINDUP-165: Rename all test Models, Operations and Rules with Test~ pref...

### DIFF
--- a/config/tests/src/test/java/org/jboss/windup/config/QueryConditionTest.java
+++ b/config/tests/src/test/java/org/jboss/windup/config/QueryConditionTest.java
@@ -41,15 +41,15 @@ public class QueryConditionTest
     {
         final ForgeArchive archive = ShrinkWrap.create(ForgeArchive.class)
                     .addBeansXML()
-                    .addClasses(MavenExampleRuleProvider.class,
-                                JavaExampleRuleProvider.class,
-                                XmlExampleRuleProvider1.class,
-                                XmlExampleRuleProvider2.class,
-                                XmlExampleRuleProvider3.class,
+                    .addClasses(TestMavenExampleRuleProvider.class,
+                                TestJavaExampleRuleProvider.class,
+                                TestXmlExampleRuleProvider1.class,
+                                TestXmlExampleRuleProvider2.class,
+                                TestXmlExampleRuleProvider3.class,
                                 TestGremlinQueryOnlyRuleProvider.class,
                                 TestXmlMetaFacetModel.class,
                                 TestSomeModel.class,
-                                WindupConfigurationExampleRuleProvider.class)
+                                TestWindupConfigurationExampleRuleProvider.class)
                     .addAsAddonDependencies(
                                 AddonDependencyEntry.create("org.jboss.windup.config:windup-config"),
                                 AddonDependencyEntry.create("org.jboss.windup.graph:windup-graph"),
@@ -149,7 +149,7 @@ public class QueryConditionTest
         methodModelToString.setJavaClass(classModel2);
         methodModelToString.setMethodName("toString");
 
-        WindupConfigurationExampleRuleProvider provider = new WindupConfigurationExampleRuleProvider();
+        TestWindupConfigurationExampleRuleProvider provider = new TestWindupConfigurationExampleRuleProvider();
         Configuration configuration = provider.getConfiguration(context);
 
         RuleSubset.evaluate(configuration).perform(event, evaluationContext);
@@ -187,7 +187,7 @@ public class QueryConditionTest
         methodModelToString.setJavaClass(classModel2);
         methodModelToString.setMethodName("toString");
 
-        JavaExampleRuleProvider provider = new JavaExampleRuleProvider();
+        TestJavaExampleRuleProvider provider = new TestJavaExampleRuleProvider();
         Configuration configuration = provider.getConfiguration(context);
 
         RuleSubset.evaluate(configuration).perform(event, evaluationContext);
@@ -215,7 +215,7 @@ public class QueryConditionTest
         DefaultEvaluationContext evaluationContext = createEvalContext(event);
 
         // build a configuration, and make sure it matches what we expect (4 items)
-        MavenExampleRuleProvider provider = new MavenExampleRuleProvider();
+        TestMavenExampleRuleProvider provider = new TestMavenExampleRuleProvider();
         Configuration configuration = provider.getConfiguration(context);
         RuleSubset.evaluate(configuration).perform(event, evaluationContext);
 
@@ -237,7 +237,7 @@ public class QueryConditionTest
         DefaultEvaluationContext evaluationContext = createEvalContext(event);
 
         // build a configuration, and make sure it matches what we expect (4 items)
-        XmlExampleRuleProvider1 provider = new XmlExampleRuleProvider1();
+        TestXmlExampleRuleProvider1 provider = new TestXmlExampleRuleProvider1();
         Configuration configuration = provider.getConfiguration(context);
         RuleSubset.evaluate(configuration).perform(event, evaluationContext);
 
@@ -267,7 +267,7 @@ public class QueryConditionTest
         DefaultEvaluationContext evaluationContext = createEvalContext(event);
 
         // build a configuration, and make sure it matches what we expect (4 items)
-        XmlExampleRuleProvider2 provider = new XmlExampleRuleProvider2();
+        TestXmlExampleRuleProvider2 provider = new TestXmlExampleRuleProvider2();
         Configuration configuration = provider.getConfiguration(context);
         RuleSubset.evaluate(configuration).perform(event, evaluationContext);
 
@@ -290,7 +290,7 @@ public class QueryConditionTest
         DefaultEvaluationContext evaluationContext = createEvalContext(event);
 
         // build a configuration, and make sure it matches what we expect (4 items)
-        XmlExampleRuleProvider3 provider = new XmlExampleRuleProvider3();
+        TestXmlExampleRuleProvider3 provider = new TestXmlExampleRuleProvider3();
         Configuration configuration = provider.getConfiguration(context);
         RuleSubset.evaluate(configuration).perform(event, evaluationContext);
 

--- a/config/tests/src/test/java/org/jboss/windup/config/TestJavaExampleRuleProvider.java
+++ b/config/tests/src/test/java/org/jboss/windup/config/TestJavaExampleRuleProvider.java
@@ -32,9 +32,9 @@ import com.tinkerpop.gremlin.java.GremlinPipeline;
  * @author <a href="mailto:lincolnbaxter@gmail.com">Lincoln Baxter, III</a>
  * 
  */
-public class JavaExampleRuleProvider extends WindupRuleProvider
+public class TestJavaExampleRuleProvider extends WindupRuleProvider
 {
-    private static final Logger LOG = LoggerFactory.getLogger(JavaExampleRuleProvider.class);
+    private static final Logger LOG = LoggerFactory.getLogger(TestJavaExampleRuleProvider.class);
 
     private final List<JavaMethodModel> results = new ArrayList<>();
 

--- a/config/tests/src/test/java/org/jboss/windup/config/TestMavenExampleRuleProvider.java
+++ b/config/tests/src/test/java/org/jboss/windup/config/TestMavenExampleRuleProvider.java
@@ -24,7 +24,7 @@ import org.ocpsoft.rewrite.context.EvaluationContext;
  * @author <a href="mailto:lincolnbaxter@gmail.com">Lincoln Baxter, III</a>
  * 
  */
-public class MavenExampleRuleProvider extends WindupRuleProvider
+public class TestMavenExampleRuleProvider extends WindupRuleProvider
 {
     private final List<MavenProjectModel> results = new LinkedList<>();
 

--- a/config/tests/src/test/java/org/jboss/windup/config/TestWindupConfigurationExampleRuleProvider.java
+++ b/config/tests/src/test/java/org/jboss/windup/config/TestWindupConfigurationExampleRuleProvider.java
@@ -32,9 +32,9 @@ import com.tinkerpop.gremlin.java.GremlinPipeline;
  * @author <a href="mailto:lincolnbaxter@gmail.com">Lincoln Baxter, III</a>
  * 
  */
-public class WindupConfigurationExampleRuleProvider extends WindupRuleProvider
+public class TestWindupConfigurationExampleRuleProvider extends WindupRuleProvider
 {
-    private static final Logger LOG = LoggerFactory.getLogger(WindupConfigurationExampleRuleProvider.class);
+    private static final Logger LOG = LoggerFactory.getLogger(TestWindupConfigurationExampleRuleProvider.class);
 
     private final List<JavaMethodModel> results = new ArrayList<>();
 
@@ -91,7 +91,7 @@ public class WindupConfigurationExampleRuleProvider extends WindupRuleProvider
                 @Override
                 public void perform(GraphRewrite event, EvaluationContext context, JavaMethodModel methodModel)
                 {
-                    WindupConfigurationExampleRuleProvider.this.config = GraphService
+                    TestWindupConfigurationExampleRuleProvider.this.config = GraphService
                                 .getConfigurationModel(event.getGraphContext());
 
                     results.add(methodModel);

--- a/config/tests/src/test/java/org/jboss/windup/config/TestXmlExampleRuleProvider1.java
+++ b/config/tests/src/test/java/org/jboss/windup/config/TestXmlExampleRuleProvider1.java
@@ -26,7 +26,7 @@ import org.ocpsoft.rewrite.context.EvaluationContext;
  * @author <a href="mailto:lincolnbaxter@gmail.com">Lincoln Baxter, III</a>
  * 
  */
-public class XmlExampleRuleProvider1 extends WindupRuleProvider
+public class TestXmlExampleRuleProvider1 extends WindupRuleProvider
 {
     final List<TestXmlMetaFacetModel> typeSearchResults = new ArrayList<>();
     final Set<String> xmlRootNames = new HashSet<>();

--- a/config/tests/src/test/java/org/jboss/windup/config/TestXmlExampleRuleProvider2.java
+++ b/config/tests/src/test/java/org/jboss/windup/config/TestXmlExampleRuleProvider2.java
@@ -10,8 +10,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.jboss.windup.config.model.TestXmlMetaFacetModel;
+import org.jboss.windup.config.operation.GraphOperation;
 import org.jboss.windup.config.operation.Iteration;
-import org.jboss.windup.config.operation.ruleelement.AbstractIterationOperation;
 import org.jboss.windup.config.query.Query;
 import org.jboss.windup.config.query.QueryPropertyComparisonType;
 import org.jboss.windup.graph.GraphContext;
@@ -23,7 +23,7 @@ import org.ocpsoft.rewrite.context.EvaluationContext;
  * @author <a href="mailto:lincolnbaxter@gmail.com">Lincoln Baxter, III</a>
  * 
  */
-public class XmlExampleRuleProvider3 extends WindupRuleProvider
+public class TestXmlExampleRuleProvider2 extends WindupRuleProvider
 {
     final List<TestXmlMetaFacetModel> typeSearchResults = new ArrayList<>();
 
@@ -38,21 +38,24 @@ public class XmlExampleRuleProvider3 extends WindupRuleProvider
     public Configuration getConfiguration(GraphContext context)
     {
         Configuration configuration = ConfigurationBuilder.begin()
-            .addRule()
+        .addRule()
             .when(Query.find(TestXmlMetaFacetModel.class)
                 .withProperty(TestXmlMetaFacetModel.PROPERTY_ROOT_TAG_NAME,
-                    QueryPropertyComparisonType.EQUALS, "xmlTag2"))
-            .perform(Iteration.over(TestXmlMetaFacetModel.class)
-                .perform(new AbstractIterationOperation<TestXmlMetaFacetModel>()
-                {
-                    public void perform(GraphRewrite event, EvaluationContext context, TestXmlMetaFacetModel payload) {
-                        Variables varStack = Variables.instance(event);
-                        TestXmlMetaFacetModel xmlFacetModel = Iteration.getCurrentPayload(varStack,
-                                    TestXmlMetaFacetModel.class, Iteration.DEFAULT_SINGLE_VARIABLE_STRING);
-                        typeSearchResults.add(xmlFacetModel);
-                    }
-                })
-                .endIteration()
+                            QueryPropertyComparisonType.EQUALS, "xmlTag3"))
+            .perform(
+                Iteration.over(TestXmlMetaFacetModel.class)
+                    .perform(new GraphOperation()
+                    {
+                        @Override
+                        public void perform(GraphRewrite event, EvaluationContext context)
+                        {
+                            Variables varStack = org.jboss.windup.config.Variables.instance(event);
+                            TestXmlMetaFacetModel xmlFacetModel =
+                                Iteration.getCurrentPayload(varStack, TestXmlMetaFacetModel.class, Iteration.DEFAULT_SINGLE_VARIABLE_STRING);
+                            typeSearchResults.add(xmlFacetModel);
+                        }
+                    })
+                    .endIteration()
             );
         return configuration;
     }
@@ -62,4 +65,5 @@ public class XmlExampleRuleProvider3 extends WindupRuleProvider
     {
         return typeSearchResults;
     }
+
 }

--- a/config/tests/src/test/java/org/jboss/windup/config/TestXmlExampleRuleProvider3.java
+++ b/config/tests/src/test/java/org/jboss/windup/config/TestXmlExampleRuleProvider3.java
@@ -10,8 +10,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.jboss.windup.config.model.TestXmlMetaFacetModel;
-import org.jboss.windup.config.operation.GraphOperation;
 import org.jboss.windup.config.operation.Iteration;
+import org.jboss.windup.config.operation.ruleelement.AbstractIterationOperation;
 import org.jboss.windup.config.query.Query;
 import org.jboss.windup.config.query.QueryPropertyComparisonType;
 import org.jboss.windup.graph.GraphContext;
@@ -23,7 +23,7 @@ import org.ocpsoft.rewrite.context.EvaluationContext;
  * @author <a href="mailto:lincolnbaxter@gmail.com">Lincoln Baxter, III</a>
  * 
  */
-public class XmlExampleRuleProvider2 extends WindupRuleProvider
+public class TestXmlExampleRuleProvider3 extends WindupRuleProvider
 {
     final List<TestXmlMetaFacetModel> typeSearchResults = new ArrayList<>();
 
@@ -38,24 +38,21 @@ public class XmlExampleRuleProvider2 extends WindupRuleProvider
     public Configuration getConfiguration(GraphContext context)
     {
         Configuration configuration = ConfigurationBuilder.begin()
-        .addRule()
+            .addRule()
             .when(Query.find(TestXmlMetaFacetModel.class)
                 .withProperty(TestXmlMetaFacetModel.PROPERTY_ROOT_TAG_NAME,
-                            QueryPropertyComparisonType.EQUALS, "xmlTag3"))
-            .perform(
-                Iteration.over(TestXmlMetaFacetModel.class)
-                    .perform(new GraphOperation()
-                    {
-                        @Override
-                        public void perform(GraphRewrite event, EvaluationContext context)
-                        {
-                            Variables varStack = org.jboss.windup.config.Variables.instance(event);
-                            TestXmlMetaFacetModel xmlFacetModel =
-                                Iteration.getCurrentPayload(varStack, TestXmlMetaFacetModel.class, Iteration.DEFAULT_SINGLE_VARIABLE_STRING);
-                            typeSearchResults.add(xmlFacetModel);
-                        }
-                    })
-                    .endIteration()
+                    QueryPropertyComparisonType.EQUALS, "xmlTag2"))
+            .perform(Iteration.over(TestXmlMetaFacetModel.class)
+                .perform(new AbstractIterationOperation<TestXmlMetaFacetModel>()
+                {
+                    public void perform(GraphRewrite event, EvaluationContext context, TestXmlMetaFacetModel payload) {
+                        Variables varStack = Variables.instance(event);
+                        TestXmlMetaFacetModel xmlFacetModel = Iteration.getCurrentPayload(varStack,
+                                    TestXmlMetaFacetModel.class, Iteration.DEFAULT_SINGLE_VARIABLE_STRING);
+                        typeSearchResults.add(xmlFacetModel);
+                    }
+                })
+                .endIteration()
             );
         return configuration;
     }
@@ -65,5 +62,4 @@ public class XmlExampleRuleProvider2 extends WindupRuleProvider
     {
         return typeSearchResults;
     }
-
 }

--- a/config/tests/src/test/java/org/jboss/windup/config/selectables/IterationPayloadTest.java
+++ b/config/tests/src/test/java/org/jboss/windup/config/selectables/IterationPayloadTest.java
@@ -35,7 +35,7 @@ public class IterationPayloadTest
     public static ForgeArchive getDeployment()
     {
         final ForgeArchive archive = ShrinkWrap.create(ForgeArchive.class)
-                    .addClasses(IterationPayloadTestRuleProvider.class, TestChildModel.class, TestParentModel.class)
+                    .addClasses(TestIterationPayloadTestRuleProvider.class, TestChildModel.class, TestParentModel.class)
                     .addBeansXML()
                     .addAsAddonDependencies(
                                 AddonDependencyEntry.create("org.jboss.windup.config:windup-config"),
@@ -48,7 +48,7 @@ public class IterationPayloadTest
     private GraphContextFactory factory;
 
     @Inject
-    private IterationPayloadTestRuleProvider provider;
+    private TestIterationPayloadTestRuleProvider provider;
 
     @Test
     public void testIterationVariableResolving()

--- a/config/tests/src/test/java/org/jboss/windup/config/selectables/TestIterationPayloadTestRuleProvider.java
+++ b/config/tests/src/test/java/org/jboss/windup/config/selectables/TestIterationPayloadTestRuleProvider.java
@@ -16,7 +16,7 @@ import org.ocpsoft.rewrite.config.Configuration;
 import org.ocpsoft.rewrite.config.ConfigurationBuilder;
 import org.ocpsoft.rewrite.context.EvaluationContext;
 
-public class IterationPayloadTestRuleProvider extends WindupRuleProvider
+public class TestIterationPayloadTestRuleProvider extends WindupRuleProvider
 {
     private Set<TestParentModel> parents = new HashSet<>();
     private Set<TestChildModel> children = new HashSet<>();

--- a/reporting/tests/src/test/java/org/jboss/windup/reporting/FreeMarkerIterationOperationTest.java
+++ b/reporting/tests/src/test/java/org/jboss/windup/reporting/FreeMarkerIterationOperationTest.java
@@ -44,7 +44,7 @@ public class FreeMarkerIterationOperationTest
     {
         ForgeArchive archive = ShrinkWrap.create(ForgeArchive.class)
                     .addBeansXML()
-                    .addClass(FreeMarkerOperationRuleProvider.class)
+                    .addClass(TestFreeMarkerOperationRuleProvider.class)
                     .addAsResource(new File("src/test/resources/reports"))
                     .addAsAddonDependencies(
                                 AddonDependencyEntry.create("org.jboss.windup.config:windup-config"),
@@ -57,8 +57,9 @@ public class FreeMarkerIterationOperationTest
 
     @Inject
     private GraphContext context;
+    
     @Inject
-    private FreeMarkerOperationRuleProvider provider;
+    private TestFreeMarkerOperationRuleProvider provider;
 
     private Path tempFolder;
 

--- a/reporting/tests/src/test/java/org/jboss/windup/reporting/TestFreeMarkerOperationRuleProvider.java
+++ b/reporting/tests/src/test/java/org/jboss/windup/reporting/TestFreeMarkerOperationRuleProvider.java
@@ -10,7 +10,7 @@ import org.jboss.windup.reporting.freemarker.FreeMarkerOperation;
 import org.ocpsoft.rewrite.config.Configuration;
 import org.ocpsoft.rewrite.config.ConfigurationBuilder;
 
-public class FreeMarkerOperationRuleProvider extends WindupRuleProvider
+public class TestFreeMarkerOperationRuleProvider extends WindupRuleProvider
 {
 
     @Inject

--- a/rules/app/java/src/test/java/org/jboss/windup/rules/java/HintsClassificationsTest.java
+++ b/rules/app/java/src/test/java/org/jboss/windup/rules/java/HintsClassificationsTest.java
@@ -63,7 +63,7 @@ public class HintsClassificationsTest
     {
         final ForgeArchive archive = ShrinkWrap.create(ForgeArchive.class)
                     .addBeansXML()
-                    .addClass(HintsClassificationsTestRuleProvider.class)
+                    .addClass(TestHintsClassificationsTestRuleProvider.class)
                     .addAsAddonDependencies(
                                 AddonDependencyEntry.create("org.jboss.windup.config:windup-config"),
                                 AddonDependencyEntry.create("org.jboss.windup.exec:windup-exec"),
@@ -77,7 +77,7 @@ public class HintsClassificationsTest
     }
 
     @Inject
-    private HintsClassificationsTestRuleProvider provider;
+    private TestHintsClassificationsTestRuleProvider provider;
 
     @Inject
     private WindupProcessor processor;
@@ -145,7 +145,7 @@ public class HintsClassificationsTest
     }
 
     @Singleton
-    public static class HintsClassificationsTestRuleProvider extends WindupRuleProvider
+    public static class TestHintsClassificationsTestRuleProvider extends WindupRuleProvider
     {
         private Set<TypeReferenceModel> typeReferences = new HashSet<>();
 


### PR DESCRIPTION
...ix

I found only rule providers, any test specific condition nor operation. Models were already renamed before.
