### PR TITLE
WINDUP-300 Replace all logging implementations with JUL.

### DIFF
--- a/config/tests/src/test/java/org/jboss/windup/config/TestJavaExampleRuleProvider.java
+++ b/config/tests/src/test/java/org/jboss/windup/config/TestJavaExampleRuleProvider.java
@@ -22,19 +22,19 @@ import org.ocpsoft.rewrite.config.Configuration;
 import org.ocpsoft.rewrite.config.ConfigurationBuilder;
 import org.ocpsoft.rewrite.context.Context;
 import org.ocpsoft.rewrite.context.EvaluationContext;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import java.util.logging.Logger;
+import org.jboss.windup.util.Logging;
 
 import com.tinkerpop.blueprints.Vertex;
 import com.tinkerpop.gremlin.java.GremlinPipeline;
 
 /**
  * @author <a href="mailto:lincolnbaxter@gmail.com">Lincoln Baxter, III</a>
- * 
+ *
  */
 public class TestJavaExampleRuleProvider extends WindupRuleProvider
 {
-    private static final Logger LOG = LoggerFactory.getLogger(TestJavaExampleRuleProvider.class);
+    private static final Logger LOG = Logging.get(TestJavaExampleRuleProvider.class);
 
     private final List<JavaMethodModel> results = new ArrayList<>();
 

--- a/config/tests/src/test/java/org/jboss/windup/config/TestWindupConfigurationExampleRuleProvider.java
+++ b/config/tests/src/test/java/org/jboss/windup/config/TestWindupConfigurationExampleRuleProvider.java
@@ -22,8 +22,8 @@ import org.jboss.windup.rules.apps.java.model.JavaMethodModel;
 import org.ocpsoft.rewrite.config.Configuration;
 import org.ocpsoft.rewrite.config.ConfigurationBuilder;
 import org.ocpsoft.rewrite.context.EvaluationContext;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import java.util.logging.Logger;
+import org.jboss.windup.util.Logging;
 
 import com.tinkerpop.blueprints.Vertex;
 import com.tinkerpop.gremlin.java.GremlinPipeline;
@@ -34,7 +34,7 @@ import com.tinkerpop.gremlin.java.GremlinPipeline;
  */
 public class TestWindupConfigurationExampleRuleProvider extends WindupRuleProvider
 {
-    private static final Logger LOG = LoggerFactory.getLogger(TestWindupConfigurationExampleRuleProvider.class);
+    private static final Logger LOG = Logging.get(TestWindupConfigurationExampleRuleProvider.class);
 
     private final List<JavaMethodModel> results = new ArrayList<>();
 

--- a/reporting/impl/src/main/java/org/jboss/windup/reporting/renderer/GraphExporter.java
+++ b/reporting/impl/src/main/java/org/jboss/windup/reporting/renderer/GraphExporter.java
@@ -12,13 +12,13 @@ import org.jboss.windup.reporting.renderer.dot.VizJSHtmlWriter;
 import org.jboss.windup.reporting.renderer.gexf.SigmaJSHtmlWriter;
 import org.jboss.windup.reporting.renderer.graphlib.DagreD3JSHtmlWriter;
 import org.jboss.windup.util.exception.WindupException;
-import org.slf4j.LoggerFactory;
+import org.jboss.windup.util.Logging;
 
 import com.tinkerpop.blueprints.Graph;
 
 public class GraphExporter extends AbstractGraphRenderer
 {
-    private static final org.slf4j.Logger LOG = LoggerFactory.getLogger(GraphExporter.class);
+    private static final java.util.logging.Logger LOG = Logging.get(GraphExporter.class);
 
     @Override
     public void renderGraph(GraphContext context)
@@ -37,19 +37,19 @@ public class GraphExporter extends AbstractGraphRenderer
 
     public void renderVizjs(Graph graph, File output, String vertexLabelProperty, String edgeLabel)
     {
-        LOG.debug("Writing Vizjs graph to: " + output.getAbsolutePath());
+        LOG.fine("Writing Vizjs graph to: " + output.getAbsolutePath());
         render(new VizJSHtmlWriter(graph, vertexLabelProperty, edgeLabel), output);
     }
 
     public void renderSigma(Graph graph, File output, String vertexLabelProperty, String edgeLabel)
     {
-        LOG.debug("Writing Sigmajs graph to: " + output.getAbsolutePath());
+        LOG.fine("Writing Sigmajs graph to: " + output.getAbsolutePath());
         render(new SigmaJSHtmlWriter(graph, vertexLabelProperty, edgeLabel), output);
     }
 
     public void renderDagreD3(Graph graph, File output, String vertexLabelProperty, String edgeLabel)
     {
-        LOG.debug("Writing DagreD3 graph to: " + output.getAbsolutePath());
+        LOG.fine("Writing DagreD3 graph to: " + output.getAbsolutePath());
         render(new DagreD3JSHtmlWriter(graph, vertexLabelProperty, edgeLabel), output);
     }
 

--- a/reporting/impl/src/main/java/org/jboss/windup/reporting/renderer/dot/VizJSHtmlWriter.java
+++ b/reporting/impl/src/main/java/org/jboss/windup/reporting/renderer/dot/VizJSHtmlWriter.java
@@ -15,16 +15,17 @@ import javax.xml.transform.stream.StreamResult;
 
 import org.jboss.windup.reporting.renderer.GraphWriter;
 import org.jboss.windup.reporting.renderer.dot.DotConstants.DotGraphType;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import java.util.logging.Logger;
+import org.jboss.windup.util.Logging;
 import org.w3c.dom.Document;
 import org.xml.sax.SAXException;
 
 import com.tinkerpop.blueprints.Graph;
+import java.util.logging.Level;
 
 public class VizJSHtmlWriter implements GraphWriter
 {
-    private static Logger LOG = LoggerFactory.getLogger(VizJSHtmlWriter.class);
+    private static Logger LOG = Logging.get(VizJSHtmlWriter.class);
 
     private final GraphWriter writer;
 
@@ -50,10 +51,8 @@ public class VizJSHtmlWriter implements GraphWriter
             result = baos.toString();
         }
 
-        if (LOG.isDebugEnabled())
-        {
-            LOG.debug("DOT: " + result);
-        }
+        if (LOG.isLoggable(Level.FINE))
+            LOG.fine("DOT: " + result);
 
         // read the document.
         Document document;

--- a/reporting/impl/src/main/java/org/jboss/windup/reporting/renderer/gexf/SigmaJSHtmlWriter.java
+++ b/reporting/impl/src/main/java/org/jboss/windup/reporting/renderer/gexf/SigmaJSHtmlWriter.java
@@ -14,16 +14,17 @@ import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 
 import org.jboss.windup.reporting.renderer.GraphWriter;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import java.util.logging.Logger;
+import org.jboss.windup.util.Logging;
 import org.w3c.dom.Document;
 import org.xml.sax.SAXException;
 
 import com.tinkerpop.blueprints.Graph;
+import java.util.logging.Level;
 
 public class SigmaJSHtmlWriter implements GraphWriter
 {
-    private static final Logger LOG = LoggerFactory.getLogger(SigmaJSHtmlWriter.class);
+    private static final Logger LOG = Logging.get(SigmaJSHtmlWriter.class);
 
     private final GexfWriter gexfWriter;
 
@@ -49,10 +50,8 @@ public class SigmaJSHtmlWriter implements GraphWriter
             result = baos.toString();
         }
 
-        if (LOG.isDebugEnabled())
-        {
-            LOG.debug("GEXF: " + result);
-        }
+        if (LOG.isLoggable(Level.FINE))
+            LOG.fine("GEXF: " + result);
 
         // read the document.
         Document document;

--- a/reporting/impl/src/main/java/org/jboss/windup/reporting/renderer/graphlib/DagreD3JSHtmlWriter.java
+++ b/reporting/impl/src/main/java/org/jboss/windup/reporting/renderer/graphlib/DagreD3JSHtmlWriter.java
@@ -16,16 +16,17 @@ import javax.xml.transform.stream.StreamResult;
 import org.jboss.windup.reporting.renderer.GraphWriter;
 import org.jboss.windup.reporting.renderer.graphlib.GraphvizConstants.GraphvizDirection;
 import org.jboss.windup.reporting.renderer.graphlib.GraphvizConstants.GraphvizType;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import java.util.logging.Logger;
+import org.jboss.windup.util.Logging;
 import org.w3c.dom.Document;
 import org.xml.sax.SAXException;
 
 import com.tinkerpop.blueprints.Graph;
+import java.util.logging.Level;
 
 public class DagreD3JSHtmlWriter implements GraphWriter
 {
-    private static Logger LOG = LoggerFactory.getLogger(DagreD3JSHtmlWriter.class);
+    private static Logger LOG = Logging.get(DagreD3JSHtmlWriter.class);
 
     private final GraphWriter writer;
 
@@ -47,9 +48,9 @@ public class DagreD3JSHtmlWriter implements GraphWriter
             result = baos.toString();
         }
 
-        if (LOG.isDebugEnabled())
+        if (LOG.isLoggable(Level.FINE))
         {
-            LOG.debug("Graphlib: " + result);
+            LOG.fine("Graphlib: " + result);
         }
 
         // read the document.

--- a/reporting/impl/src/main/java/org/jboss/windup/reporting/renderer/graphviz/GraphvizWriter.java
+++ b/reporting/impl/src/main/java/org/jboss/windup/reporting/renderer/graphviz/GraphvizWriter.java
@@ -16,14 +16,14 @@ import javax.script.ScriptException;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.builder.ReflectionToStringBuilder;
 import org.jboss.windup.reporting.renderer.dot.DotWriter;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import java.util.logging.Logger;
+import org.jboss.windup.util.Logging;
 
 import com.tinkerpop.blueprints.Graph;
 
 public class GraphvizWriter extends DotWriter
 {
-    private static final Logger LOG = LoggerFactory.getLogger(GraphvizWriter.class);
+    private static final Logger LOG = Logging.get(GraphvizWriter.class);
 
     private final CompiledScript vizJsCompiled;
 

--- a/rules-java/src/main/java/org/jboss/windup/rules/apps/java/scan/ast/VariableResolvingASTVisitor.java
+++ b/rules-java/src/main/java/org/jboss/windup/rules/apps/java/scan/ast/VariableResolvingASTVisitor.java
@@ -53,8 +53,8 @@ import org.jboss.windup.graph.model.resource.FileModel;
 import org.jboss.windup.rules.apps.java.model.JavaClassModel;
 import org.jboss.windup.rules.apps.java.service.JavaClassService;
 import org.jboss.windup.rules.apps.java.service.TypeReferenceService;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import java.util.logging.Logger;
+import org.jboss.windup.util.Logging;
 
 /**
  * Runs through the source code and checks "type" uses against the blacklisted class entries.
@@ -63,7 +63,7 @@ import org.slf4j.LoggerFactory;
  */
 public class VariableResolvingASTVisitor extends ASTVisitor
 {
-    private static final Logger LOG = LoggerFactory.getLogger(VariableResolvingASTVisitor.class);
+    private static final Logger LOG = Logging.get(VariableResolvingASTVisitor.class);
 
     private final JavaClassService javaClassService;
     private final TypeReferenceService typeRefService;
@@ -138,7 +138,7 @@ public class VariableResolvingASTVisitor extends ASTVisitor
                         TypeReferenceLocation.CONSTRUCTOR_CALL,
                         lineNumber, columnNumber, length, text);
 
-            LOG.trace("Candidate: " + typeRef);
+            LOG.finer("Candidate: " + typeRef);
         }
     }
 
@@ -151,7 +151,7 @@ public class VariableResolvingASTVisitor extends ASTVisitor
                         TypeReferenceLocation.METHOD_CALL,
                         lineNumber, columnNumber, length, text);
 
-            LOG.trace("Candidate: " + typeRef);
+            LOG.finer("Candidate: " + typeRef);
         }
     }
 
