### PR TITLE
WINDUP-429: Fix for JavaClassXmlRulesTest.testJavaClassCondition

### DIFF
--- a/rules-java/src/test/java/org/jboss/windup/rules/java/JavaClassXmlRulesTest.java
+++ b/rules-java/src/test/java/org/jboss/windup/rules/java/JavaClassXmlRulesTest.java
@@ -114,10 +114,12 @@ public class JavaClassXmlRulesTest
             int count = 0;
             for (JavaTypeReferenceModel ref : typeReferences)
             {
-                Assert.assertTrue(ref.getSourceSnippit().contains("org.apache.commons"));
+                String sourceSnippit = ref.getSourceSnippit();
+                Assert.assertTrue(sourceSnippit.contains("org.apache.commons")
+                            || sourceSnippit.contains("org.jboss.windup.rules.java.JavaClassTestFile"));
                 count++;
             }
-            Assert.assertEquals(6, count);
+            Assert.assertEquals(8, count);
 
             GraphService<InlineHintModel> hintService = new GraphService<>(context, InlineHintModel.class);
             Iterable<InlineHintModel> hints = hintService.findAll();


### PR DESCRIPTION
https://issues.jboss.org/browse/WINDUP-429
