### PR TITLE
WINDUP-226: Classification adds multiple fileModels even though they are...

### DIFF
--- a/rules-java/src/test/java/org/jboss/windup/rules/java/JavaHintsClassificationsTest.java
+++ b/rules-java/src/test/java/org/jboss/windup/rules/java/JavaHintsClassificationsTest.java
@@ -174,11 +174,8 @@ public class JavaHintsClassificationsTest
                 List<ClassificationModel> classifications = Iterators.asList(classificationService.findAll());
                 Assert.assertEquals(1, classifications.size());
 
-                @SuppressWarnings("unused")
                 Iterable<FileModel> fileModels = classifications.get(0).getFileModels();
-
-                // TODO fix this: there is a file multiple times:
-                // Assert.assertEquals(2, Iterators.asList(fileModels).size());
+                Assert.assertEquals(2, Iterators.asList(fileModels).size());
             }
             finally
             {


### PR DESCRIPTION
... the same

This was already fixed in the Classification.java file.
