### PR TITLE
WINDUP-288a: Iteration.over() should iterate over the nearest when() res...

### DIFF
--- a/config/api/src/main/java/org/jboss/windup/config/Variables.java
+++ b/config/api/src/main/java/org/jboss/windup/config/Variables.java
@@ -97,6 +97,17 @@ public class Variables
         frame.put(name, frames);
     }
     
+    public String getTopLevelSingletonName() {
+        Map<String, Iterable<WindupVertexFrame>> topLayer = peek();
+        if (!topLayer.keySet().iterator().hasNext() || topLayer.keySet().size() > 1)
+        {
+            throw new IllegalArgumentException(
+                        "Cannot return the top layer name because the top layer of varstack is not a singleton.");
+        }
+        String name = topLayer.keySet().iterator().next();
+        return name;
+    }
+    
     /**
      * Remove a variable in the top variables layer. 
      */

--- a/config/api/src/main/java/org/jboss/windup/config/operation/Iteration.java
+++ b/config/api/src/main/java/org/jboss/windup/config/operation/Iteration.java
@@ -24,6 +24,7 @@ import org.jboss.windup.config.operation.iteration.IterationBuilderWhen;
 import org.jboss.windup.config.operation.iteration.IterationPayloadManager;
 import org.jboss.windup.config.operation.iteration.NamedFramesSelector;
 import org.jboss.windup.config.operation.iteration.NamedIterationPayloadManager;
+import org.jboss.windup.config.operation.iteration.TopLayerSingletonFramesSelector;
 import org.jboss.windup.config.operation.iteration.TypedFramesSelector;
 import org.jboss.windup.config.operation.iteration.TypedNamedFramesSelector;
 import org.jboss.windup.config.operation.iteration.TypedNamedIterationPayloadManager;
@@ -90,7 +91,7 @@ public class Iteration extends DefaultOperationBuilder
                     singleVariableIterationName(source)));
         return iterationImpl;
     }
-
+    
     /**
      * Begin an {@link Iteration} over the named selection. Also sets the name of the variable for this iteration's
      * "current element".
@@ -115,12 +116,12 @@ public class Iteration extends DefaultOperationBuilder
     }
 
     /**
-     * Begin an {@link Iteration} over the selection named with the default name. Also sets the name of the variable for
-     * this iteration's "current element" to have the default value.
+     * Begin an {@link Iteration} over the selection that is placed on the top of the varstack. Also sets the name of the variable for
+     * this iteration's "current element" (i.e payload) to have the default value.
      */
     public static IterationBuilderOver over()
     {
-        Iteration iterationImpl = new Iteration(new NamedFramesSelector(DEFAULT_VARIABLE_LIST_STRING));
+        Iteration iterationImpl = new Iteration(new TopLayerSingletonFramesSelector());
         iterationImpl.setPayloadManager(new NamedIterationPayloadManager(DEFAULT_SINGLE_VARIABLE_STRING));
         return iterationImpl;
     }
@@ -253,19 +254,6 @@ public class Iteration extends DefaultOperationBuilder
     public List<Operation> getOperations()
     {
         return Arrays.asList(operationPerform, operationOtherwise);
-    }
-
-    public static String getPayloadVariableName(GraphRewrite event, EvaluationContext ctx)
-    {
-        Variables varStack = Variables.instance(event);
-        Map<String, Iterable<WindupVertexFrame>> topLayer = varStack.peek();
-        if (!topLayer.keySet().iterator().hasNext() || topLayer.keySet().size() > 1)
-        {
-            throw new IllegalArgumentException(
-                        "Cannot return the payload name because the top layer of varstack is not a singleton.");
-        }
-        String name = topLayer.keySet().iterator().next();
-        return name;
     }
 
     /**

--- a/config/api/src/main/java/org/jboss/windup/config/operation/iteration/TopLayerSingletonFramesSelector.java
+++ b/config/api/src/main/java/org/jboss/windup/config/operation/iteration/TopLayerSingletonFramesSelector.java
@@ -1,0 +1,21 @@
+package org.jboss.windup.config.operation.iteration;
+
+import org.jboss.windup.config.GraphRewrite;
+import org.jboss.windup.config.Variables;
+import org.jboss.windup.config.selectors.FramesSelector;
+import org.jboss.windup.graph.model.WindupVertexFrame;
+import org.ocpsoft.rewrite.context.EvaluationContext;
+
+public class TopLayerSingletonFramesSelector implements FramesSelector
+{
+
+    private String varName;
+    
+    @Override
+    public Iterable<WindupVertexFrame> getFrames(GraphRewrite event, EvaluationContext context)
+    {
+        Variables instance = Variables.instance(event);
+        this.varName=instance.getTopLevelSingletonName();
+        return instance.findVariable(varName);
+    }
+}

--- a/config/api/src/main/java/org/jboss/windup/config/operation/ruleelement/AbstractIterationFilter.java
+++ b/config/api/src/main/java/org/jboss/windup/config/operation/ruleelement/AbstractIterationFilter.java
@@ -48,7 +48,8 @@ public abstract class AbstractIterationFilter<T extends WindupVertexFrame> exten
      */
     protected void checkVariableName(GraphRewrite event, EvaluationContext context) {
         if(variableName == null ) {
-            setVariableName(Iteration.getPayloadVariableName(event, context));
+            Variables variables = Variables.instance(event);
+            setVariableName(variables.getTopLevelSingletonName());
         }
     }
 

--- a/config/api/src/main/java/org/jboss/windup/config/operation/ruleelement/AbstractIterationOperation.java
+++ b/config/api/src/main/java/org/jboss/windup/config/operation/ruleelement/AbstractIterationOperation.java
@@ -66,7 +66,8 @@ public abstract class AbstractIterationOperation<T extends WindupVertexFrame> ex
      */
     protected void checkVariableName(GraphRewrite event, EvaluationContext context) {
         if(variableName == null ) {
-            setVariableName(Iteration.getPayloadVariableName(event, context));
+            Variables variables = Variables.instance(event);
+            setVariableName(variables.getTopLevelSingletonName());
         }
     }
 

--- a/config/tests/src/test/java/org/jboss/windup/config/iteration/RuleIterationOverDefaultListVariableTest.java
+++ b/config/tests/src/test/java/org/jboss/windup/config/iteration/RuleIterationOverDefaultListVariableTest.java
@@ -126,7 +126,7 @@ public class RuleIterationOverDefaultListVariableTest
         {
             Configuration configuration = ConfigurationBuilder.begin()
             .addRule()
-            .when(Query.find(TestSimple2Model.class))
+            .when(Query.find(TestSimple2Model.class).as("abc"))
             .perform(Iteration
                 .over()
                 .perform(new GraphOperation()


### PR DESCRIPTION
...ult

I strongly believe this is expected behavior by the user.
Thanks to this, the code below will work:

```
.when(XmlFile.matchesXpath("/spring").as("spring"))
.perform(Classification.as("Spring"))
```
