### PR TITLE
Set default forkCount to 0.5C (half the CPU cores available)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,7 @@
                         <exclude>${testExcludeString}</exclude>
                     </excludes>
                     <argLine>-Xms512m -Xmx2048m -XX:MaxPermSize=768m -XX:ReservedCodeCacheSize=128m</argLine>
+                    <forkCount>.5C</forkCount>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
Set default forkCount to 0.5C (half the CPU cores available). This improves the build-time dramatically in local tests (from ~26 minutes down to ~15 minutes)