@@ -166,7 +166,7 @@ public class VariableResolvingASTVisitor extends ASTVisitor
                         TypeReferenceLocation.IMPORT,
                         lineNumber, columnNumber, length, interest.toString());
 
-            LOG.trace("Candidate: " + typeRef);
+            LOG.finer("Candidate: " + typeRef);
         }
     }
 
@@ -186,14 +186,14 @@ public class VariableResolvingASTVisitor extends ASTVisitor
             JavaTypeReferenceModel typeRef = typeRefService.createTypeReference(fileModel, referenceLocation,
                         lineNumber, columnNumber, length, sourceString);
 
-            LOG.trace("Prefix: " + referenceLocation);
+            LOG.finer("Prefix: " + referenceLocation);
             if (type instanceof SimpleType)
             {
                 SimpleType sType = (SimpleType) type;
-                LOG.trace("The type name is: " + sType.getName().getFullyQualifiedName() + " and " + sourceString);
+                LOG.finer("The type name is: " + sType.getName().getFullyQualifiedName() + " and " + sourceString);
 
             }
-            LOG.trace("Candidate: " + typeRef);
+            LOG.finer("Candidate: " + typeRef);
         }
     }
 
@@ -211,8 +211,8 @@ public class VariableResolvingASTVisitor extends ASTVisitor
             JavaTypeReferenceModel typeRef = typeRefService.createTypeReference(fileModel, referenceLocation,
                         lineNumber, columnNumber, length, sourceString);
 
