### PR TITLE
WINDUP-331: Fail gracefully on unreadable archive

### DIFF
--- a/graph/api/src/main/java/org/jboss/windup/graph/model/ArchiveModel.java
+++ b/graph/api/src/main/java/org/jboss/windup/graph/model/ArchiveModel.java
@@ -10,6 +10,9 @@ import com.tinkerpop.frames.modules.typedgraph.TypeValue;
 @TypeValue("ArchiveModel")
 public interface ArchiveModel extends FileModel
 {
+    public static String MALFORMED_ARCHIVE= "Malformed archive";
+    
+    
     @Adjacency(label = "parentArchive", direction = Direction.IN)
     public ArchiveModel getParentArchive();
 

--- a/rules-java/src/main/java/org/jboss/windup/rules/apps/java/scan/operation/UnzipArchiveToOutputFolder.java
+++ b/rules-java/src/main/java/org/jboss/windup/rules/apps/java/scan/operation/UnzipArchiveToOutputFolder.java
@@ -15,6 +15,7 @@ import org.jboss.windup.graph.model.resource.FileModel;
 import org.jboss.windup.graph.service.FileModelService;
 import org.jboss.windup.graph.service.GraphService;
 import org.jboss.windup.graph.service.WindupConfigurationService;
+import org.jboss.windup.reporting.service.ClassificationService;
 import org.jboss.windup.rules.apps.java.model.IgnoredFileModel;
 import org.jboss.windup.rules.apps.java.service.WindupJavaConfigurationService;
 import org.jboss.windup.util.ZipUtil;
@@ -128,8 +129,11 @@ public class UnzipArchiveToOutputFolder extends AbstractIterationOperation<Archi
         }
         catch (Throwable e)
         {
-            throw new WindupException("Unzipping archive: " + inputZipFile.getAbsolutePath() + " failed due to: "
-                        + e.getMessage(), e);
+            ClassificationService classificationService = new ClassificationService(context);
+            classificationService.attachClassification(archiveModel, ArchiveModel.MALFORMED_ARCHIVE, "Cannot unzip the file");
+            LOG.warning("Cannot unzip the file " + inputZipFile.getPath() + " to " + appArchiveFolder.toString() + 
+                        ". The ArchiveModel was classified as malformed.");
+            return;
         }
 
         FileModel newFileModel = fileService.createByFilePath(appArchiveFolder.toString());


### PR DESCRIPTION
I tried to test this, but to do that best, mocking of the static method should be done. This does not work with forge tests (https://issues.jboss.org/browse/FORGE-2144)
