### PR TITLE
WINDUP-510: Fix build order

### DIFF
--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -83,6 +83,13 @@
         </dependency>
 
         <dependency>
+            <groupId>org.jboss.windup</groupId>
+            <artifactId>windup-bom</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+        </dependency>
+
+        <dependency>
             <groupId>org.jboss.windup.maven</groupId>
             <artifactId>nexus-indexer-data</artifactId>
             <version>${version.nexus.index}</version>


### PR DESCRIPTION
An alternative implementation of https://github.com/windup/windup/pull/469.

Basically this makes the dist depend on the bom, because it appears that the addon-installs themselves depend on it. I think this also fixes the double build issue on release.