-            LOG.trace("Prefix: " + referenceLocation);
-            LOG.trace("Candidate: " + typeRef);
+            LOG.finer("Prefix: " + referenceLocation);
+            LOG.finer("Candidate: " + typeRef);
         }
     }
 
@@ -357,7 +357,7 @@ public class VariableResolvingASTVisitor extends ASTVisitor
                     }
                     else
                     {
-                        LOG.trace("" + clzInterface);
+                        LOG.finer("" + clzInterface);
                     }
                 }
             }
@@ -370,7 +370,7 @@ public class VariableResolvingASTVisitor extends ASTVisitor
             }
             else
             {
-                LOG.trace("" + clzSuperClasses);
+                LOG.finer("" + clzSuperClasses);
             }
         }
 
@@ -456,7 +456,7 @@ public class VariableResolvingASTVisitor extends ASTVisitor
     @Override
     public boolean visit(PackageDeclaration node)
     {
-        LOG.trace("Found package: " + node.getName().toString());
+        LOG.finer("Found package: " + node.getName().toString());
         return super.visit(node);
     }
 
@@ -577,7 +577,7 @@ public class VariableResolvingASTVisitor extends ASTVisitor
             }
             else
             {
-                LOG.trace("Unable to determine type: " + o.getClass() + ReflectionToStringBuilder.toString(o));
+                LOG.finer("Unable to determine type: " + o.getClass() + ReflectionToStringBuilder.toString(o));
                 resolvedParams.add("Undefined");
             }
         }

