### PR TITLE
Fix Classification adding the filemodel twice for a new instance.

### DIFF
--- a/reporting/api/src/main/java/org/jboss/windup/reporting/config/Classification.java
+++ b/reporting/api/src/main/java/org/jboss/windup/reporting/config/Classification.java
@@ -118,7 +118,6 @@ public class Classification extends AbstractIterationOperation<FileModel>
         if (classification == null)
         {
             classification = classificationService.create();
-            classification.addFileModel(payload);
             classification.setEffort(effort);
             classification.setDescription(details);
             classification.setClassifiation(classificationText);


### PR DESCRIPTION
Just a small change, however for the sake of simplicity, don't want to fix this inside other issue that has nothing in common with this.

I also filled an issue for this multi-value addition: https://issues.jboss.org/browse/WINDUP-226
