### PR TITLE
Fixes an issue in which an archive can be set with two different project...

### DIFF
--- a/rules-java/api/src/main/java/org/jboss/windup/rules/apps/java/scan/provider/DiscoverFilesAndTypesRuleProvider.java
+++ b/rules-java/api/src/main/java/org/jboss/windup/rules/apps/java/scan/provider/DiscoverFilesAndTypesRuleProvider.java
@@ -1,18 +1,23 @@
 package org.jboss.windup.rules.apps.java.scan.provider;
 
+import org.jboss.windup.config.GraphRewrite;
 import org.jboss.windup.config.WindupRuleProvider;
-import org.jboss.windup.config.operation.Iteration;
 import org.jboss.windup.config.phase.Discovery;
 import org.jboss.windup.config.phase.RulePhase;
 import org.jboss.windup.config.query.Query;
+import org.jboss.windup.config.query.QueryGremlinCriterion;
 import org.jboss.windup.config.query.QueryPropertyComparisonType;
 import org.jboss.windup.graph.GraphContext;
+import org.jboss.windup.graph.model.WindupConfigurationModel;
 import org.jboss.windup.graph.model.resource.FileModel;
 import org.jboss.windup.rules.apps.java.scan.operation.AddArchiveReferenceInformation;
 import org.jboss.windup.rules.apps.java.scan.operation.RecurseDirectoryAndAddFiles;
 import org.jboss.windup.util.ZipUtil;
 import org.ocpsoft.rewrite.config.Configuration;
 import org.ocpsoft.rewrite.config.ConfigurationBuilder;
+
+import com.tinkerpop.blueprints.Vertex;
+import com.tinkerpop.gremlin.java.GremlinPipeline;
 
 public class DiscoverFilesAndTypesRuleProvider extends WindupRuleProvider
 {
@@ -29,8 +34,17 @@ public class DiscoverFilesAndTypesRuleProvider extends WindupRuleProvider
         return ConfigurationBuilder.begin()
 
         .addRule()
-        .when(Query.fromType(FileModel.class)
-            .withProperty(FileModel.IS_DIRECTORY, true)
+        .when(Query.fromType(WindupConfigurationModel.class)
+                    .piped(new QueryGremlinCriterion()
+                    {
+                        
+                        @Override
+                        public void query(GraphRewrite event, GremlinPipeline<Vertex, Vertex> pipeline)
+                        {
+                            pipeline.out(WindupConfigurationModel.INPUT_PATH);
+                            pipeline.has(FileModel.IS_DIRECTORY, true);
+                        }
+                    })
         )
         .perform(new RecurseDirectoryAndAddFiles()
         )

--- a/rules-java/api/src/main/java/org/jboss/windup/rules/apps/java/scan/provider/DiscoverMavenProjectsRuleProvider.java
+++ b/rules-java/api/src/main/java/org/jboss/windup/rules/apps/java/scan/provider/DiscoverMavenProjectsRuleProvider.java
@@ -68,7 +68,7 @@ public class DiscoverMavenProjectsRuleProvider extends WindupRuleProvider
                 if (mavenProjectModel != null)
                 {
                     ArchiveModel archiveModel = payload.getParentArchive();
-                    if (archiveModel != null)
+                    if (archiveModel != null && !isAlreadyMavenProject(archiveModel))
                     {
                         archiveModel.setProjectModel(mavenProjectModel);
 
@@ -92,7 +92,7 @@ public class DiscoverMavenProjectsRuleProvider extends WindupRuleProvider
                         // add the parent file
                         File parentFile = payload.asFile().getParentFile();
                         FileModel parentFileModel = new FileService(event.getGraphContext()).findByPath(parentFile.getAbsolutePath());
-                        if (parentFileModel != null)
+                        if (parentFileModel != null && !isAlreadyMavenProject(parentFileModel))
                         {
                             parentFileModel.setProjectModel(mavenProjectModel);
                             mavenProjectModel.addFileModel(parentFileModel);
@@ -121,6 +121,17 @@ public class DiscoverMavenProjectsRuleProvider extends WindupRuleProvider
             .when(fileWhen)
             .perform(evaluatePomFiles);
         // @formatter:on
+    }
+
+    /**
+     * This method is here so that the caller can know not to try to reset the project model for an archive (or directory) if the archive (or
+     * directory) is already a maven project.
+     * 
+     * This can sometimes help in cases in which an archive includes multiple poms in its META-INF.
+     */
+    private boolean isAlreadyMavenProject(FileModel fileModel)
+    {
+        return fileModel.getProjectModel() != null && fileModel.getProjectModel() instanceof MavenProjectModel;
     }
 
     private void addFilesToModel(MavenProjectModel mavenProjectModel, FileModel fileModel)

--- a/tests/src/test/java/org/jboss/windup/tests/application/WindupArchitectureMediumBinaryModeTest.java
+++ b/tests/src/test/java/org/jboss/windup/tests/application/WindupArchitectureMediumBinaryModeTest.java
@@ -52,7 +52,6 @@ public class WindupArchitectureMediumBinaryModeTest extends WindupArchitectureTe
                                 AddonDependencyEntry.create("org.jboss.windup.exec:windup-exec"),
                                 AddonDependencyEntry.create("org.jboss.windup.rules.apps:windup-rules-java"),
                                 AddonDependencyEntry.create("org.jboss.windup.rules.apps:windup-rules-java-ee"),
-                                // AddonDependencyEntry.create("org.jboss.windup.rules.apps:windup-rules-tattletale"),
                                 AddonDependencyEntry.create("org.jboss.windup.tests:test-util"),
                                 AddonDependencyEntry.create("org.jboss.windup.config:windup-config-groovy"),
                                 AddonDependencyEntry.create("org.jboss.forge.furnace.container:cdi")


### PR DESCRIPTION
... models. This can produce strange results that are difficult to debug. Also, made it so that only the input directory is scanned, so we don't end up with user rules directories being scanned during Windup execution.