--- a/rules-java/src/main/java/org/jboss/windup/rules/apps/java/scan/operation/UnzipArchiveToOutputFolder.java
+++ b/rules-java/src/main/java/org/jboss/windup/rules/apps/java/scan/operation/UnzipArchiveToOutputFolder.java
@@ -18,13 +18,13 @@ import org.jboss.windup.graph.service.WindupConfigurationService;
 import org.jboss.windup.util.ZipUtil;
 import org.jboss.windup.util.exception.WindupException;
 import org.ocpsoft.rewrite.context.EvaluationContext;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import java.util.logging.Logger;
+import org.jboss.windup.util.Logging;
 
 public class UnzipArchiveToOutputFolder extends AbstractIterationOperation<ArchiveModel>
 {
     private static final String ARCHIVES = "archives";
-    private static final Logger LOG = LoggerFactory.getLogger(UnzipArchiveToOutputFolder.class);
+    private static final Logger LOG = Logging.get(UnzipArchiveToOutputFolder.class);
 
     public UnzipArchiveToOutputFolder(String variableName)
     {

--- a/rules-java/src/main/java/org/jboss/windup/rules/apps/java/scan/provider/DiscoverMavenHierarchyRuleProvider.java
+++ b/rules-java/src/main/java/org/jboss/windup/rules/apps/java/scan/provider/DiscoverMavenHierarchyRuleProvider.java
@@ -14,12 +14,12 @@ import org.jboss.windup.rules.apps.java.model.project.MavenProjectModel;
 import org.ocpsoft.rewrite.config.Configuration;
 import org.ocpsoft.rewrite.config.ConfigurationBuilder;
 import org.ocpsoft.rewrite.context.EvaluationContext;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import java.util.logging.Logger;
+import org.jboss.windup.util.Logging;
 
 public class DiscoverMavenHierarchyRuleProvider extends WindupRuleProvider
 {
-    private static final Logger LOG = LoggerFactory.getLogger(DiscoverMavenProjectsRuleProvider.class);
+    private static final Logger LOG = Logging.get(DiscoverMavenProjectsRuleProvider.class);
 
     @Override
     public RulePhase getPhase()

--- a/rules-java/src/main/java/org/jboss/windup/rules/apps/java/scan/provider/DiscoverMavenProjectsRuleProvider.java
+++ b/rules-java/src/main/java/org/jboss/windup/rules/apps/java/scan/provider/DiscoverMavenProjectsRuleProvider.java
@@ -26,15 +26,15 @@ import org.ocpsoft.rewrite.config.ConditionBuilder;
 import org.ocpsoft.rewrite.config.Configuration;
 import org.ocpsoft.rewrite.config.ConfigurationBuilder;
 import org.ocpsoft.rewrite.context.EvaluationContext;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import java.util.logging.Logger;
+import org.jboss.windup.util.Logging;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
 public class DiscoverMavenProjectsRuleProvider extends WindupRuleProvider
 {
-    private static final Logger LOG = LoggerFactory.getLogger(DiscoverMavenProjectsRuleProvider.class);
+    private static final Logger LOG = Logging.get(DiscoverMavenProjectsRuleProvider.class);
 
     private static final Map<String, String> namespaces = new HashMap<>();
     static
@@ -321,7 +321,7 @@ public class DiscoverMavenProjectsRuleProvider extends WindupRuleProvider
 
                 if (nodes.getLength() == 0 || nodes.item(0) == null)
                 {
-                    LOG.warn("Expected: " + property + " but it wasn't found in the POM.");
+                    LOG.warning("Expected: " + property + " but it wasn't found in the POM.");
                 }
                 else
                 {

--- a/rules-xml/src/main/java/org/jboss/windup/rules/apps/xml/operation/xslt/XSLTTransformation.java
+++ b/rules-xml/src/main/java/org/jboss/windup/rules/apps/xml/operation/xslt/XSLTTransformation.java
@@ -6,6 +6,7 @@ import java.io.InputStream;
 import java.nio.file.Path;
 import java.util.Map;
 import java.util.concurrent.Callable;
+import java.util.logging.Level;
 
 import javax.inject.Inject;
 import javax.xml.transform.Result;
@@ -36,8 +37,8 @@ import org.jboss.windup.rules.apps.xml.model.XmlFileModel;
 import org.jboss.windup.rules.apps.xml.model.XsltTransformationModel;
 import org.jboss.windup.rules.apps.xml.service.XsltTransformationService;
 import org.ocpsoft.rewrite.context.EvaluationContext;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import java.util.logging.Logger;
+import org.jboss.windup.util.Logging;
 
 public class XSLTTransformation extends AbstractIterationOperation<XmlFileModel>
 {
@@ -46,7 +47,7 @@ public class XSLTTransformation extends AbstractIterationOperation<XmlFileModel>
     @Inject
     GraphApiCompositeClassLoaderProvider compositeClassLoader;
 
-    private static final Logger LOG = LoggerFactory.getLogger(XSLTTransformation.class);
+    private static final Logger LOG = Logging.get(XSLTTransformation.class);
 
     private String description;
     private String location;
@@ -70,7 +71,7 @@ public class XSLTTransformation extends AbstractIterationOperation<XmlFileModel>
      * Set the payload to the fileModel of the given instance even though the variable is not directly of it's type.
      * This is mainly to simplify the creation of the rule, when the FileModel itself is not being iterated but just a
      * model referencing it.
-     * 
+     *
      */
     @Override
     public void perform(GraphRewrite event, EvaluationContext context)
@@ -176,7 +177,7 @@ public class XSLTTransformation extends AbstractIterationOperation<XmlFileModel>
                     // fetch local only, for speed reasons.
                     if (StringUtils.contains(href, "http://"))
                     {
-                        LOG.warn("Trying to fetch remote URL for XSLT.  This is not possible; for speed reasons: "
+                        LOG.warning("Trying to fetch remote URL for XSLT.  This is not possible; for speed reasons: "
                                     + href + ": " + base);
                         return null;
                     }
@@ -198,18 +199,12 @@ public class XSLTTransformation extends AbstractIterationOperation<XmlFileModel>
             {
                 for (String key : xsltParameters.keySet())
                 {
-                    if (LOG.isDebugEnabled())
-                    {
-                        LOG.debug("Setting property: " + key + " -> " + xsltParameters.get(key));
-                    }
+                    LOG.fine("Setting property: " + key + " -> " + xsltParameters.get(key));
                     xsltTransformer.setParameter(key, xsltParameters.get(key));
                 }
             }
 
-            if (LOG.isDebugEnabled())
-            {
-                LOG.debug("Created XSLT successfully: " + location);
-            }
+            LOG.fine("Created XSLT successfully: " + location);
         }
         catch (TransformerConfigurationException e)
         {
@@ -265,7 +260,7 @@ public class XSLTTransformation extends AbstractIterationOperation<XmlFileModel>
         }
         catch (TransformerException e)
         {
-            LOG.error("Exception transforming XML.", e);
+            LOG.log(Level.SEVERE, "Exception transforming XML.", e);
         }
     }
 


### PR DESCRIPTION
This should prevent all those:
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
