### PR TITLE
Remove source format note from the project's title page.

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -14,12 +14,6 @@ Get involved at: http://windup.jboss.org
 
 Visit https://github.com/windup/windup-legacy 
 
-=== Project Source Code Format
-
-This project has an agreed upon source format style documented via an Eclipse code formatter profile ( https://github.com/windup/windup/blob/master/Eclipse_Code_Format_Profile.xml ). If using an alternate IDE, plugins are available to allow use of this profile (see below.) All contributions should be formatted using this profile before submission.
-
-* Netbeans: http://plugins.netbeans.org/plugin/50877/eclipse-code-formatter-for-java
-* IntelliJ: http://plugins.jetbrains.com/plugin/?id=6546
 
 === Installation and Usage
 


### PR DESCRIPTION
Users don't care about our source code format.
I've moved that to the "Dev: Guidelines & Conventions" wiki page.
