### PR TITLE
Update to Forge 2.10.0.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     <description>Migration Tools</description>
 
     <properties>
-        <version.furnace>2.9.2.Final</version.furnace>
+        <version.furnace>2.10.0.Final</version.furnace>
         <version.titangraph>0.5.0</version.titangraph>
         <version.tinkerpop.blueprints>2.5.0</version.tinkerpop.blueprints>
         <version.freemarker>2.3.20</version.freemarker>


### PR DESCRIPTION
Fixes development time problem where <optional> dependencies are not picked up by the maven reactor (or in Furnace test cases)
