### PR TITLE
WINDUP-521: Rule Externalization - Create XML Handlers for Rule metadata

### DIFF
--- a/config-xml/addon/src/main/java/org/jboss/windup/config/parser/WindupXMLRulesetParsingException.java
+++ b/config-xml/addon/src/main/java/org/jboss/windup/config/parser/WindupXMLRulesetParsingException.java
@@ -1,0 +1,28 @@
+package org.jboss.windup.config.parser;
+
+import org.jboss.windup.util.exception.WindupException;
+
+/**
+ * Exception thrown when parsing of the ruleset failed.
+ * @author mbriskar
+ *
+ */
+public class WindupXMLRulesetParsingException extends WindupException
+{
+
+    private static final long serialVersionUID = 1L;
+
+    public WindupXMLRulesetParsingException()
+    {
+    }
+
+    public WindupXMLRulesetParsingException(String message)
+    {
+        super(message);
+    }
+
+    public WindupXMLRulesetParsingException(String message, Throwable cause)
+    {
+        super(message, cause);
+    }
+}

--- a/config-xml/addon/src/main/java/org/jboss/windup/config/parser/metadata/MetadataAddonDependenciesHandler.java
+++ b/config-xml/addon/src/main/java/org/jboss/windup/config/parser/metadata/MetadataAddonDependenciesHandler.java
@@ -1,0 +1,39 @@
+package org.jboss.windup.config.parser.metadata;
+
+import static org.joox.JOOX.$;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.jboss.forge.furnace.addons.AddonId;
+import org.jboss.windup.config.exception.ConfigurationException;
+import org.jboss.windup.config.parser.ElementHandler;
+import org.jboss.windup.config.parser.NamespaceElementHandler;
+import org.jboss.windup.config.parser.ParserContext;
+import org.jboss.windup.config.parser.xml.RuleProviderHandler;
+import org.w3c.dom.Element;
+
+@NamespaceElementHandler(elementName = "dependencies", namespace = RuleProviderHandler.WINDUP_RULE_NAMESPACE)
+public class MetadataAddonDependenciesHandler implements ElementHandler<List<AddonId>>
+{
+
+    @Override
+    public List<AddonId> processElement(ParserContext context, Element element) throws ConfigurationException
+    {
+        List<Element> children = $(element).children().get();
+        List<AddonId> addonIds = new ArrayList<AddonId>();
+        for (Element child : children)
+        {
+            Object result = context.processElement(child);
+            switch ($(child).tag())
+            {
+            case "addon":
+                addonIds.add((AddonId)result);
+                break;
+            }
+           
+        }
+        return addonIds;
+    }
+    
+}

--- a/config-xml/addon/src/main/java/org/jboss/windup/config/parser/metadata/MetadataAddonDependencyHandler.java
+++ b/config-xml/addon/src/main/java/org/jboss/windup/config/parser/metadata/MetadataAddonDependencyHandler.java
@@ -1,0 +1,31 @@
+package org.jboss.windup.config.parser.metadata;
+
+import org.apache.commons.lang.StringUtils;
+import org.jboss.forge.furnace.addons.AddonId;
+import org.jboss.windup.config.exception.ConfigurationException;
+import org.jboss.windup.config.parser.ElementHandler;
+import org.jboss.windup.config.parser.NamespaceElementHandler;
+import org.jboss.windup.config.parser.ParserContext;
+import org.jboss.windup.config.parser.WindupXMLRulesetParsingException;
+import org.jboss.windup.config.parser.xml.RuleProviderHandler;
+import org.w3c.dom.Element;
+
+@NamespaceElementHandler(elementName = MetadataAddonDependencyHandler.ADDON_DEPENDENCY_ELEMENT, namespace = RuleProviderHandler.WINDUP_RULE_NAMESPACE)
+public class MetadataAddonDependencyHandler implements ElementHandler<AddonId>
+{
+    private static String ID = "id";
+    public static final String  ADDON_DEPENDENCY_ELEMENT = "addon";
+
+    @Override
+    public AddonId processElement(ParserContext handlerManager, Element element) throws ConfigurationException
+    {
+        String id = element.getAttribute(ID);
+        if (StringUtils.isBlank(id))
+        {
+            throw new WindupXMLRulesetParsingException("The '" + ADDON_DEPENDENCY_ELEMENT + "' element must have a non-empty '" + ID + "' attribute");
+        }
+        AddonId addonId = AddonId.fromCoordinates(id);
+        return addonId;
+    }
+
+}

--- a/config-xml/addon/src/main/java/org/jboss/windup/config/parser/metadata/MetadataExecuteAfterHandler.java
+++ b/config-xml/addon/src/main/java/org/jboss/windup/config/parser/metadata/MetadataExecuteAfterHandler.java
@@ -1,0 +1,27 @@
+package org.jboss.windup.config.parser.metadata;
+
+import org.jboss.windup.config.exception.ConfigurationException;
+import org.jboss.windup.config.parser.ElementHandler;
+import org.jboss.windup.config.parser.NamespaceElementHandler;
+import org.jboss.windup.config.parser.ParserContext;
+import org.jboss.windup.config.parser.WindupXMLRulesetParsingException;
+import org.jboss.windup.config.parser.xml.RuleProviderHandler;
+import org.w3c.dom.Element;
+
+@NamespaceElementHandler(elementName = MetadataExecuteAfterHandler.EXECUTE_AFTER_ELEMENT, namespace = RuleProviderHandler.WINDUP_RULE_NAMESPACE)
+public class MetadataExecuteAfterHandler implements ElementHandler<String>
+{
+    
+    public static final String EXECUTE_AFTER_ELEMENT = "executeAfter";
+
+    @Override
+    public String processElement(ParserContext handlerManager, Element element) throws ConfigurationException
+    {
+        String executeAfterId = element.getTextContent();
+        if(executeAfterId == null || executeAfterId.equals("")) {
+            throw new WindupXMLRulesetParsingException("The '" + EXECUTE_AFTER_ELEMENT + "' must contain non-empty text value");
+        }
+        return executeAfterId;
+    }
+    
+}

--- a/config-xml/addon/src/main/java/org/jboss/windup/config/parser/metadata/MetadataExecuteBeforeHandler.java
+++ b/config-xml/addon/src/main/java/org/jboss/windup/config/parser/metadata/MetadataExecuteBeforeHandler.java
@@ -1,0 +1,27 @@
+package org.jboss.windup.config.parser.metadata;
+
+import org.jboss.windup.config.exception.ConfigurationException;
+import org.jboss.windup.config.parser.ElementHandler;
+import org.jboss.windup.config.parser.NamespaceElementHandler;
+import org.jboss.windup.config.parser.ParserContext;
+import org.jboss.windup.config.parser.WindupXMLRulesetParsingException;
+import org.jboss.windup.config.parser.xml.RuleProviderHandler;
+import org.w3c.dom.Element;
+
+@NamespaceElementHandler(elementName = MetadataExecuteBeforeHandler.EXECUTE_BEFORE_ELEMENT, namespace = RuleProviderHandler.WINDUP_RULE_NAMESPACE)
+public class MetadataExecuteBeforeHandler implements ElementHandler<String>
+{
+
+    public static final String EXECUTE_BEFORE_ELEMENT = "executeBefore";
+    
+    @Override
+    public String processElement(ParserContext handlerManager, Element element) throws ConfigurationException
+    {
+        String executeBefore = element.getTextContent();
+        if(executeBefore == null || executeBefore.equals("")) {
+            throw new WindupXMLRulesetParsingException("The '" + EXECUTE_BEFORE_ELEMENT + "' must contain non-empty text value");
+        }
+        return executeBefore;
+    }
+    
+}

--- a/config-xml/addon/src/main/java/org/jboss/windup/config/parser/metadata/MetadataSourceTechnologyHandler.java
+++ b/config-xml/addon/src/main/java/org/jboss/windup/config/parser/metadata/MetadataSourceTechnologyHandler.java
@@ -1,0 +1,46 @@
+package org.jboss.windup.config.parser.metadata;
+
+import org.apache.commons.lang.StringUtils;
+import org.jboss.forge.furnace.versions.VersionException;
+import org.jboss.forge.furnace.versions.Versions;
+import org.jboss.windup.config.exception.ConfigurationException;
+import org.jboss.windup.config.metadata.TechnologyReference;
+import org.jboss.windup.config.parser.ElementHandler;
+import org.jboss.windup.config.parser.NamespaceElementHandler;
+import org.jboss.windup.config.parser.ParserContext;
+import org.jboss.windup.config.parser.WindupXMLRulesetParsingException;
+import org.jboss.windup.config.parser.xml.RuleProviderHandler;
+import org.w3c.dom.Element;
+
+@NamespaceElementHandler(elementName = MetadataSourceTechnologyHandler.METADATA_SOURCE_TECHNOLOGY_ELEMENT, namespace = RuleProviderHandler.WINDUP_RULE_NAMESPACE)
+public class MetadataSourceTechnologyHandler implements ElementHandler<TechnologyReference>
+{
+
+    private static String ID="id";
+    private static String VERSION_RANGE="versionRange";
+    public static final String METADATA_SOURCE_TECHNOLOGY_ELEMENT="sourceTechnology";
+    
+    @Override
+    public TechnologyReference processElement(ParserContext handlerManager, Element element) throws ConfigurationException
+    {
+        String id = element.getAttribute(ID);
+        String versionRange = element.getAttribute(VERSION_RANGE);
+        if (StringUtils.isBlank(id))
+        {
+            throw new WindupXMLRulesetParsingException("The '" + METADATA_SOURCE_TECHNOLOGY_ELEMENT + "' element must have a non-empty '" + ID + "' attribute");
+        }
+        if (StringUtils.isBlank(versionRange))
+        {
+            throw new WindupXMLRulesetParsingException("The '" + METADATA_SOURCE_TECHNOLOGY_ELEMENT + "' element must have a non-empty '" + VERSION_RANGE + "' attribute");
+        }
+        try{
+            Versions.parseVersionRange(versionRange);
+        } catch(VersionException ex) {
+            throw new WindupXMLRulesetParsingException("The '" + VERSION_RANGE + "' attribute with value \"" + versionRange+ "\" in the element " +METADATA_SOURCE_TECHNOLOGY_ELEMENT + " is not a valid version",ex);
+        }
+        
+        TechnologyReference reference = new TechnologyReference(id, versionRange);
+        return reference;
+    }
+    
+}

--- a/config-xml/addon/src/main/java/org/jboss/windup/config/parser/metadata/MetadataTagHandler.java
+++ b/config-xml/addon/src/main/java/org/jboss/windup/config/parser/metadata/MetadataTagHandler.java
@@ -1,0 +1,38 @@
+package org.jboss.windup.config.parser.metadata;
+
+import static org.joox.JOOX.$;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.jboss.windup.config.exception.ConfigurationException;
+import org.jboss.windup.config.parser.ElementHandler;
+import org.jboss.windup.config.parser.NamespaceElementHandler;
+import org.jboss.windup.config.parser.ParserContext;
+import org.jboss.windup.config.parser.xml.RuleProviderHandler;
+import org.w3c.dom.Element;
+
+@NamespaceElementHandler(elementName = "tags", namespace = RuleProviderHandler.WINDUP_RULE_NAMESPACE)
+public class MetadataTagHandler implements ElementHandler<List<String>>
+{
+
+    @Override
+    public List<String> processElement(ParserContext handlerManager, Element element) throws ConfigurationException
+    {
+        List<Element> children = $(element).children().get();
+        
+        List<String> tags = new ArrayList<String>();
+        for (Element child : children)
+        {
+            switch ($(child).tag())
+            {
+            case "tag":
+                tags.add(child.getTextContent());
+                break;
+            }
+           
+        }
+        return tags;
+    }
+    
+}

--- a/config-xml/addon/src/main/java/org/jboss/windup/config/parser/metadata/MetadataTargetTechnologyHandler.java
+++ b/config-xml/addon/src/main/java/org/jboss/windup/config/parser/metadata/MetadataTargetTechnologyHandler.java
@@ -1,0 +1,47 @@
+package org.jboss.windup.config.parser.metadata;
+
+import org.apache.commons.lang.StringUtils;
+import org.jboss.forge.furnace.versions.VersionException;
+import org.jboss.forge.furnace.versions.Versions;
+import org.jboss.windup.config.exception.ConfigurationException;
+import org.jboss.windup.config.metadata.TechnologyReference;
+import org.jboss.windup.config.parser.ElementHandler;
+import org.jboss.windup.config.parser.NamespaceElementHandler;
+import org.jboss.windup.config.parser.ParserContext;
+import org.jboss.windup.config.parser.WindupXMLRulesetParsingException;
+import org.jboss.windup.config.parser.xml.RuleProviderHandler;
+import org.w3c.dom.Element;
+
+@NamespaceElementHandler(elementName = MetadataTargetTechnologyHandler.METADATA_TARGET_TECHNOLOGY_ELEMENT, namespace = RuleProviderHandler.WINDUP_RULE_NAMESPACE)
+public class MetadataTargetTechnologyHandler implements ElementHandler<TechnologyReference>
+{
+
+    private static String ID = "id";
+    private static String VERSION_RANGE = "versionRange";
+    public static final String METADATA_TARGET_TECHNOLOGY_ELEMENT = "targetTechnology";
+
+    @Override
+    public TechnologyReference processElement(ParserContext handlerManager, Element element) throws ConfigurationException
+    {
+        String id = element.getAttribute(ID);
+        String versionRange = element.getAttribute(VERSION_RANGE);
+        if (StringUtils.isBlank(id))
+        {
+            throw new WindupXMLRulesetParsingException("The '" + METADATA_TARGET_TECHNOLOGY_ELEMENT + "' element must have a non-empty '" + ID + "' attribute");
+        }
+        if (StringUtils.isBlank(versionRange))
+        {
+            throw new WindupXMLRulesetParsingException("The '" + METADATA_TARGET_TECHNOLOGY_ELEMENT + "' element must have a non-empty '" + VERSION_RANGE
+                        + "' attribute");
+        }
+        try{
+            Versions.parseVersionRange(versionRange);
+        } catch(VersionException ex) {
+            throw new WindupXMLRulesetParsingException("The '" + VERSION_RANGE + "' attribute with value \"" + versionRange+ "\" in the element " +METADATA_TARGET_TECHNOLOGY_ELEMENT + " is not a valid version",ex);
+        }
+        
+        TechnologyReference reference = new TechnologyReference(id, versionRange);
+        return reference;
+    }
+
+}

--- a/config-xml/addon/src/main/java/org/jboss/windup/config/parser/xml/MetadataRootHandler.java
+++ b/config-xml/addon/src/main/java/org/jboss/windup/config/parser/xml/MetadataRootHandler.java
@@ -1,0 +1,64 @@
+package org.jboss.windup.config.parser.xml;
+
+import static org.joox.JOOX.$;
+
+import java.util.List;
+
+import org.jboss.forge.furnace.addons.AddonId;
+import org.jboss.windup.config.exception.ConfigurationException;
+import org.jboss.windup.config.metadata.MetadataBuilder;
+import org.jboss.windup.config.metadata.RulesetMetadata;
+import org.jboss.windup.config.metadata.TechnologyReference;
+import org.jboss.windup.config.parser.ElementHandler;
+import org.jboss.windup.config.parser.NamespaceElementHandler;
+import org.jboss.windup.config.parser.ParserContext;
+import org.w3c.dom.Element;
+
+@NamespaceElementHandler(elementName = "metadata", namespace = RuleProviderHandler.WINDUP_RULE_NAMESPACE)
+public class MetadataRootHandler implements ElementHandler<RulesetMetadata>
+{
+
+    @Override
+    public RulesetMetadata processElement(ParserContext context, Element element) throws ConfigurationException
+    {
+        List<Element> children = $(element).children().get();
+        MetadataBuilder metadataBuilder = context.getBuilder().getMetadataBuilder();
+        for (Element child : children)
+        {
+            Object result = context.processElement(child);
+            
+            switch ($(child).tag())
+            {
+            case "dependencies":
+                List<AddonId> resultList = (List<AddonId>)result;
+                for(AddonId id : resultList) {
+                    metadataBuilder.addRequiredAddon(id);
+                }
+                break;
+
+            case "sourceTechnology":
+                metadataBuilder.addSourceTechnology((TechnologyReference)result);
+                break;
+
+            case "targetTechnology":
+                metadataBuilder.addTargetTechnology((TechnologyReference)result);
+                break;
+                
+            case "tags":
+                List<String> tagList = (List<String>)result;
+                for(String tag : tagList) {
+                    metadataBuilder.addTag(tag);
+                }
+                break;
+            case "executeAfter":
+                metadataBuilder.addExecuteAfterId((String)result);
+                break;
+            case "executeBefore":
+                metadataBuilder.addExecuteBeforeId((String)result);
+                break;
+            }
+        }
+        return metadataBuilder;
+    }
+
+}

--- a/config-xml/addon/src/main/java/org/jboss/windup/config/parser/xml/PhaseHandler.java
+++ b/config-xml/addon/src/main/java/org/jboss/windup/config/parser/xml/PhaseHandler.java
@@ -32,7 +32,7 @@ public class PhaseHandler implements ElementHandler<Void>
         Class<? extends RulePhase> phase = getPhases().get(classNameToKey(phaseStr));
         if (phase == null)
         {
-            throw new IllegalArgumentException("Unrecognized phase \"" + phase + "\"");
+            throw new IllegalArgumentException("Unrecognized phase \"" + phaseStr + "\"");
         }
         context.getBuilder().setPhase(phase);
         return null;

--- a/config-xml/addon/src/main/java/org/jboss/windup/config/parser/xml/RuleHandler.java
+++ b/config-xml/addon/src/main/java/org/jboss/windup/config/parser/xml/RuleHandler.java
@@ -16,7 +16,7 @@ import org.w3c.dom.Element;
 /**
  * Handles parsing the "rule" element to add rules to the current ruleset.
  */
-@NamespaceElementHandler(elementName = "rule", namespace = "http://windup.jboss.org/v1/xml")
+@NamespaceElementHandler(elementName = "rule", namespace = RuleProviderHandler.WINDUP_RULE_NAMESPACE)
 public class RuleHandler implements ElementHandler<Void>
 {
     @Override

--- a/config-xml/addon/src/main/java/org/jboss/windup/config/parser/xml/RuleProviderHandler.java
+++ b/config-xml/addon/src/main/java/org/jboss/windup/config/parser/xml/RuleProviderHandler.java
@@ -2,17 +2,23 @@ package org.jboss.windup.config.parser.xml;
 
 import static org.joox.JOOX.$;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.commons.lang.RandomStringUtils;
 import org.apache.commons.lang.StringUtils;
+import org.jboss.forge.furnace.Furnace;
+import org.jboss.forge.furnace.proxy.Proxies;
 import org.jboss.windup.config.AbstractRuleProvider;
 import org.jboss.windup.config.builder.RuleProviderBuilder;
 import org.jboss.windup.config.exception.ConfigurationException;
+import org.jboss.windup.config.furnace.FurnaceHolder;
 import org.jboss.windup.config.parser.ElementHandler;
 import org.jboss.windup.config.parser.NamespaceElementHandler;
 import org.jboss.windup.config.parser.ParserContext;
+import org.jboss.windup.config.phase.RulePhase;
 import org.w3c.dom.Element;
 
 /**
@@ -20,11 +26,14 @@ import org.w3c.dom.Element;
  * 
  * @author jsightler <jesse.sightler@gmail.com>
  */
-@NamespaceElementHandler(elementName = "ruleset", namespace = "http://windup.jboss.org/v1/xml")
+@NamespaceElementHandler(elementName = "ruleset", namespace = RuleProviderHandler.WINDUP_RULE_NAMESPACE)
 public class RuleProviderHandler implements ElementHandler<Void>
 {
     private static final String ID = "id";
+    private static final String PHASE = "phase";
     private static final AtomicInteger currentDefaultIDIndex = new AtomicInteger(0);
+    private Map<String, Class<? extends RulePhase>> cachedPhases;
+    public static final String WINDUP_RULE_NAMESPACE="http://windup.jboss.org/v1/xml";
 
     @Override
     public Void processElement(ParserContext context, Element element) throws ConfigurationException
@@ -35,20 +44,16 @@ public class RuleProviderHandler implements ElementHandler<Void>
             id = generateDefaultID();
         }
         RuleProviderBuilder builder = RuleProviderBuilder.begin(id);
+        String phaseStr = element.getAttribute(PHASE);
+        Class<? extends RulePhase> phase = getPhases().get(classNameToKey(phaseStr));
+        builder.setPhase(phase);
+        
         context.setBuilder(builder);
 
         List<Element> children = $(element).children().get();
         for (Element child : children)
         {
             Object result = context.processElement(child);
-
-            switch ($(child).tag())
-            {
-            case "execute-after":
-                builder.getMetadata().getExecuteAfterIDs().add(result.toString());
-            case "execute-before":
-                builder.getMetadata().getExecuteBeforeIDs().add(result.toString());
-            }
         }
         context.addRuleProvider(builder);
 
@@ -58,5 +63,27 @@ public class RuleProviderHandler implements ElementHandler<Void>
     private String generateDefaultID()
     {
         return "XMLRuleProvider:" + RandomStringUtils.random(4) + ":" + currentDefaultIDIndex.incrementAndGet();
+    }
+    
+    private Map<String, Class<? extends RulePhase>> getPhases()
+    {
+        if (cachedPhases == null)
+        {
+            cachedPhases = new HashMap<>();
+            Furnace furnace = FurnaceHolder.getFurnace();
+            for (RulePhase phase : furnace.getAddonRegistry().getServices(RulePhase.class))
+            {
+                @SuppressWarnings("unchecked")
+                Class<? extends RulePhase> unwrappedClass = (Class<? extends RulePhase>) Proxies.unwrap(phase).getClass();
+                String simpleName = unwrappedClass.getSimpleName();
+                cachedPhases.put(classNameToKey(simpleName), unwrappedClass);
+            }
+        }
+        return cachedPhases;
+    }
+    
+    private String classNameToKey(String className)
+    {
+        return className.toUpperCase();
     }
 }

--- a/config-xml/addon/src/main/java/org/jboss/windup/config/parser/xml/RulesHandler.java
+++ b/config-xml/addon/src/main/java/org/jboss/windup/config/parser/xml/RulesHandler.java
@@ -9,7 +9,7 @@ import org.jboss.windup.config.parser.NamespaceElementHandler;
 import org.jboss.windup.config.parser.ParserContext;
 import org.w3c.dom.Element;
 
-@NamespaceElementHandler(elementName = "rules", namespace = "http://windup.jboss.org/v1/xml")
+@NamespaceElementHandler(elementName = "rules", namespace = RuleProviderHandler.WINDUP_RULE_NAMESPACE)
 public class RulesHandler implements ElementHandler<Void>
 {
     @Override

--- a/config-xml/addon/src/main/java/org/jboss/windup/config/parser/xml/perform/IterationHandler.java
+++ b/config-xml/addon/src/main/java/org/jboss/windup/config/parser/xml/perform/IterationHandler.java
@@ -14,6 +14,7 @@ import org.jboss.windup.config.operation.iteration.IterationBuilderPerform;
 import org.jboss.windup.config.parser.ElementHandler;
 import org.jboss.windup.config.parser.NamespaceElementHandler;
 import org.jboss.windup.config.parser.ParserContext;
+import org.jboss.windup.config.parser.xml.RuleProviderHandler;
 import org.ocpsoft.rewrite.config.Condition;
 import org.ocpsoft.rewrite.config.Operation;
 import org.ocpsoft.rewrite.config.Perform;
@@ -24,7 +25,7 @@ import org.w3c.dom.Element;
  * 
  * @author jsightler <jesse.sightler@gmail.com>
  */
-@NamespaceElementHandler(elementName = "iteration", namespace = "http://windup.jboss.org/v1/xml")
+@NamespaceElementHandler(elementName = "iteration", namespace = RuleProviderHandler.WINDUP_RULE_NAMESPACE)
 public class IterationHandler implements ElementHandler<Iteration>
 {
 

--- a/config-xml/addon/src/main/java/org/jboss/windup/config/parser/xml/perform/LogHandler.java
+++ b/config-xml/addon/src/main/java/org/jboss/windup/config/parser/xml/perform/LogHandler.java
@@ -7,11 +7,12 @@ import org.jboss.windup.config.operation.Log;
 import org.jboss.windup.config.parser.ElementHandler;
 import org.jboss.windup.config.parser.NamespaceElementHandler;
 import org.jboss.windup.config.parser.ParserContext;
+import org.jboss.windup.config.parser.xml.RuleProviderHandler;
 import org.ocpsoft.logging.Logger.Level;
 import org.ocpsoft.rewrite.config.Operation;
 import org.w3c.dom.Element;
 
-@NamespaceElementHandler(elementName = "log", namespace = "http://windup.jboss.org/v1/xml")
+@NamespaceElementHandler(elementName = "log", namespace = RuleProviderHandler.WINDUP_RULE_NAMESPACE)
 public class LogHandler implements ElementHandler<Operation>
 {
     @Override

--- a/config-xml/addon/src/main/java/org/jboss/windup/config/parser/xml/perform/OtherwiseHandler.java
+++ b/config-xml/addon/src/main/java/org/jboss/windup/config/parser/xml/perform/OtherwiseHandler.java
@@ -8,12 +8,13 @@ import org.jboss.windup.config.exception.ConfigurationException;
 import org.jboss.windup.config.parser.ElementHandler;
 import org.jboss.windup.config.parser.NamespaceElementHandler;
 import org.jboss.windup.config.parser.ParserContext;
+import org.jboss.windup.config.parser.xml.RuleProviderHandler;
 import org.ocpsoft.rewrite.config.Operation;
 import org.ocpsoft.rewrite.config.OperationBuilder;
 import org.ocpsoft.rewrite.config.Operations;
 import org.w3c.dom.Element;
 
-@NamespaceElementHandler(elementName = "otherwise", namespace = "http://windup.jboss.org/v1/xml")
+@NamespaceElementHandler(elementName = "otherwise", namespace = RuleProviderHandler.WINDUP_RULE_NAMESPACE)
 public class OtherwiseHandler implements ElementHandler<Operation>
 {
     @Override

--- a/config-xml/addon/src/main/java/org/jboss/windup/config/parser/xml/perform/PerformHandler.java
+++ b/config-xml/addon/src/main/java/org/jboss/windup/config/parser/xml/perform/PerformHandler.java
@@ -10,6 +10,7 @@ import org.jboss.windup.config.parser.ElementHandler;
 import org.jboss.windup.config.parser.NamespaceElementHandler;
 import org.jboss.windup.config.parser.ParserContext;
 import org.jboss.windup.config.parser.xml.RuleHandler;
+import org.jboss.windup.config.parser.xml.RuleProviderHandler;
 import org.ocpsoft.rewrite.config.ConfigurationBuilder;
 import org.ocpsoft.rewrite.config.ConfigurationRuleBuilder;
 import org.ocpsoft.rewrite.config.Operation;
@@ -17,7 +18,7 @@ import org.ocpsoft.rewrite.config.OperationBuilder;
 import org.ocpsoft.rewrite.config.Operations;
 import org.w3c.dom.Element;
 
-@NamespaceElementHandler(elementName = "perform", namespace = "http://windup.jboss.org/v1/xml")
+@NamespaceElementHandler(elementName = "perform", namespace = RuleProviderHandler.WINDUP_RULE_NAMESPACE)
 public class PerformHandler implements ElementHandler<Operation>
 {
     @Override

--- a/config-xml/addon/src/main/java/org/jboss/windup/config/parser/xml/when/AndHandler.java
+++ b/config-xml/addon/src/main/java/org/jboss/windup/config/parser/xml/when/AndHandler.java
@@ -8,11 +8,12 @@ import java.util.List;
 import org.jboss.windup.config.parser.ElementHandler;
 import org.jboss.windup.config.parser.NamespaceElementHandler;
 import org.jboss.windup.config.parser.ParserContext;
+import org.jboss.windup.config.parser.xml.RuleProviderHandler;
 import org.ocpsoft.rewrite.config.And;
 import org.ocpsoft.rewrite.config.Condition;
 import org.w3c.dom.Element;
 
-@NamespaceElementHandler(elementName = "and", namespace = "http://windup.jboss.org/v1/xml")
+@NamespaceElementHandler(elementName = "and", namespace = RuleProviderHandler.WINDUP_RULE_NAMESPACE)
 public class AndHandler implements ElementHandler<And>
 {
    @Override

--- a/config-xml/addon/src/main/java/org/jboss/windup/config/parser/xml/when/NamespaceHandler.java
+++ b/config-xml/addon/src/main/java/org/jboss/windup/config/parser/xml/when/NamespaceHandler.java
@@ -5,10 +5,11 @@ import static org.joox.JOOX.$;
 import org.jboss.windup.config.parser.ElementHandler;
 import org.jboss.windup.config.parser.NamespaceElementHandler;
 import org.jboss.windup.config.parser.ParserContext;
+import org.jboss.windup.config.parser.xml.RuleProviderHandler;
 import org.jboss.windup.util.xml.NamespaceEntry;
 import org.w3c.dom.Element;
 
-@NamespaceElementHandler(elementName = "namespace", namespace = "http://windup.jboss.org/v1/xml")
+@NamespaceElementHandler(elementName = "namespace", namespace = RuleProviderHandler.WINDUP_RULE_NAMESPACE)
 public class NamespaceHandler implements ElementHandler<NamespaceEntry>
 {
    @Override

--- a/config-xml/addon/src/main/java/org/jboss/windup/config/parser/xml/when/NotHandler.java
+++ b/config-xml/addon/src/main/java/org/jboss/windup/config/parser/xml/when/NotHandler.java
@@ -5,11 +5,12 @@ import static org.joox.JOOX.$;
 import org.jboss.windup.config.parser.ElementHandler;
 import org.jboss.windup.config.parser.NamespaceElementHandler;
 import org.jboss.windup.config.parser.ParserContext;
+import org.jboss.windup.config.parser.xml.RuleProviderHandler;
 import org.ocpsoft.rewrite.config.Condition;
 import org.ocpsoft.rewrite.config.Not;
 import org.w3c.dom.Element;
 
-@NamespaceElementHandler(elementName = "not", namespace = "http://windup.jboss.org/v1/xml")
+@NamespaceElementHandler(elementName = "not", namespace = RuleProviderHandler.WINDUP_RULE_NAMESPACE)
 public class NotHandler implements ElementHandler<Not>
 {
 

--- a/config-xml/addon/src/main/java/org/jboss/windup/config/parser/xml/when/OrHandler.java
+++ b/config-xml/addon/src/main/java/org/jboss/windup/config/parser/xml/when/OrHandler.java
@@ -8,11 +8,12 @@ import java.util.List;
 import org.jboss.windup.config.parser.ElementHandler;
 import org.jboss.windup.config.parser.NamespaceElementHandler;
 import org.jboss.windup.config.parser.ParserContext;
+import org.jboss.windup.config.parser.xml.RuleProviderHandler;
 import org.ocpsoft.rewrite.config.Condition;
 import org.ocpsoft.rewrite.config.Or;
 import org.w3c.dom.Element;
 
-@NamespaceElementHandler(elementName = "or", namespace = "http://windup.jboss.org/v1/xml")
+@NamespaceElementHandler(elementName = "or", namespace = RuleProviderHandler.WINDUP_RULE_NAMESPACE)
 public class OrHandler implements ElementHandler<Or>
 {
    @Override

--- a/config-xml/addon/src/main/java/org/jboss/windup/config/parser/xml/when/ParamHandler.java
+++ b/config-xml/addon/src/main/java/org/jboss/windup/config/parser/xml/when/ParamHandler.java
@@ -6,10 +6,11 @@ import org.jboss.windup.config.condition.ParamCondition;
 import org.jboss.windup.config.parser.ElementHandler;
 import org.jboss.windup.config.parser.NamespaceElementHandler;
 import org.jboss.windup.config.parser.ParserContext;
+import org.jboss.windup.config.parser.xml.RuleProviderHandler;
 import org.ocpsoft.rewrite.config.Condition;
 import org.w3c.dom.Element;
 
-@NamespaceElementHandler(elementName = "param", namespace = "http://windup.jboss.org/v1/xml")
+@NamespaceElementHandler(elementName = "param", namespace = RuleProviderHandler.WINDUP_RULE_NAMESPACE)
 public class ParamHandler implements ElementHandler<Condition>
 {
    @Override

--- a/config-xml/addon/src/main/java/org/jboss/windup/config/parser/xml/when/TrueHandler.java
+++ b/config-xml/addon/src/main/java/org/jboss/windup/config/parser/xml/when/TrueHandler.java
@@ -3,10 +3,11 @@ package org.jboss.windup.config.parser.xml.when;
 import org.jboss.windup.config.parser.ElementHandler;
 import org.jboss.windup.config.parser.NamespaceElementHandler;
 import org.jboss.windup.config.parser.ParserContext;
+import org.jboss.windup.config.parser.xml.RuleProviderHandler;
 import org.ocpsoft.rewrite.config.True;
 import org.w3c.dom.Element;
 
-@NamespaceElementHandler(elementName = "true", namespace = "http://windup.jboss.org/v1/xml")
+@NamespaceElementHandler(elementName = "true", namespace = RuleProviderHandler.WINDUP_RULE_NAMESPACE)
 public class TrueHandler implements ElementHandler<True>
 {
    @Override

--- a/config-xml/addon/src/main/java/org/jboss/windup/config/parser/xml/when/WhenHandler.java
+++ b/config-xml/addon/src/main/java/org/jboss/windup/config/parser/xml/when/WhenHandler.java
@@ -8,6 +8,7 @@ import java.util.List;
 import org.jboss.windup.config.parser.ElementHandler;
 import org.jboss.windup.config.parser.NamespaceElementHandler;
 import org.jboss.windup.config.parser.ParserContext;
+import org.jboss.windup.config.parser.xml.RuleProviderHandler;
 import org.ocpsoft.rewrite.config.And;
 import org.ocpsoft.rewrite.config.Condition;
 import org.w3c.dom.Element;
@@ -15,7 +16,7 @@ import org.w3c.dom.Element;
 /**
  * Parses the "when" element, which will contain {@link Condition} that will be combined together via {@link And}.
  */
-@NamespaceElementHandler(elementName = "when", namespace = "http://windup.jboss.org/v1/xml")
+@NamespaceElementHandler(elementName = "when", namespace = RuleProviderHandler.WINDUP_RULE_NAMESPACE)
 public class WhenHandler implements ElementHandler<And>
 {
     @Override

--- a/config-xml/addon/src/main/java/org/jboss/windup/config/parser/xml/where/MatchesHandler.java
+++ b/config-xml/addon/src/main/java/org/jboss/windup/config/parser/xml/where/MatchesHandler.java
@@ -5,9 +5,10 @@ import static org.joox.JOOX.$;
 import org.jboss.windup.config.parser.ElementHandler;
 import org.jboss.windup.config.parser.NamespaceElementHandler;
 import org.jboss.windup.config.parser.ParserContext;
+import org.jboss.windup.config.parser.xml.RuleProviderHandler;
 import org.w3c.dom.Element;
 
-@NamespaceElementHandler(elementName = "matches", namespace = "http://windup.jboss.org/v1/xml")
+@NamespaceElementHandler(elementName = "matches", namespace = RuleProviderHandler.WINDUP_RULE_NAMESPACE)
 public class MatchesHandler implements ElementHandler<Void>
 {
    @Override

--- a/config-xml/addon/src/main/java/org/jboss/windup/config/parser/xml/where/WhereHandler.java
+++ b/config-xml/addon/src/main/java/org/jboss/windup/config/parser/xml/where/WhereHandler.java
@@ -7,6 +7,7 @@ import java.util.List;
 import org.jboss.windup.config.parser.ElementHandler;
 import org.jboss.windup.config.parser.NamespaceElementHandler;
 import org.jboss.windup.config.parser.ParserContext;
+import org.jboss.windup.config.parser.xml.RuleProviderHandler;
 import org.ocpsoft.rewrite.config.ConfigurationRuleBuilderPerform;
 import org.ocpsoft.rewrite.config.ConfigurationRuleParameterWhere;
 import org.w3c.dom.Element;
@@ -14,7 +15,7 @@ import org.w3c.dom.Element;
 /**
  * Parses any {@link ConfigurationRuleParameterWhere} elements that may be in this ruleset.
  */
-@NamespaceElementHandler(elementName = "where", namespace = "http://windup.jboss.org/v1/xml")
+@NamespaceElementHandler(elementName = "where", namespace = RuleProviderHandler.WINDUP_RULE_NAMESPACE)
 public class WhereHandler implements ElementHandler<Void>
 {
     @Override

--- a/config-xml/tests/pom.xml
+++ b/config-xml/tests/pom.xml
@@ -36,6 +36,13 @@
             <classifier>forge-addon</classifier>
             <scope>provided</scope>
         </dependency>
+        
+        <dependency>
+            <groupId>org.jboss.windup.utils</groupId>
+            <artifactId>windup-utils</artifactId>
+            <classifier>forge-addon</classifier>
+            <scope>provided</scope>
+        </dependency>
 
 
         <!-- Test Dependencies -->

--- a/config-xml/tests/src/test/java/org/jboss/windup/config/metadata/MetaDataHandlerTest.java
+++ b/config-xml/tests/src/test/java/org/jboss/windup/config/metadata/MetaDataHandlerTest.java
@@ -1,0 +1,103 @@
+package org.jboss.windup.config.metadata;
+
+import java.io.File;
+import java.util.List;
+import java.util.Set;
+
+import javax.inject.Inject;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.forge.arquillian.AddonDependency;
+import org.jboss.forge.arquillian.Dependencies;
+import org.jboss.forge.arquillian.archive.ForgeArchive;
+import org.jboss.forge.furnace.Furnace;
+import org.jboss.forge.furnace.addons.AddonId;
+import org.jboss.forge.furnace.repositories.AddonDependencyEntry;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.windup.config.AbstractRuleProvider;
+import org.jboss.windup.config.parser.ParserContext;
+import org.jboss.windup.graph.GraphContext;
+import org.jboss.windup.graph.GraphContextFactory;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.ocpsoft.rewrite.config.Configuration;
+import org.w3c.dom.Document;
+
+@RunWith(Arquillian.class)
+public class MetaDataHandlerTest
+{
+
+    private static final String XML_FILE = "src/test/resources/testxml/metadata.windup.xml";
+
+    @Deployment
+    @Dependencies({
+                @AddonDependency(name = "org.jboss.windup.config:windup-config"),
+                @AddonDependency(name = "org.jboss.windup.config:windup-config-xml"),
+                @AddonDependency(name = "org.jboss.forge.furnace.container:cdi")
+    })
+    public static ForgeArchive getDeployment()
+    {
+        final ForgeArchive archive = ShrinkWrap.create(ForgeArchive.class)
+                    .addBeansXML()
+                    .addClass(MetaDataHandlerTest.class)
+                    .addAsAddonDependencies(
+                                AddonDependencyEntry.create("org.jboss.windup.config:windup-config"),
+                                AddonDependencyEntry.create("org.jboss.windup.config:windup-config-xml"),
+                                AddonDependencyEntry.create("org.jboss.forge.furnace.container:cdi")
+                    );
+
+        return archive;
+    }
+
+    @Inject
+    private Furnace furnace;
+
+    @Inject
+    private GraphContextFactory graphContextFactory;
+
+    @Test
+    public void testXmlParsinfOfRulesetMetadata() throws Exception
+    {
+        ParserContext parser = new ParserContext(furnace);
+        File fXmlFile = new File(XML_FILE);
+        DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
+        dbFactory.setNamespaceAware(true);
+        DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
+        Document firstXmlFile = dBuilder.parse(fXmlFile);
+        parser.processElement(firstXmlFile.getDocumentElement());
+        // verify xmlfile
+        Assert.assertEquals(1, parser.getRuleProviders().size());
+        AbstractRuleProvider abstractRuleProvider = parser.getRuleProviders().get(0);
+        RuleProviderMetadata metadata = abstractRuleProvider.getMetadata();
+        List<String> executeAfterIDs = metadata.getExecuteAfterIDs();
+        List<String> executeBeforeIDs = metadata.getExecuteBeforeIDs();
+        Set<AddonId> requiredAddons = metadata.getRequiredAddons();
+        Set<TechnologyReference> sourceTechnologies = metadata.getSourceTechnologies();
+        Set<TechnologyReference> targetTechnologies = metadata.getTargetTechnologies();
+        Set<String> tags = metadata.getTags();
+
+        Assert.assertTrue(executeAfterIDs.contains("AfterId"));
+        Assert.assertTrue(executeBeforeIDs.contains("BeforeId"));
+        Assert.assertTrue(tags.contains("require-stateless"));
+        Assert.assertTrue(tags.contains("require-nofilesystem-io"));
+        Assert.assertTrue(requiredAddons.contains(AddonId.valueOf("org.jboss.windup.rules,windup-rules-javaee,2.0.1.Final")));
+        Assert.assertTrue(requiredAddons.contains(AddonId.valueOf("org.jboss.windup.rules,windup-rules-java,2.0.0.Final")));
+        Assert.assertTrue(sourceTechnologies.contains(new TechnologyReference("ejb", "(2,3]")));
+        Assert.assertTrue(sourceTechnologies.contains(new TechnologyReference("weblogic", "(10,12]")));
+        Assert.assertTrue(targetTechnologies.contains(new TechnologyReference("eap", "(5,6]")));
+        Assert.assertTrue(targetTechnologies.contains(new TechnologyReference("ejb", "(2,3]")));
+        Assert.assertTrue(targetTechnologies.contains(new TechnologyReference("ejb", "(2,3]")));
+
+        try (GraphContext graphContext = graphContextFactory.create())
+        {
+            Configuration configuration = abstractRuleProvider.getConfiguration(graphContext);
+            Assert.assertFalse(configuration.getRules().isEmpty());
+            Assert.assertTrue(configuration.getRules().get(0).toString().contains("test {foo} iteration perform"));
+        }
+    }
+
+}

--- a/config-xml/tests/src/test/resources/testxml/Test1.windup.xml
+++ b/config-xml/tests/src/test/resources/testxml/Test1.windup.xml
@@ -1,10 +1,7 @@
 <?xml version="1.0"?>
-<ruleset xmlns="http://windup.jboss.org/v1/xml" id="testruleprovider">
+<ruleset xmlns="http://windup.jboss.org/v1/xml" id="testruleprovider" phase="DiscoveryPhase">
 
     <!-- This defaults to MIGRATION_RULES, set a non-default value for test purposes -->
-    <phase>
-        DiscoveryPhase
-    </phase>
 
     <rules>
 

--- a/config-xml/tests/src/test/resources/testxml/metadata.windup.xml
+++ b/config-xml/tests/src/test/resources/testxml/metadata.windup.xml
@@ -1,0 +1,47 @@
+<ruleset xmlns="http://windup.jboss.org/v1/xml" id="WLS_10_12_TO_EAP_6" phase="testPhase">
+
+<metadata>
+	<dependencies>
+		<addon id="org.jboss.windup.rules,windup-rules-javaee,2.0.1.Final"/>			
+		<addon id="org.jboss.windup.rules,windup-rules-java,2.0.0.Final"/>
+	</dependencies>
+	<sourceTechnology id="weblogic" versionRange="(10,12]"/>
+	<sourceTechnology id="ejb" versionRange="(2,3]"/>
+	<targetTechnology id="eap" versionRange="(5,6]"/>
+	<targetTechnology id="ejb" versionRange="(2,3]"/>
+	<tags>
+		<tag>require-stateless</tag>
+		<tag>require-nofilesystem-io</tag>
+	</tags>
+	<executeAfter>AfterId</executeAfter>
+	<executeBefore>BeforeId</executeBefore>
+</metadata>
+
+
+<rules>
+        <rule>
+            <when>
+                <true/>
+            </when>
+            <perform>
+                <iteration>
+                    <when>
+                        <true/>
+                    </when>
+                    <perform>
+                        <log message="test {foo} iteration perform"/>
+                    </perform>
+                    <otherwise>
+                        <log message="test {foo} iteration otherwise"/>
+                    </otherwise>
+                </iteration>
+            </perform>
+            <otherwise>
+                <log message="test rule {foo} otherwise"/>
+            </otherwise>
+            <where param="foo">
+                <matches pattern="\d+"/>
+            </where>
+        </rule>
+</rules>
+</ruleset>

--- a/config/api/src/main/java/org/jboss/windup/config/AbstractConfigurationOption.java
+++ b/config/api/src/main/java/org/jboss/windup/config/AbstractConfigurationOption.java
@@ -1,17 +1,33 @@
 package org.jboss.windup.config;
 
+import java.util.Collection;
+import java.util.Collections;
+
 /**
  * Provides a base class for sharing default functionality between {@link ConfigurationOption}s.
  *
  * @author jsightler <jesse.sightler@gmail.com>
  * @author ozizka
  */
-public abstract class AbstractWindupConfigurationOption implements ConfigurationOption
+public abstract class AbstractConfigurationOption implements ConfigurationOption
 {
+    private Collection<?> availableValues = Collections.emptyList();
+
     @Override
     public int getPriority()
     {
         return 0;
+    }
+
+    @Override
+    public Collection<?> getAvailableValues()
+    {
+        return availableValues;
+    }
+
+    protected void setAvailableValues(Collection<?> availableValues)
+    {
+        this.availableValues = availableValues;
     }
 
     @Override

--- a/config/api/src/main/java/org/jboss/windup/config/AbstractPathConfigurationOption.java
+++ b/config/api/src/main/java/org/jboss/windup/config/AbstractPathConfigurationOption.java
@@ -5,13 +5,13 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 
 /**
- * Provides a base for validating {@link ConfigurationOption}s of type {@link File}. This uses the results of
- * {@link ConfigurationOption#getUIType()} to determine whether to validate as a file or as a directory.
+ * Provides a base for validating {@link ConfigurationOption}s of type {@link File}. This uses the results of {@link ConfigurationOption#getUIType()}
+ * to determine whether to validate as a file or as a directory.
  * 
  * @author jsightler <jesse.sightler@gmail.com>
  *
  */
-public abstract class AbstractPathConfigurationOption extends AbstractWindupConfigurationOption
+public abstract class AbstractPathConfigurationOption extends AbstractConfigurationOption
 {
     private boolean mustExist = false;
 

--- a/config/api/src/main/java/org/jboss/windup/config/AbstractRuleProvider.java
+++ b/config/api/src/main/java/org/jboss/windup/config/AbstractRuleProvider.java
@@ -7,8 +7,8 @@
 package org.jboss.windup.config;
 
 import org.jboss.forge.furnace.util.Annotations;
-import org.jboss.windup.config.metadata.RuleMetadata;
 import org.jboss.windup.config.metadata.MetadataBuilder;
+import org.jboss.windup.config.metadata.RuleMetadata;
 import org.jboss.windup.config.metadata.RuleMetadataType;
 import org.jboss.windup.config.metadata.RuleProviderMetadata;
 import org.jboss.windup.graph.GraphContext;
@@ -17,8 +17,8 @@ import org.ocpsoft.rewrite.context.Context;
 import org.ocpsoft.rewrite.context.ContextBase;
 
 /**
- * {@link AbstractRuleProvider} provides metadata, and a list of {@link Rule} objects that are then evaluated by the
- * {@link RuleSubet} during Windup execution.
+ * {@link AbstractRuleProvider} provides metadata, and a list of {@link Rule} objects that are then evaluated by the {@link RuleSubset} during Windup
+ * execution.
  *
  * @author <a href="mailto:lincolnbaxter@gmail.com">Lincoln Baxter, III</a>
  */
@@ -46,8 +46,7 @@ public abstract class AbstractRuleProvider extends ContextBase implements RulePr
     }
 
     /**
-     * Create a new {@link AbstractRuleProvider} instance using the given parameters to construct default
-     * {@link RuleProviderMetadata}.
+     * Create a new {@link AbstractRuleProvider} instance using the given parameters to construct default {@link RuleProviderMetadata}.
      */
     public AbstractRuleProvider(Class<? extends RuleProvider> implementationType, String id)
     {
@@ -67,8 +66,7 @@ public abstract class AbstractRuleProvider extends ContextBase implements RulePr
     }
 
     /**
-     * Specify additional meta-data to individual {@link Rule} instances originating from the corresponding
-     * {@link RuleProvider} instance.
+     * Specify additional meta-data to individual {@link Rule} instances originating from the corresponding {@link RuleProvider} instance.
      */
     public static void enhanceRuleMetadata(RuleProvider provider, Rule rule)
     {

--- a/config/api/src/main/java/org/jboss/windup/config/ConfigurationOption.java
+++ b/config/api/src/main/java/org/jboss/windup/config/ConfigurationOption.java
@@ -1,5 +1,7 @@
 package org.jboss.windup.config;
 
+import java.util.Collection;
+
 /**
  * Specifies details regarding a particular configuraiton option that can be passed into the Windup executor. This information is used by the UI to
  * determine the available options for running Windup.
@@ -44,6 +46,11 @@ public interface ConfigurationOption
      * Default value for this option (if not set by user).
      */
     Object getDefaultValue();
+
+    /**
+     * Returns an ordered list of available values. This is intended for use with {@link InputType#SELECT_MANY} and {@link InputType#SELECT_ONE}.
+     */
+    Collection<?> getAvailableValues();
 
     /**
      * Validate the user indicated value and return the result.

--- a/config/api/src/main/java/org/jboss/windup/config/RuleProvider.java
+++ b/config/api/src/main/java/org/jboss/windup/config/RuleProvider.java
@@ -6,8 +6,8 @@ import org.ocpsoft.rewrite.config.ConfigurationProvider;
 import org.ocpsoft.rewrite.config.Rule;
 
 /**
- * A windup-specific implementation of {@link ConfigurationProvider}. Provides {@link Rule} instances and relevant
- * {@link RuleProviderMetadata} for those {@link Rule} instances.
+ * A windup-specific implementation of {@link ConfigurationProvider}. Provides {@link Rule} instances and relevant {@link RuleProviderMetadata} for
+ * those {@link Rule} instances.
  * 
  * @author <a href="mailto:lincolnbaxter@gmail.com">Lincoln Baxter, III</a>
  */

--- a/config/api/src/main/java/org/jboss/windup/config/Variables.java
+++ b/config/api/src/main/java/org/jboss/windup/config/Variables.java
@@ -193,7 +193,7 @@ public class Variables
                 {
                     if (!type.isAssignableFrom(frame.getClass()))
                     {
-                        continue;
+                        break;
                     }
                 }
                 // now we know all the frames are of the chosen type

--- a/config/api/src/main/java/org/jboss/windup/config/builder/RuleProviderBuilder.java
+++ b/config/api/src/main/java/org/jboss/windup/config/builder/RuleProviderBuilder.java
@@ -26,6 +26,8 @@ public final class RuleProviderBuilder extends AbstractRuleProvider implements
     private ConfigurationBuilder configurationBuilder;
     private MetadataBuilder metadata;
 
+    
+   
     /**
      * Begin creating a new dynamic {@link AbstractRuleProvider}.
      */
@@ -105,6 +107,10 @@ public final class RuleProviderBuilder extends AbstractRuleProvider implements
     public Configuration getConfiguration(GraphContext context)
     {
         return configurationBuilder;
+    }
+    
+    public MetadataBuilder getMetadataBuilder() {
+        return metadata;
     }
 
     @Override

--- a/config/api/src/main/java/org/jboss/windup/config/builder/RuleProviderBuilder.java
+++ b/config/api/src/main/java/org/jboss/windup/config/builder/RuleProviderBuilder.java
@@ -14,7 +14,7 @@ import org.ocpsoft.rewrite.config.Rule;
 /**
  * Used to construct new dynamic {@link AbstractRuleProvider} instances.
  * 
- * @author jsightler
+ * @author <a href="mailto:jesse.sightler@gmail.com">Jess Sightler</a>
  * @author <a href="mailto:lincolnbaxter@gmail.com">Lincoln Baxter, III</a>
  */
 @Vetoed

--- a/config/api/src/main/java/org/jboss/windup/config/metadata/MetadataBuilder.java
+++ b/config/api/src/main/java/org/jboss/windup/config/metadata/MetadataBuilder.java
@@ -356,6 +356,14 @@ public class MetadataBuilder extends AbstractRulesetMetadata implements RuleProv
 
         return this;
     }
+    
+    public MetadataBuilder addTag(String tag) 
+    {
+        if (!StringUtils.isBlank(tag)) {
+            this.tags.add(tag.trim());
+        }
+        return this;
+    }
 
     @Override
     public Set<String> getTags()

--- a/config/api/src/main/java/org/jboss/windup/config/metadata/MetadataBuilder.java
+++ b/config/api/src/main/java/org/jboss/windup/config/metadata/MetadataBuilder.java
@@ -20,15 +20,13 @@ import org.jboss.windup.config.phase.RulePhase;
 import org.ocpsoft.rewrite.config.Rule;
 
 /**
- * Fluent builder for creating {@link RuleProviderMetadata} instances. Provides sensible defaults using given required
- * values.
+ * Fluent builder for creating {@link RuleProviderMetadata} instances. Provides sensible defaults using given required values.
  * <p>
- * If {@link RulesetMetadata} is available in the {@link Addon} in which this {@link MetadataBuilder} was constructed,
- * this will inherit values from {@link RulesetMetadata} for {@link #getTags()}, {@link #getSourceTechnologies()},
- * {@link #getTargetTechnologies()} and {@link #getRequiredAddons()}.
+ * If {@link RulesetMetadata} is available in the {@link Addon} in which this {@link MetadataBuilder} was constructed, this will inherit values from
+ * {@link RulesetMetadata} for {@link #getTags()}, {@link #getSourceTechnologies()}, {@link #getTargetTechnologies()} and {@link #getRequiredAddons()}.
  * <p>
- * Inherited metadata is specified by {@link #setRulesetMetadata(RulesetMetadata)}, and is typically performed by the
- * {@link RuleProviderLoader} implementation.
+ * Inherited metadata is specified by {@link #setRulesetMetadata(RulesetMetadata)}, and is typically performed by the {@link RuleProviderLoader}
+ * implementation.
  * 
  * @author <a href="mailto:lincolnbaxter@gmail.com">Lincoln Baxter, III</a>
  */
@@ -57,8 +55,8 @@ public class MetadataBuilder extends AbstractRulesetMetadata implements RuleProv
     }
 
     /**
-     * Create a new {@link RuleProviderMetadata} builder instance for the given {@link RuleProvider} type, using the
-     * provided parameters and {@link RulesetMetadata} to seed sensible defaults.
+     * Create a new {@link RuleProviderMetadata} builder instance for the given {@link RuleProvider} type, using the provided parameters and
+     * {@link RulesetMetadata} to seed sensible defaults.
      */
     public static MetadataBuilder forProvider(Class<? extends RuleProvider> implementationType)
     {
@@ -72,8 +70,8 @@ public class MetadataBuilder extends AbstractRulesetMetadata implements RuleProv
     }
 
     /**
-     * Create a new {@link RuleProviderMetadata} builder instance for the given {@link RuleProvider} type, and
-     * {@link String} ID, using the provided parameters and {@link RulesetMetadata} to seed sensible defaults.
+     * Create a new {@link RuleProviderMetadata} builder instance for the given {@link RuleProvider} type, and {@link String} ID, using the provided
+     * parameters and {@link RulesetMetadata} to seed sensible defaults.
      */
     public static MetadataBuilder forProvider(Class<? extends RuleProvider> implementationType, String providerId)
     {
@@ -162,8 +160,8 @@ public class MetadataBuilder extends AbstractRulesetMetadata implements RuleProv
     }
 
     /**
-     * Set the descriptive information indicating where the corresponding {@link RuleProvider} instance is located (eg,
-     * a path to an XML file on disk, or an {@link Addon} coordinate and class name).
+     * Set the descriptive information indicating where the corresponding {@link RuleProvider} instance is located (eg, a path to an XML file on disk,
+     * or an {@link Addon} coordinate and class name).
      */
     public MetadataBuilder setOrigin(String origin)
     {
@@ -178,10 +176,9 @@ public class MetadataBuilder extends AbstractRulesetMetadata implements RuleProv
     }
 
     /**
-     * Set the {@link RulePhase} in which the {@link Rule} instances from the corresponding {@link RuleProvider}
-     * instance should be executed.
+     * Set the {@link RulePhase} in which the {@link Rule} instances from the corresponding {@link RuleProvider} instance should be executed.
      * <p>
-     * The default phase is {@link RulePhase#MIGRATION_RULES}.
+     * The default phase is {@link org.jboss.windup.config.phase.MigrationRulesPhase}.
      */
     public MetadataBuilder setPhase(Class<? extends RulePhase> phase)
     {
@@ -196,11 +193,11 @@ public class MetadataBuilder extends AbstractRulesetMetadata implements RuleProv
     }
 
     /**
-     * Set the list of {@link RuleProvider} classes that should execute before the {@link Rule} instances in the
-     * corresponding {@link RuleProvider} instance.
+     * Set the list of {@link RuleProvider} classes that should execute before the {@link Rule} instances in the corresponding {@link RuleProvider}
+     * instance.
      *
      * <p>
-     * {@link RuleProvider} references can also be specified based on id ({@link #getExecuteAfterID}).
+     * {@link RuleProvider} references can also be specified based on id ({@link #getExecuteAfterIDs}).
      */
     public MetadataBuilder setExecuteAfter(List<Class<? extends RuleProvider>> executeAfter)
     {
@@ -209,10 +206,10 @@ public class MetadataBuilder extends AbstractRulesetMetadata implements RuleProv
     }
 
     /**
-     * Ad an entry to the list of {@link RuleProvider} classes that should execute after the {@link Rule} instances in
-     * the corresponding {@link RuleProvider} instance.
+     * Ad an entry to the list of {@link RuleProvider} classes that should execute after the {@link Rule} instances in the corresponding
+     * {@link RuleProvider} instance.
      *
-     * {@link RuleProvider}s can also be specified based on id ({@link #getExecuteBeforeID}).
+     * {@link RuleProvider}s can also be specified based on id ({@link #getExecuteBeforeIDs}).
      */
     public MetadataBuilder addExecuteAfter(Class<? extends RuleProvider> type)
     {
@@ -230,13 +227,12 @@ public class MetadataBuilder extends AbstractRulesetMetadata implements RuleProv
     }
 
     /**
-     * Set the list of the {@link RuleProvider} classes that should execute before the {@link Rule} instances in the
-     * corresponding {@link RuleProvider} instance.
+     * Set the list of the {@link RuleProvider} classes that should execute before the {@link Rule} instances in the corresponding
+     * {@link RuleProvider} instance.
      *
      * <p>
-     * This is returned as a list of Rule IDs in order to support extensions that cannot depend on each other via class
-     * names. For example, in the case of the Groovy rules extension, a single class covers many rules with their own
-     * IDs.
+     * This is returned as a list of Rule IDs in order to support extensions that cannot depend on each other via class names. For example, in the
+     * case of the Groovy rules extension, a single class covers many rules with their own IDs.
      *
      * For specifying Java-based rules, {@link #getExecuteAfter()} is preferred.
      */
@@ -247,13 +243,12 @@ public class MetadataBuilder extends AbstractRulesetMetadata implements RuleProv
     }
 
     /**
-     * Add an entry to the list of the {@link RuleProvider} classes that should execute before the {@link Rule}
-     * instances in the corresponding {@link RuleProvider} instance.
+     * Add an entry to the list of the {@link RuleProvider} classes that should execute before the {@link Rule} instances in the corresponding
+     * {@link RuleProvider} instance.
      *
      * <p>
-     * This is returned as a list of Rule IDs in order to support extensions that cannot depend on each other via class
-     * names. For example, in the case of the Groovy rules extension, a single class covers many rules with their own
-     * IDs.
+     * This is returned as a list of Rule IDs in order to support extensions that cannot depend on each other via class names. For example, in the
+     * case of the Groovy rules extension, a single class covers many rules with their own IDs.
      *
      * For specifying Java-based rules, {@link #getExecuteAfter()} is preferred.
      */
@@ -273,10 +268,10 @@ public class MetadataBuilder extends AbstractRulesetMetadata implements RuleProv
     }
 
     /**
-     * Set the list of {@link RuleProvider} classes that should execute after the {@link Rule} instances in the
-     * corresponding {@link RuleProvider} instance.
+     * Set the list of {@link RuleProvider} classes that should execute after the {@link Rule} instances in the corresponding {@link RuleProvider}
+     * instance.
      *
-     * {@link RuleProvider}s can also be specified based on id ({@link #getExecuteBeforeID}).
+     * {@link RuleProvider}s can also be specified based on id ({@link #getExecuteBeforeIDs}).
      */
     public MetadataBuilder setExecuteBefore(List<Class<? extends RuleProvider>> executeBefore)
     {
@@ -285,10 +280,10 @@ public class MetadataBuilder extends AbstractRulesetMetadata implements RuleProv
     }
 
     /**
-     * Ad an entry to the list of {@link RuleProvider} classes that should execute after the {@link Rule} instances in
-     * the corresponding {@link RuleProvider} instance.
+     * Ad an entry to the list of {@link RuleProvider} classes that should execute after the {@link Rule} instances in the corresponding
+     * {@link RuleProvider} instance.
      *
-     * {@link RuleProvider}s can also be specified based on id ({@link #getExecuteBeforeID}).
+     * {@link RuleProvider}s can also be specified based on id ({@link #getExecuteBeforeIDs}).
      */
     public MetadataBuilder addExecuteBefore(Class<? extends RuleProvider> type)
     {
@@ -306,13 +301,12 @@ public class MetadataBuilder extends AbstractRulesetMetadata implements RuleProv
     }
 
     /**
-     * Set the list of the {@link RuleProvider} classes that should execute after the {@link Rule} instances in the
-     * corresponding {@link RuleProvider} instance.
+     * Set the list of the {@link RuleProvider} classes that should execute after the {@link Rule} instances in the corresponding {@link RuleProvider}
+     * instance.
      *
      * <p>
-     * This is returned as a list of Rule IDs in order to support extensions that cannot depend on each other via class
-     * names. For example, in the case of the Groovy rules extension, a single class covers many rules with their own
-     * IDs.
+     * This is returned as a list of Rule IDs in order to support extensions that cannot depend on each other via class names. For example, in the
+     * case of the Groovy rules extension, a single class covers many rules with their own IDs.
      *
      * For specifying Java-based rules, {@link #getExecuteBefore()} is preferred.
      */
@@ -323,13 +317,12 @@ public class MetadataBuilder extends AbstractRulesetMetadata implements RuleProv
     }
 
     /**
-     * Add to the list of the {@link RuleProvider} classes that should execute after the {@link Rule} instances in the
-     * corresponding {@link RuleProvider} instance.
+     * Add to the list of the {@link RuleProvider} classes that should execute after the {@link Rule} instances in the corresponding
+     * {@link RuleProvider} instance.
      *
      * <p>
-     * This is returned as a list of Rule IDs in order to support extensions that cannot depend on each other via class
-     * names. For example, in the case of the Groovy rules extension, a single class covers many rules with their own
-     * IDs.
+     * This is returned as a list of Rule IDs in order to support extensions that cannot depend on each other via class names. For example, in the
+     * case of the Groovy rules extension, a single class covers many rules with their own IDs.
      *
      * For specifying Java-based rules, {@link #getExecuteBefore()} is preferred.
      */
@@ -392,8 +385,7 @@ public class MetadataBuilder extends AbstractRulesetMetadata implements RuleProv
     }
 
     /**
-     * Add to the {@link Set} of source {@link TechnologyReference} instances to which this {@link RuleProvider} is
-     * related.
+     * Add to the {@link Set} of source {@link TechnologyReference} instances to which this {@link RuleProvider} is related.
      * <p>
      * Inherits from {@link RulesetMetadata#getSourceTechnologies()} if available.
      */
@@ -412,8 +404,7 @@ public class MetadataBuilder extends AbstractRulesetMetadata implements RuleProv
     }
 
     /**
-     * Add to the {@link Set} of target {@link TechnologyReference} instances to which this {@link RuleProvider} is
-     * related.
+     * Add to the {@link Set} of target {@link TechnologyReference} instances to which this {@link RuleProvider} is related.
      * <p>
      * Inherits from {@link RulesetMetadata#getTargetTechnologies()} if available.
      */
@@ -432,9 +423,8 @@ public class MetadataBuilder extends AbstractRulesetMetadata implements RuleProv
     }
 
     /**
-     * Add to the {@link Set} of {@link Addon}s required to run this rule-set. (<b>Note:</b> This is typically only used
-     * in situations where rules are provided externally - such as XML - whereas in Java, the {@link Addon} will already
-     * define its dependencies on other addons directly.)
+     * Add to the {@link Set} of {@link Addon}s required to run this rule-set. (<b>Note:</b> This is typically only used in situations where rules are
+     * provided externally - such as XML - whereas in Java, the {@link Addon} will already define its dependencies on other addons directly.)
      * <p>
      * Inherits from {@link RulesetMetadata#getRequiredAddons()} if available.
      */

--- a/config/api/src/main/java/org/jboss/windup/config/metadata/RuleProviderMetadata.java
+++ b/config/api/src/main/java/org/jboss/windup/config/metadata/RuleProviderMetadata.java
@@ -27,15 +27,15 @@ public interface RuleProviderMetadata extends RulesetMetadata
     /**
      * Return the {@link RulePhase} in which {@link Rule} instances from this {@link RuleProvider} should be executed.
      * <p>
-     * The default phase is {@link RulePhase#MIGRATION_RULES}.
+     * The default phase is {@link org.jboss.windup.config.phase.MigrationRulesPhase}.
      */
     public Class<? extends RulePhase> getPhase();
 
     /**
-     * Returns a list of {@link RuleProvider} classes that should execute before the {@link Rule} instances in this
-     * corresponding {@link RuleProvider}.
+     * Returns a list of {@link RuleProvider} classes that should execute before the {@link Rule} instances in this corresponding {@link RuleProvider}
+     * .
      *
-     * {@link RuleProvider}s can also be specified based on id ({@link #getExecuteAfterID}).
+     * {@link RuleProvider}s can also be specified based on id ({@link #getExecuteAfterIDs}).
      */
     public List<Class<? extends RuleProvider>> getExecuteAfter();
 
@@ -52,10 +52,9 @@ public interface RuleProviderMetadata extends RulesetMetadata
     public List<String> getExecuteAfterIDs();
 
     /**
-     * Returns a list of {@link RuleProvider} classes that should execute after the {@link Rule}s in this
-     * {@link RuleProvider}.
+     * Returns a list of {@link RuleProvider} classes that should execute after the {@link Rule}s in this {@link RuleProvider}.
      *
-     * {@link RuleProvider}s can also be specified based on id ({@link #getExecuteBeforeID}).
+     * {@link RuleProvider}s can also be specified based on id ({@link #getExecuteBeforeIDs}).
      */
     public List<Class<? extends RuleProvider>> getExecuteBefore();
 

--- a/config/api/src/main/java/org/jboss/windup/config/metadata/RuleProviderRegistryCache.java
+++ b/config/api/src/main/java/org/jboss/windup/config/metadata/RuleProviderRegistryCache.java
@@ -1,0 +1,71 @@
+package org.jboss.windup.config.metadata;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+import org.jboss.windup.config.loader.RuleLoader;
+import org.jboss.windup.graph.GraphContext;
+import org.jboss.windup.graph.GraphContextFactory;
+
+/**
+ * This class provides convenience methods for retrieving a {@link RuleProviderRegistry}. The registry is cached for a period of time in order to
+ * improve performance. This is useful for cases in which you need to repeatedly query the registry for information, such as when looking up metadata
+ * in the user interface.
+ *
+ * @author <a href="mailto:jesse.sightler@gmail.com">jsightler</a>
+ */
+@Singleton
+public class RuleProviderRegistryCache
+{
+    private static Logger LOG = Logger.getLogger(RuleProviderRegistryCache.class.getSimpleName());
+    private static long MAX_CACHE_AGE = 1000L * 60L * 1L;
+
+    @Inject
+    private GraphContextFactory graphContextFactory;
+    @Inject
+    private RuleLoader ruleLoader;
+
+    private RuleProviderRegistry cachedRegistry;
+    private long cacheRefreshTime;
+
+    /**
+     * Returns the {@link RuleProviderRegistry}, loading it if necessary.
+     */
+    public RuleProviderRegistry getRuleProviderRegistry()
+    {
+        if (cacheValid())
+        {
+            return cachedRegistry;
+        }
+        else
+        {
+            this.cachedRegistry = null;
+            try
+            {
+                try (GraphContext graphContext = graphContextFactory.create())
+                {
+                    this.cachedRegistry = ruleLoader.loadConfiguration(graphContext, null);
+                    this.cacheRefreshTime = System.currentTimeMillis();
+                    graphContext.clear();
+                }
+            }
+            catch (Exception e)
+            {
+                LOG.log(Level.WARNING, "Failed to load rule information due to: " + e.getMessage(), e);
+            }
+            return cachedRegistry;
+        }
+    }
+
+    private boolean cacheValid()
+    {
+        if (cachedRegistry == null)
+            return false;
+
+        long cacheAge = System.currentTimeMillis() - this.cacheRefreshTime;
+        return cacheAge < MAX_CACHE_AGE;
+    }
+}

--- a/config/api/src/main/java/org/jboss/windup/config/operation/iteration/AbstractIterationOperation.java
+++ b/config/api/src/main/java/org/jboss/windup/config/operation/iteration/AbstractIterationOperation.java
@@ -52,7 +52,7 @@ public abstract class AbstractIterationOperation<T extends WindupVertexFrame> ex
     public void setVariableName(String variableName)
     {
         this.variableName = variableName;
-    };
+    }
 
     public boolean hasVariableNameSet()
     {

--- a/config/tests/src/test/java/org/jboss/windup/config/RuleLoaderTest.java
+++ b/config/tests/src/test/java/org/jboss/windup/config/RuleLoaderTest.java
@@ -29,7 +29,7 @@ import org.ocpsoft.rewrite.context.EvaluationContext;
 import org.ocpsoft.rewrite.event.Rewrite;
 
 @RunWith(Arquillian.class)
-public class WindupRuleLoaderTest
+public class RuleLoaderTest
 {
 
     @Deployment

--- a/exec/api/src/main/java/org/jboss/windup/exec/configuration/options/ExcludeTagsOption.java
+++ b/exec/api/src/main/java/org/jboss/windup/exec/configuration/options/ExcludeTagsOption.java
@@ -1,0 +1,79 @@
+package org.jboss.windup.exec.configuration.options;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+
+import javax.inject.Inject;
+
+import org.jboss.windup.config.AbstractConfigurationOption;
+import org.jboss.windup.config.InputType;
+import org.jboss.windup.config.RuleProvider;
+import org.jboss.windup.config.ValidationResult;
+import org.jboss.windup.config.metadata.RuleProviderRegistryCache;
+
+/**
+ * Specifies the tags to be excluded during Windup execution. The default behavior is not to exclude any tags.
+ *
+ * @author <a href="mailto:jesse.sightler@gmail.com">jsightler</a>
+ */
+public class ExcludeTagsOption extends AbstractConfigurationOption
+{
+    public static final String NAME = "excludeTags";
+
+    @Inject
+    private RuleProviderRegistryCache cache;
+
+    @Override
+    public Collection<?> getAvailableValues()
+    {
+        Set<String> tags = new HashSet<>();
+        for (RuleProvider provider : cache.getRuleProviderRegistry().getProviders())
+        {
+            tags.addAll(provider.getMetadata().getTags());
+        }
+        return tags;
+    }
+
+    @Override
+    public String getName()
+    {
+        return NAME;
+    }
+
+    @Override
+    public String getLabel()
+    {
+        return "Indicates the tags to explicitly exclude from processing (by default all tags are processed)";
+    }
+
+    @Override
+    public String getDescription()
+    {
+        return "Indicates the tags to exclude from processing. If this is unset, then all tags will be processed. If this is set, then Rules with the specified tags will be skipped.";
+    }
+
+    @Override
+    public InputType getUIType()
+    {
+        return InputType.SELECT_MANY;
+    }
+
+    @Override
+    public Class<String> getType()
+    {
+        return String.class;
+    }
+
+    public boolean isRequired()
+    {
+        return false;
+    }
+
+    @Override
+    public ValidationResult validate(Object value)
+    {
+        return ValidationResult.SUCCESS;
+    }
+
+}

--- a/exec/api/src/main/java/org/jboss/windup/exec/configuration/options/IncludeTagsOption.java
+++ b/exec/api/src/main/java/org/jboss/windup/exec/configuration/options/IncludeTagsOption.java
@@ -1,0 +1,79 @@
+package org.jboss.windup.exec.configuration.options;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+
+import javax.inject.Inject;
+
+import org.jboss.windup.config.AbstractConfigurationOption;
+import org.jboss.windup.config.InputType;
+import org.jboss.windup.config.RuleProvider;
+import org.jboss.windup.config.ValidationResult;
+import org.jboss.windup.config.metadata.RuleProviderRegistryCache;
+
+/**
+ * Specifies the tags to be included during Windup execution. The default behavior is to include all tags.
+ * 
+ * @author <a href="mailto:jesse.sightler@gmail.com">jsightler</a>
+ */
+public class IncludeTagsOption extends AbstractConfigurationOption
+{
+    public static final String NAME = "includeTags";
+
+    @Inject
+    private RuleProviderRegistryCache cache;
+
+    @Override
+    public Collection<?> getAvailableValues()
+    {
+        Set<String> tags = new HashSet<>();
+        for (RuleProvider provider : cache.getRuleProviderRegistry().getProviders())
+        {
+            tags.addAll(provider.getMetadata().getTags());
+        }
+        return tags;
+    }
+
+    @Override
+    public String getName()
+    {
+        return NAME;
+    }
+
+    @Override
+    public String getLabel()
+    {
+        return "Indicates the tags to process (by default all tags are processed)";
+    }
+
+    @Override
+    public String getDescription()
+    {
+        return "Indicates the tags to process. If this is unset, then all tags will be processed. If this is set, then only Rules with the specified tags will be processed.";
+    }
+
+    @Override
+    public InputType getUIType()
+    {
+        return InputType.SELECT_MANY;
+    }
+
+    @Override
+    public Class<String> getType()
+    {
+        return String.class;
+    }
+
+    public boolean isRequired()
+    {
+        return false;
+    }
+
+    @Override
+    public ValidationResult validate(Object value)
+    {
+        return ValidationResult.SUCCESS;
+    }
+
+}

--- a/exec/api/src/main/java/org/jboss/windup/exec/configuration/options/OfflineModeOption.java
+++ b/exec/api/src/main/java/org/jboss/windup/exec/configuration/options/OfflineModeOption.java
@@ -1,13 +1,13 @@
 package org.jboss.windup.exec.configuration.options;
 
-import org.jboss.windup.config.AbstractWindupConfigurationOption;
+import org.jboss.windup.config.AbstractConfigurationOption;
 import org.jboss.windup.config.InputType;
 import org.jboss.windup.config.ValidationResult;
 
 /**
  * Indicates that all operations should function in "Offline" mode (without accessing the internet).
  */
-public class OfflineModeOption extends AbstractWindupConfigurationOption
+public class OfflineModeOption extends AbstractConfigurationOption
 {
     public static final String NAME = "offline";
 

--- a/exec/api/src/main/java/org/jboss/windup/exec/configuration/options/OverwriteOption.java
+++ b/exec/api/src/main/java/org/jboss/windup/exec/configuration/options/OverwriteOption.java
@@ -1,6 +1,6 @@
 package org.jboss.windup.exec.configuration.options;
 
-import org.jboss.windup.config.AbstractWindupConfigurationOption;
+import org.jboss.windup.config.AbstractConfigurationOption;
 import org.jboss.windup.config.InputType;
 import org.jboss.windup.config.ValidationResult;
 
@@ -10,7 +10,7 @@ import org.jboss.windup.config.ValidationResult;
  * @author jsightler
  *
  */
-public class OverwriteOption extends AbstractWindupConfigurationOption
+public class OverwriteOption extends AbstractConfigurationOption
 {
     public static final String NAME = "overwrite";
 

--- a/exec/api/src/main/java/org/jboss/windup/exec/configuration/options/SourceOption.java
+++ b/exec/api/src/main/java/org/jboss/windup/exec/configuration/options/SourceOption.java
@@ -1,0 +1,86 @@
+package org.jboss.windup.exec.configuration.options;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+
+import javax.inject.Inject;
+
+import org.jboss.windup.config.AbstractConfigurationOption;
+import org.jboss.windup.config.InputType;
+import org.jboss.windup.config.RuleProvider;
+import org.jboss.windup.config.ValidationResult;
+import org.jboss.windup.config.metadata.RuleProviderRegistryCache;
+import org.jboss.windup.config.metadata.TechnologyReference;
+
+/**
+ * Specifies the source framework or server to migrate from. This could include multiple items.
+ * 
+ * For example, this might be a migration from Weblogic, EJB2, and JSF 1.x to JBoss EAP 6, EJB 3, and JSF 2. Source in that case would include
+ * Weblogic, EJB2, and JSF 1.x.
+ * 
+ * @author <a href="mailto:jesse.sightler@gmail.com">jsightler</a>
+ *
+ */
+public class SourceOption extends AbstractConfigurationOption
+{
+    public static final String NAME = "source";
+
+    @Inject
+    private RuleProviderRegistryCache cache;
+
+    @Override
+    public Collection<?> getAvailableValues()
+    {
+        Set<String> sourceOptions = new HashSet<>();
+        for (RuleProvider provider : cache.getRuleProviderRegistry().getProviders())
+        {
+            for (TechnologyReference technologyReference : provider.getMetadata().getSourceTechnologies())
+            {
+                sourceOptions.add(technologyReference.getId());
+            }
+        }
+        return sourceOptions;
+    }
+
+    @Override
+    public String getName()
+    {
+        return NAME;
+    }
+
+    @Override
+    public String getLabel()
+    {
+        return "Source server or framework";
+    }
+
+    @Override
+    public String getDescription()
+    {
+        return "The source server or framework to migrate from. This could include multiple items (eg, \"WebLogic\" and \"EJB 2\")";
+    }
+
+    @Override
+    public InputType getUIType()
+    {
+        return InputType.SELECT_MANY;
+    }
+
+    @Override
+    public Class<String> getType()
+    {
+        return String.class;
+    }
+
+    public boolean isRequired()
+    {
+        return false;
+    }
+
+    @Override
+    public ValidationResult validate(Object value)
+    {
+        return ValidationResult.SUCCESS;
+    }
+}

--- a/exec/api/src/main/java/org/jboss/windup/exec/configuration/options/TargetOption.java
+++ b/exec/api/src/main/java/org/jboss/windup/exec/configuration/options/TargetOption.java
@@ -1,0 +1,87 @@
+package org.jboss.windup.exec.configuration.options;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+
+import javax.inject.Inject;
+
+import org.jboss.windup.config.AbstractConfigurationOption;
+import org.jboss.windup.config.InputType;
+import org.jboss.windup.config.RuleProvider;
+import org.jboss.windup.config.ValidationResult;
+import org.jboss.windup.config.metadata.RuleProviderRegistryCache;
+import org.jboss.windup.config.metadata.TechnologyReference;
+
+/**
+ * Specifies the target framework or server to migrate to. This could include multiple items.
+ * 
+ * For example, this might be a migration from Weblogic, EJB2, and JSF 1.x to JBoss EAP 6, EJB 3, and JSF 2. Target in that case would include JBoss
+ * EAP 6, EJB 3, and JSF 2.
+ * 
+ * @author <a href="mailto:jesse.sightler@gmail.com">jsightler</a>
+ *
+ */
+public class TargetOption extends AbstractConfigurationOption
+{
+    public static final String NAME = "target";
+
+    @Inject
+    private RuleProviderRegistryCache cache;
+
+    @Override
+    public Collection<?> getAvailableValues()
+    {
+        Set<String> targetOptions = new HashSet<>();
+        for (RuleProvider provider : cache.getRuleProviderRegistry().getProviders())
+        {
+            for (TechnologyReference technologyReference : provider.getMetadata().getTargetTechnologies())
+            {
+                targetOptions.add(technologyReference.getId());
+            }
+        }
+        return targetOptions;
+    }
+
+    @Override
+    public String getName()
+    {
+        return NAME;
+    }
+
+    @Override
+    public String getLabel()
+    {
+        return "Target server or framework";
+    }
+
+    @Override
+    public String getDescription()
+    {
+        return "The target server or framework to migrate to. This could include multiple items (eg, \"JBoss EAP 6\" and \"EJB 3\")";
+    }
+
+    @Override
+    public InputType getUIType()
+    {
+        return InputType.SELECT_MANY;
+    }
+
+    @Override
+    public Class<String> getType()
+    {
+        return String.class;
+    }
+
+    public boolean isRequired()
+    {
+        return false;
+    }
+
+    @Override
+    public ValidationResult validate(Object value)
+    {
+        return ValidationResult.SUCCESS;
+    }
+
+}

--- a/exec/impl/src/main/java/org/jboss/windup/exec/WindupProcessorImpl.java
+++ b/exec/impl/src/main/java/org/jboss/windup/exec/WindupProcessorImpl.java
@@ -40,7 +40,7 @@ public class WindupProcessorImpl implements WindupProcessor
     private static Logger LOG = Logging.get(WindupProcessorImpl.class);
 
     @Inject
-    private RuleLoader windupConfigurationLoader;
+    private RuleLoader ruleLoader;
 
     @Inject
     private Imported<RuleLifecycleListener> listeners;
@@ -85,7 +85,7 @@ public class WindupProcessorImpl implements WindupProcessor
 
         final GraphRewrite event = new GraphRewrite(context);
 
-        RuleProviderRegistry providerRegistry = windupConfigurationLoader.loadConfiguration(context,
+        RuleProviderRegistry providerRegistry = ruleLoader.loadConfiguration(context,
                     windupConfiguration.getRuleProviderFilter());
         event.getRewriteContext().put(RuleProviderRegistry.class, providerRegistry);
 

--- a/exec/tests/src/test/java/org/jboss/windup/exec/configuration/MetadataOptionsTest.java
+++ b/exec/tests/src/test/java/org/jboss/windup/exec/configuration/MetadataOptionsTest.java
@@ -1,0 +1,119 @@
+package org.jboss.windup.exec.configuration;
+
+import java.util.Collection;
+
+import javax.inject.Inject;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.forge.arquillian.AddonDependency;
+import org.jboss.forge.arquillian.Dependencies;
+import org.jboss.forge.arquillian.archive.ForgeArchive;
+import org.jboss.forge.furnace.Furnace;
+import org.jboss.forge.furnace.repositories.AddonDependencyEntry;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.windup.config.AbstractRuleProvider;
+import org.jboss.windup.config.metadata.RuleMetadata;
+import org.jboss.windup.config.metadata.Technology;
+import org.jboss.windup.exec.configuration.options.ExcludeTagsOption;
+import org.jboss.windup.exec.configuration.options.IncludeTagsOption;
+import org.jboss.windup.exec.configuration.options.SourceOption;
+import org.jboss.windup.exec.configuration.options.TargetOption;
+import org.jboss.windup.graph.GraphContext;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.ocpsoft.rewrite.config.Configuration;
+import org.ocpsoft.rewrite.config.ConfigurationBuilder;
+
+/**
+ * @author <a href="mailto:jesse.sightler@gmail.com">jsightler</a>
+ */
+@RunWith(Arquillian.class)
+public class MetadataOptionsTest
+{
+    @Deployment
+    @Dependencies({
+                @AddonDependency(name = "org.jboss.windup.exec:windup-exec"),
+                @AddonDependency(name = "org.jboss.windup.graph:windup-graph"),
+    })
+    public static ForgeArchive getDeployment()
+    {
+        ForgeArchive archive = ShrinkWrap
+                    .create(ForgeArchive.class)
+                    .addBeansXML()
+                    .addAsAddonDependencies(
+                                AddonDependencyEntry.create("org.jboss.windup.exec:windup-exec"),
+                                AddonDependencyEntry.create("org.jboss.windup.graph:windup-graph"),
+                                AddonDependencyEntry.create("org.jboss.forge.furnace.container:cdi")
+                    );
+
+        return archive;
+    }
+
+    @Inject
+    private Furnace furnace;
+    @Inject
+    private SourceOption sourceOption;
+    @Inject
+    private TargetOption targetOption;
+    @Inject
+    private IncludeTagsOption includeTagsOption;
+    @Inject
+    private ExcludeTagsOption excludeTagsOption;
+
+    @Test
+    public void testSourceOption() throws Exception
+    {
+        Collection<?> availableValues = sourceOption.getAvailableValues();
+
+        Assert.assertTrue(availableValues.contains("sourceTech1"));
+        Assert.assertTrue(availableValues.contains("sourceTech2"));
+    }
+
+    @Test
+    public void testTargetOption() throws Exception
+    {
+        Collection<?> availableValues = targetOption.getAvailableValues();
+
+        Assert.assertTrue(availableValues.contains("targetTech1"));
+        Assert.assertTrue(availableValues.contains("targetTech1"));
+    }
+
+    @Test
+    public void testIncludeTags() throws Exception {
+        Collection<?> availableValues = includeTagsOption.getAvailableValues();
+
+        Assert.assertTrue(availableValues.contains("tag1"));
+        Assert.assertTrue(availableValues.contains("tag2"));
+        Assert.assertTrue(availableValues.contains("tag3"));
+    }
+
+    @Test
+    public void testExcludeTags() throws Exception {
+        Collection<?> availableValues = excludeTagsOption.getAvailableValues();
+
+        Assert.assertTrue(availableValues.contains("tag1"));
+        Assert.assertTrue(availableValues.contains("tag2"));
+        Assert.assertTrue(availableValues.contains("tag3"));
+    }
+
+    @RuleMetadata(
+                sourceTechnologies = {
+                            @Technology(id = "sourceTech1", versionRange = "[0, ]"),
+                            @Technology(id = "sourceTech2", versionRange = "[0, ]")
+                },
+                targetTechnologies = {
+                            @Technology(id = "targetTech1", versionRange = "[0, ]"),
+                            @Technology(id = "targetTech2", versionRange = "[0, ]")
+                },
+                tags = { "tag1", "tag2", "tag3" })
+    public static class MetadataRuleProvider extends AbstractRuleProvider
+    {
+        @Override
+        public Configuration getConfiguration(GraphContext context)
+        {
+            return ConfigurationBuilder.begin();
+        }
+    }
+}

--- a/frames/.gitignore
+++ b/frames/.gitignore
@@ -1,1 +1,2 @@
 /target/
+/target/

--- a/frames/src/test/java/com/tinkerpop/frames/domain/classes/Person.java
+++ b/frames/src/test/java/com/tinkerpop/frames/domain/classes/Person.java
@@ -19,7 +19,10 @@ import com.tinkerpop.frames.modules.javahandler.JavaHandlerContext;
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
 public interface Person extends NamedObject {
-    enum Gender {FEMALE, MALE};
+    enum Gender
+    {
+        FEMALE, MALE
+    }
 
     @Property("age")
     public Integer getAge();

--- a/frames/src/test/java/com/tinkerpop/frames/modules/typedgraph/TypeRegistryTest.java
+++ b/frames/src/test/java/com/tinkerpop/frames/modules/typedgraph/TypeRegistryTest.java
@@ -5,10 +5,6 @@ import static org.junit.Assert.assertNull;
 
 import org.junit.Test;
 
-import com.tinkerpop.frames.modules.typedgraph.TypeField;
-import com.tinkerpop.frames.modules.typedgraph.TypeRegistry;
-import com.tinkerpop.frames.modules.typedgraph.TypeValue;
-
 public class TypeRegistryTest {
 	@Test(expected = IllegalArgumentException.class) public void noAnotations() {
 		//You can't register interfaces when there is no @TypeField on it or on any of the parents:
@@ -77,19 +73,48 @@ public class TypeRegistryTest {
 		assertNull(reg.getType(X.class, "A"));
 	}
 	
-	public static interface Empty {};
-	public static @TypeField("type") interface Abstract extends Empty {};
-	public static @TypeField("type") interface Abstract2 {};
-	public static interface SubAbstract extends Abstract {};
-	
-	
-    public static @TypeValue("multipleTypeField") @TypeField("type") interface MultipleTypeField extends Abstract{};
-    public static @TypeValue("multipleTypeFieldChildren") interface MultipleTypeFieldInParents extends Abstract, Abstract2{};
+    public static interface Empty
+    {
+    }
 
-	public static @TypeValue("A") interface A extends Abstract {};
-	public static @TypeValue("B") interface B extends Abstract {};
-	public static @TypeValue("C") interface C extends A, B {}; // diamond shape inheritance diagram (multiple paths from C to Abstract)
+    public static @TypeField("type") interface Abstract extends Empty
+    {
+    }
+
+    public static @TypeField("type") interface Abstract2
+    {
+    }
+
+    public static interface SubAbstract extends Abstract
+    {
+    }
 	
-	public static @TypeValue("X") @TypeField("what") interface X {};
-	public static @TypeValue("Y") interface Y extends X {};
+	
+    public static @TypeValue("multipleTypeField") @TypeField("type") interface MultipleTypeField extends Abstract
+    {
+    }
+
+    public static @TypeValue("multipleTypeFieldChildren") interface MultipleTypeFieldInParents extends Abstract, Abstract2
+    {
+    }
+
+    public static @TypeValue("A") interface A extends Abstract
+    {
+    }
+
+    public static @TypeValue("B") interface B extends Abstract
+    {
+    }
+
+    public static @TypeValue("C") interface C extends A, B
+    {
+    } // diamond shape inheritance diagram (multiple paths from C to Abstract)
+	
+    public static @TypeValue("X") @TypeField("what") interface X
+    {
+    }
+
+    public static @TypeValue("Y") interface Y extends X
+    {
+    }
 }

--- a/frames/src/test/java/com/tinkerpop/frames/modules/typedgraph/TypedGraphModuleTest.java
+++ b/frames/src/test/java/com/tinkerpop/frames/modules/typedgraph/TypedGraphModuleTest.java
@@ -1,6 +1,5 @@
 package com.tinkerpop.frames.modules.typedgraph;
 
-import com.tinkerpop.frames.*;
 import junit.framework.TestCase;
 
 import com.tinkerpop.blueprints.Direction;
@@ -8,9 +7,12 @@ import com.tinkerpop.blueprints.Edge;
 import com.tinkerpop.blueprints.Graph;
 import com.tinkerpop.blueprints.Vertex;
 import com.tinkerpop.blueprints.impls.tg.TinkerGraph;
-import com.tinkerpop.frames.modules.typedgraph.TypeField;
-import com.tinkerpop.frames.modules.typedgraph.TypeValue;
-import com.tinkerpop.frames.modules.typedgraph.TypedGraphModuleBuilder;
+import com.tinkerpop.frames.EdgeFrame;
+import com.tinkerpop.frames.FramedGraph;
+import com.tinkerpop.frames.FramedGraphFactory;
+import com.tinkerpop.frames.InVertex;
+import com.tinkerpop.frames.Property;
+import com.tinkerpop.frames.VertexFrame;
 
 
 public class TypedGraphModuleTest extends TestCase {
@@ -18,15 +20,15 @@ public class TypedGraphModuleTest extends TestCase {
 	interface Base {
 		@Property("label")
 		String getLabel();
-	};
+    }
 
 	public static @TypeValue("A")
 	interface A extends Base {
-	};
+    }
 
 	public static @TypeValue("B")
 	interface B extends Base {
-	};
+    }
 
 	public static @TypeValue("C")
 	interface C extends B {
@@ -35,7 +37,7 @@ public class TypedGraphModuleTest extends TestCase {
 
         @InVertex
         <T extends Base> T getInVertex();
-	};
+    }
 
 	public void testSerializeVertexType() {
 		Graph graph = new TinkerGraph();

--- a/graph/api/src/main/java/org/jboss/windup/graph/GraphTypeRegistry.java
+++ b/graph/api/src/main/java/org/jboss/windup/graph/GraphTypeRegistry.java
@@ -15,7 +15,7 @@ import javax.inject.Singleton;
 import org.jboss.forge.furnace.util.OperatingSystemUtils;
 import org.jboss.forge.furnace.util.Predicate;
 import org.jboss.windup.graph.model.WindupVertexFrame;
-import org.jboss.windup.util.WindupPathUtil;
+import org.jboss.windup.util.PathUtil;
 import org.jboss.windup.util.furnace.FurnaceClasspathScanner;
 
 import com.tinkerpop.blueprints.Element;
@@ -82,7 +82,7 @@ public class GraphTypeRegistry
                 if (!path.endsWith("Model.class"))
                     return false;
 
-                final String clsName = WindupPathUtil.classFilePathToClassname(path);
+                final String clsName = PathUtil.classFilePathToClassname(path);
                 for (String pkg : this.skipPackages)
                     if (clsName.startsWith(pkg))
                         return false;

--- a/graph/impl/src/main/java/org/jboss/windup/graph/GraphContextImpl.java
+++ b/graph/impl/src/main/java/org/jboss/windup/graph/GraphContextImpl.java
@@ -89,7 +89,6 @@ public class GraphContextImpl implements GraphContext
             confProps.put(key, conf.getProperty(key));
         }
 
-        System.out.println("Properties: " + confProps);
         if (!afterInitializationListeners.isUnsatisfied())
         {
             for (AfterGraphInitializationListener listener : afterInitializationListeners)

--- a/graph/impl/src/main/java/org/jboss/windup/graph/GraphContextImpl.java
+++ b/graph/impl/src/main/java/org/jboss/windup/graph/GraphContextImpl.java
@@ -77,7 +77,7 @@ public class GraphContextImpl implements GraphContext
         fireListeners();
         return this;
     }
-    
+
     private void fireListeners() {
         Imported<AfterGraphInitializationListener> afterInitializationListeners = furnace.getAddonRegistry().getServices(
                     AfterGraphInitializationListener.class);
@@ -98,7 +98,7 @@ public class GraphContextImpl implements GraphContext
             }
         }
     }
-    
+
     private void createFramed(TitanGraph titanGraph) {
         this.eventGraph = new EventGraph<TitanGraph>(titanGraph);
         this.batchGraph = new BatchGraph<TitanGraph>(titanGraph, 1000L);
@@ -188,6 +188,10 @@ public class GraphContextImpl implements GraphContext
         // the performance decrease seems to be minimal.
         conf.setProperty("storage.berkeleydb.cache-percentage", 1);
 
+        // Increase storage write buffer since we basically do a large bulk load during the first phases.
+        // See http://s3.thinkaurelius.com/docs/titan/current/bulk-loading.html
+        conf.setProperty("storage.buffer-size", "4096");
+
         //
         // turn on a db-cache that persists across txn boundaries, but make it relatively small
         conf.setProperty("cache.db-cache", true);
@@ -216,7 +220,7 @@ public class GraphContextImpl implements GraphContext
     @Override
     public void close()
     {
-        //TODO: This is probably not the same instance as the one gained using AfterGraphInitializationListener interface 
+        //TODO: This is probably not the same instance as the one gained using AfterGraphInitializationListener interface
         Imported<BeforeGraphCloseListener> beforeCloseListeners = furnace.getAddonRegistry().getServices(
                     BeforeGraphCloseListener.class);
         for(BeforeGraphCloseListener listener : beforeCloseListeners) {

--- a/graph/impl/src/main/java/org/jboss/windup/graph/GraphContextImpl.java
+++ b/graph/impl/src/main/java/org/jboss/windup/graph/GraphContextImpl.java
@@ -142,24 +142,39 @@ public class GraphContextImpl implements GraphContext
 
     private void initializeTitanManagement(TitanGraph titanGraph)
     {
-        // TODO: This has to load dynamically.
+        // TODO: This has to load dynamically. WINDUP-198
         // E.g. get all Model classes and look for @Indexed - org.jboss.windup.graph.api.model.anno.
-        String[] keys = new String[] { "namespaceURI", "schemaLocation", "publicId", "rootTagName",
-                    "systemId", "qualifiedName", "filePath", "mavenIdentifier", "packageName", "classification" };
+        // We need to hard-code the property names here since we can't depend on rulesets' addons.
+        String[] keys = new String[] {
+            // rules/apps/xml/model/NamespaceMetaModel
+            "namespaceURI",
+            "schemaLocation",
+            // rules/apps/xml/model/XmlFileModel
+            "rootTagName",
+            // rules/apps/java/model/JavaClassModel
+            "qualifiedName",
+            // graph/model/resource/FileModel
+            "filePath",
+            // rules/apps/java/model/project/MavenProjectModel
+            "mavenIdentifier",
+            // JavaClassModel, JavaClassFileModel, JavaSourceFileModel, PackageModel - possible collision!
+            "packageName",
+
+            "DoctypeMeta:publicId", "DoctypeMeta:systemId",
+            "ClassificationModel:classification"
+        };
 
         TitanManagement mgmt = titanGraph.getManagementSystem();
 
         for (String key : keys)
         {
-            PropertyKey propKey = mgmt.makePropertyKey(key).dataType(String.class).cardinality(Cardinality.SINGLE)
-                        .make();
+            PropertyKey propKey = mgmt.makePropertyKey(key).dataType(String.class).cardinality(Cardinality.SINGLE).make();
             mgmt.buildIndex(key, Vertex.class).addKey(propKey).buildCompositeIndex();
         }
 
         for (String key : new String[] { "referenceSourceSnippit" })
         {
-            PropertyKey propKey = mgmt.makePropertyKey(key).dataType(String.class).cardinality(Cardinality.SINGLE)
-                        .make();
+            PropertyKey propKey = mgmt.makePropertyKey(key).dataType(String.class).cardinality(Cardinality.SINGLE).make();
             mgmt.buildIndex(key, Vertex.class).addKey(propKey).buildMixedIndex("search");
         }
 
@@ -196,7 +211,7 @@ public class GraphContextImpl implements GraphContext
         // turn on a db-cache that persists across txn boundaries, but make it relatively small
         conf.setProperty("cache.db-cache", true);
         conf.setProperty("cache.db-cache-clean-wait", 0);
-        conf.setProperty("cache.db-cache-size", .05);
+        conf.setProperty("cache.db-cache-size", .09);
         conf.setProperty("cache.db-cache-time", 0);
 
         conf.setProperty("index.search.backend", "lucene");

--- a/graph/tests/src/test/java/org/jboss/windup/graph/typedgraph/InMemoryFrameTest.java
+++ b/graph/tests/src/test/java/org/jboss/windup/graph/typedgraph/InMemoryFrameTest.java
@@ -73,7 +73,7 @@ public class InMemoryFrameTest
                 numberFound++;
                 TestFooModel framed = (TestFooModel) context.getFramed().frame(v, WindupVertexFrame.class);
 
-                Assert.assertTrue(framed instanceof TestFooModel);
+                Assert.assertNotNull(framed);
                 Assert.assertEquals("prop1", framed.getProp1());
                 Assert.assertEquals("prop2", framed.getProp2());
                 Assert.assertEquals("prop3", framed.getProp3());

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jboss</groupId>
         <artifactId>jboss-parent</artifactId>
-        <version>16</version>
+        <version>17</version>
     </parent>
 
     <groupId>org.jboss.windup</groupId>

--- a/reporting/api/src/main/java/org/jboss/windup/reporting/model/Severity.java
+++ b/reporting/api/src/main/java/org/jboss/windup/reporting/model/Severity.java
@@ -21,5 +21,5 @@ public enum Severity
     /**
      * Indicates that this problem is critically important and must be fixed in order to effectively complete the migration.
      */
-    CRITICAL;
+    CRITICAL
 }

--- a/reporting/api/src/main/java/org/jboss/windup/reporting/service/ReportService.java
+++ b/reporting/api/src/main/java/org/jboss/windup/reporting/service/ReportService.java
@@ -12,7 +12,7 @@ import org.jboss.windup.graph.model.WindupConfigurationModel;
 import org.jboss.windup.graph.service.GraphService;
 import org.jboss.windup.graph.service.WindupConfigurationService;
 import org.jboss.windup.reporting.model.ReportModel;
-import org.jboss.windup.util.WindupPathUtil;
+import org.jboss.windup.util.PathUtil;
 import org.jboss.windup.util.exception.WindupException;
 
 /**
@@ -62,12 +62,12 @@ public class ReportService extends GraphService<ReportModel>
      */
     public void setUniqueFilename(ReportModel model, String baseFilename, String extension)
     {
-        String filename = WindupPathUtil.cleanFileName(baseFilename) + "." + extension;
+        String filename = PathUtil.cleanFileName(baseFilename) + "." + extension;
 
         // FIXME this looks nasty
         while (usedFilenames.contains(filename.toString()))
         {
-            filename = WindupPathUtil.cleanFileName(baseFilename) + "." + index.getAndIncrement() + "." + extension;
+            filename = PathUtil.cleanFileName(baseFilename) + "." + index.getAndIncrement() + "." + extension;
         }
         usedFilenames.add(filename);
 

--- a/rules-base/tests/src/test/resources/xml/FileContentXmlExample.windup.xml
+++ b/rules-base/tests/src/test/resources/xml/FileContentXmlExample.windup.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0"?>
-<ruleset xmlns="http://windup.jboss.org/v1/xml" id="xmltestrules_1">
+<ruleset xmlns="http://windup.jboss.org/v1/xml" id="xmltestrules_1" phase="PostMigrationRulesPhase">
   <rules>
-    <phase>PostMigrationRulesPhase</phase>
     <rule>
       <when>
         <filecontent pattern="for the {xml} rule" filename="{filename}.txt"/>

--- a/rules-java-archives/addon/src/main/java/org/jboss/windup/rules/apps/java/archives/config/ArchiveIdentificationConfigLoadingRuleProvider.java
+++ b/rules-java-archives/addon/src/main/java/org/jboss/windup/rules/apps/java/archives/config/ArchiveIdentificationConfigLoadingRuleProvider.java
@@ -15,7 +15,7 @@ import org.jboss.windup.graph.GraphContext;
 import org.jboss.windup.rules.apps.java.archives.identify.CompositeChecksumIdentifier;
 import org.jboss.windup.rules.apps.java.archives.identify.SortedFileChecksumIdentifier;
 import org.jboss.windup.util.Logging;
-import org.jboss.windup.util.WindupPathUtil;
+import org.jboss.windup.util.PathUtil;
 import org.jboss.windup.util.exception.WindupException;
 import org.jboss.windup.util.file.FileSuffixPredicate;
 import org.jboss.windup.util.file.FileVisit;
@@ -68,8 +68,8 @@ public class ArchiveIdentificationConfigLoadingRuleProvider extends AbstractRule
                 };
 
                 FileSuffixPredicate predicate = new FileSuffixPredicate("\\.archive-metadata\\.txt");
-                FileVisit.visit(WindupPathUtil.getUserCacheDir().resolve("nexus-indexer-data").toFile(), predicate, visitor);
-                FileVisit.visit(WindupPathUtil.getWindupCacheDir().resolve("nexus-indexer-data").toFile(), predicate, visitor);
+                FileVisit.visit(PathUtil.getUserCacheDir().resolve("nexus-indexer-data").toFile(), predicate, visitor);
+                FileVisit.visit(PathUtil.getWindupCacheDir().resolve("nexus-indexer-data").toFile(), predicate, visitor);
             }
         });
         return config;

--- a/rules-java-archives/addon/src/main/java/org/jboss/windup/rules/apps/java/archives/config/IgnoredArchivesConfigLoadingRuleProvider.java
+++ b/rules-java-archives/addon/src/main/java/org/jboss/windup/rules/apps/java/archives/config/IgnoredArchivesConfigLoadingRuleProvider.java
@@ -12,7 +12,7 @@ import org.jboss.windup.config.phase.InitializationPhase;
 import org.jboss.windup.graph.GraphContext;
 import org.jboss.windup.rules.apps.java.archives.ignore.SkippedArchives;
 import org.jboss.windup.util.Logging;
-import org.jboss.windup.util.WindupPathUtil;
+import org.jboss.windup.util.PathUtil;
 import org.jboss.windup.util.exception.WindupException;
 import org.jboss.windup.util.file.FileSuffixPredicate;
 import org.jboss.windup.util.file.FileVisit;
@@ -62,8 +62,8 @@ public class IgnoredArchivesConfigLoadingRuleProvider extends AbstractRuleProvid
                 };
 
                 FileSuffixPredicate predicate = new FileSuffixPredicate("\\.archive-ignore\\.txt");
-                FileVisit.visit(WindupPathUtil.getUserIgnoreDir().toFile(), predicate, visitor);
-                FileVisit.visit(WindupPathUtil.getWindupIgnoreDir().toFile(), predicate, visitor);
+                FileVisit.visit(PathUtil.getUserIgnoreDir().toFile(), predicate, visitor);
+                FileVisit.visit(PathUtil.getWindupIgnoreDir().toFile(), predicate, visitor);
             }
         });
         return config;

--- a/rules-java-ee/addon/src/main/java/org/jboss/windup/rules/apps/javaee/rules/CreateSpringBeanReportRuleProvider.java
+++ b/rules-java-ee/addon/src/main/java/org/jboss/windup/rules/apps/javaee/rules/CreateSpringBeanReportRuleProvider.java
@@ -3,9 +3,11 @@ package org.jboss.windup.rules.apps.javaee.rules;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.jboss.forge.furnace.versions.EmptyVersionRange;
 import org.jboss.windup.config.AbstractRuleProvider;
 import org.jboss.windup.config.GraphRewrite;
 import org.jboss.windup.config.metadata.MetadataBuilder;
+import org.jboss.windup.config.metadata.TechnologyReference;
 import org.jboss.windup.config.operation.GraphOperation;
 import org.jboss.windup.config.phase.ReportGenerationPhase;
 import org.jboss.windup.config.query.Query;
@@ -39,7 +41,7 @@ public class CreateSpringBeanReportRuleProvider extends AbstractRuleProvider
     public CreateSpringBeanReportRuleProvider()
     {
         super(MetadataBuilder.forProvider(CreateSpringBeanReportRuleProvider.class, "Create Spring Bean Report")
-                    .setPhase(ReportGenerationPhase.class));
+                    .setPhase(ReportGenerationPhase.class).addSourceTechnology(new TechnologyReference("Spring", new EmptyVersionRange())));
     }
 
     @Override

--- a/rules-java-ee/addon/src/main/java/org/jboss/windup/rules/apps/javaee/rules/DiscoverEjbAnnotationsRuleProvider.java
+++ b/rules-java-ee/addon/src/main/java/org/jboss/windup/rules/apps/javaee/rules/DiscoverEjbAnnotationsRuleProvider.java
@@ -63,7 +63,7 @@ public class DiscoverEjbAnnotationsRuleProvider extends AbstractRuleProvider
                         public void perform(GraphRewrite event, EvaluationContext context, JavaTypeReferenceModel payload)
                         {
                             extractEJBMetadata(event, payload);
-                        };
+                        }
                     })
                     .where("annotationType").matches("Stateless|Stateful")
                     .withId(ruleIDPrefix + "_StatelessAndStatefulRule")

--- a/rules-java-ee/addon/src/main/java/org/jboss/windup/rules/apps/javaee/rules/DiscoverWebXmlRuleProvider.java
+++ b/rules-java-ee/addon/src/main/java/org/jboss/windup/rules/apps/javaee/rules/DiscoverWebXmlRuleProvider.java
@@ -74,11 +74,7 @@ public class DiscoverWebXmlRuleProvider extends IteratingRuleProvider<XmlFileMod
     private boolean isWebXml(XmlFileModel xml, Document doc)
     {
         // check it's doctype against the known doctype.
-        if (xml.getDoctype() != null && !processDoctypeMatches(xml.getDoctype()))
-        {
-            return false;
-        }
-        return true;
+        return !(xml.getDoctype() != null && !processDoctypeMatches(xml.getDoctype()));
     }
 
     private String getVersion(XmlFileModel xml, Document doc)

--- a/rules-java-project/addon/src/main/java/org/jboss/windup/project/condition/Version.java
+++ b/rules-java-project/addon/src/main/java/org/jboss/windup/project/condition/Version.java
@@ -2,74 +2,92 @@ package org.jboss.windup.project.condition;
 
 /**
  * Object used to specify the version range
+ * 
  * @author mbriskar
  *
  */
-public class Version{
+public class Version
+{
 
-	private String from;
-	private String to;
-	
-	public static Version fromVersion(String from) {
-		Version v = new Version();
-		v.setFrom(from);
-		return v;
-	}
-	
-	public static Version toVersion(String to) {
-		Version v = new Version();
-		v.setTo(to);
-		return v;
-	}
-	
-	public Version to(String to) {
-		this.setTo(to);
-		return this;
-	}
+    private String from;
+    private String to;
 
-	public String getFrom() {
-		return from;
-	}
+    public static Version fromVersion(String from)
+    {
+        Version v = new Version();
+        v.setFrom(from);
+        return v;
+    }
 
-	public void setFrom(String from) {
-		this.from = from;
-	}
+    public static Version toVersion(String to)
+    {
+        Version v = new Version();
+        v.setTo(to);
+        return v;
+    }
 
-	public String getTo() {
-		return to;
-	}
+    public Version to(String to)
+    {
+        this.setTo(to);
+        return this;
+    }
 
-	public void setTo(String to) {
-		this.to = to;
-	}
-	
-	public boolean validate(String versionString) {
-		boolean result = true;
-		if(from != null) {
-			result = result && firstVersionLesser(from,versionString);
-		}
-		if(to != null) {
-			result =result && firstVersionLesser(versionString,to);
-		}
-		return result;
-	}
-	
-	private boolean firstVersionLesser(String first, String second) {
-		boolean firstLesser = false;
-		for (int i=0;i<second.length();i++) {
-			if(Character.isDigit(second.charAt(i))) {
-				int numericValue = Character.getNumericValue(second.charAt(i));
-				if(!firstLesser && first != null && Character.isDigit(first.charAt(i))) {
-					 int firstInt = Character.getNumericValue(first.charAt(i));
-					 if(firstInt < numericValue) {
-						 firstLesser = true;
-					 }
-					 if(!firstLesser && (firstInt > numericValue)) {
-						 return false;
-					 }
-				}
-			}
-		}
-		return true;
-	}
+    public String getFrom()
+    {
+        return from;
+    }
+
+    public void setFrom(String from)
+    {
+        this.from = from;
+    }
+
+    public String getTo()
+    {
+        return to;
+    }
+
+    public void setTo(String to)
+    {
+        this.to = to;
+    }
+
+    public boolean validate(String versionString)
+    {
+        boolean result = true;
+        if (from != null)
+        {
+            result = result && firstVersionLesser(from, versionString);
+        }
+        if (to != null)
+        {
+            result = result && firstVersionLesser(versionString, to);
+        }
+        return result;
+    }
+
+    private boolean firstVersionLesser(String first, String second)
+    {
+        boolean firstLesser = false;
+        for (int i = 0; i < second.length(); i++)
+        {
+            if (Character.isDigit(second.charAt(i)))
+            {
+                int numericValue = Character.getNumericValue(second.charAt(i));
+                if (!firstLesser && first != null && Character.isDigit(first.charAt(i)))
+                {
+                    int firstInt = Character.getNumericValue(first.charAt(i));
+                    if (firstInt < numericValue)
+                    {
+                        firstLesser = true;
+                    }
+                    if (!firstLesser && (firstInt > numericValue))
+                    {
+                        return false;
+                    }
+                }
+            }
+        }
+        return true;
+    }
 }

--- a/rules-java/api/src/main/java/org/jboss/windup/rules/apps/java/config/ExcludePackagesOption.java
+++ b/rules-java/api/src/main/java/org/jboss/windup/rules/apps/java/config/ExcludePackagesOption.java
@@ -1,10 +1,10 @@
 package org.jboss.windup.rules.apps.java.config;
 
-import org.jboss.windup.config.AbstractWindupConfigurationOption;
+import org.jboss.windup.config.AbstractConfigurationOption;
 import org.jboss.windup.config.InputType;
 import org.jboss.windup.config.ValidationResult;
 
-public class ExcludePackagesOption extends AbstractWindupConfigurationOption
+public class ExcludePackagesOption extends AbstractConfigurationOption
 {
 
     public static final String NAME = "excludePackages";

--- a/rules-java/api/src/main/java/org/jboss/windup/rules/apps/java/config/ScanPackagesOption.java
+++ b/rules-java/api/src/main/java/org/jboss/windup/rules/apps/java/config/ScanPackagesOption.java
@@ -1,6 +1,6 @@
 package org.jboss.windup.rules.apps.java.config;
 
-import org.jboss.windup.config.AbstractWindupConfigurationOption;
+import org.jboss.windup.config.AbstractConfigurationOption;
 import org.jboss.windup.config.InputType;
 import org.jboss.windup.config.ValidationResult;
 
@@ -9,7 +9,7 @@ import org.jboss.windup.config.ValidationResult;
  * 
  * @author jsightler <jesse.sightler@gmail.com>
  */
-public class ScanPackagesOption extends AbstractWindupConfigurationOption
+public class ScanPackagesOption extends AbstractConfigurationOption
 {
     public static final String NAME = "packages";
 

--- a/rules-java/api/src/main/java/org/jboss/windup/rules/apps/java/config/SourceModeOption.java
+++ b/rules-java/api/src/main/java/org/jboss/windup/rules/apps/java/config/SourceModeOption.java
@@ -1,6 +1,6 @@
 package org.jboss.windup.rules.apps.java.config;
 
-import org.jboss.windup.config.AbstractWindupConfigurationOption;
+import org.jboss.windup.config.AbstractConfigurationOption;
 import org.jboss.windup.config.InputType;
 import org.jboss.windup.config.ValidationResult;
 
@@ -9,7 +9,7 @@ import org.jboss.windup.config.ValidationResult;
  * 
  * @author jsightler <jesse.sightler@gmail.com>
  */
-public class SourceModeOption extends AbstractWindupConfigurationOption
+public class SourceModeOption extends AbstractConfigurationOption
 {
     public static final String NAME = "sourceMode";
 

--- a/rules-java/api/src/main/java/org/jboss/windup/rules/apps/java/decompiler/ProcyonDecompilerOperation.java
+++ b/rules-java/api/src/main/java/org/jboss/windup/rules/apps/java/decompiler/ProcyonDecompilerOperation.java
@@ -34,7 +34,7 @@ import org.jboss.windup.rules.apps.java.model.JavaSourceFileModel;
 import org.jboss.windup.rules.apps.java.model.WarArchiveModel;
 import org.jboss.windup.util.ExecutionStatistics;
 import org.jboss.windup.util.Logging;
-import org.jboss.windup.util.WindupPathUtil;
+import org.jboss.windup.util.PathUtil;
 import org.jboss.windup.util.exception.WindupException;
 import org.ocpsoft.rewrite.context.EvaluationContext;
 
@@ -231,7 +231,7 @@ public class ProcyonDecompilerOperation extends AbstractIterationOperation<Archi
                             // Set the root path of this source file (if possible). Procyon should always be placing the file
                             // into a location that is appropriate for the package name, so this should always yield
                             // a non-null root path.
-                            Path rootSourcePath = WindupPathUtil.getRootFolderForSource(decompiledSourceFileModel.asFile().toPath(),
+                            Path rootSourcePath = PathUtil.getRootFolderForSource(decompiledSourceFileModel.asFile().toPath(),
                                         classModel.getPackageName());
                             if (rootSourcePath != null)
                             {

--- a/rules-java/api/src/main/java/org/jboss/windup/rules/apps/java/ip/DiscoverStaticIPAddressRuleProvider.java
+++ b/rules-java/api/src/main/java/org/jboss/windup/rules/apps/java/ip/DiscoverStaticIPAddressRuleProvider.java
@@ -51,7 +51,7 @@ public class DiscoverStaticIPAddressRuleProvider extends AbstractRuleProvider
                             location.setTitle("Static IP: " + location.getSourceSnippit());
                             location.setHint("When migrating environments, static IP addresses may need to be modified or eliminated.");
                             location.setEffort(0);
-                        };
+                        }
                     })
                     .where("ip").matches("\\b\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\b")
                     .where("type").matches("java|properties|xml");

--- a/rules-java/api/src/main/java/org/jboss/windup/rules/apps/java/scan/provider/IndexJavaSourceFilesRuleProvider.java
+++ b/rules-java/api/src/main/java/org/jboss/windup/rules/apps/java/scan/provider/IndexJavaSourceFilesRuleProvider.java
@@ -35,7 +35,7 @@ import org.jboss.windup.rules.apps.java.model.JavaSourceFileModel;
 import org.jboss.windup.rules.apps.java.scan.ast.WindupWildcardImportResolver;
 import org.jboss.windup.rules.apps.java.service.JavaClassService;
 import org.jboss.windup.util.Logging;
-import org.jboss.windup.util.WindupPathUtil;
+import org.jboss.windup.util.PathUtil;
 import org.jboss.windup.util.exception.WindupException;
 import org.ocpsoft.rewrite.config.Configuration;
 import org.ocpsoft.rewrite.config.ConfigurationBuilder;
@@ -173,7 +173,7 @@ public class IndexJavaSourceFilesRuleProvider extends AbstractRuleProvider
             // Set the root path of this source file (if possible). As this could be coming from user-provided source, it
             // is possible that the path will not match the package name. In this case, we will likely end up with a null
             // root path.
-            Path rootSourcePath = WindupPathUtil.getRootFolderForSource(sourceFileModel.asFile().toPath(), packageName);
+            Path rootSourcePath = PathUtil.getRootFolderForSource(sourceFileModel.asFile().toPath(), packageName);
             if (rootSourcePath != null)
             {
                 FileModel rootSourceFileModel = new FileService(context).createByFilePath(rootSourcePath.toString());

--- a/rules-java/impl/src/main/java/org/jboss/windup/rules/apps/java/config/CopyJavaConfigToGraphRuleProvider.java
+++ b/rules-java/impl/src/main/java/org/jboss/windup/rules/apps/java/config/CopyJavaConfigToGraphRuleProvider.java
@@ -18,7 +18,7 @@ import org.jboss.windup.config.phase.InitializationPhase;
 import org.jboss.windup.graph.GraphContext;
 import org.jboss.windup.rules.apps.java.model.WindupJavaConfigurationModel;
 import org.jboss.windup.rules.apps.java.service.WindupJavaConfigurationService;
-import org.jboss.windup.util.WindupPathUtil;
+import org.jboss.windup.util.PathUtil;
 import org.jboss.windup.util.exception.WindupException;
 import org.jboss.windup.util.file.FileSuffixPredicate;
 import org.jboss.windup.util.file.FileVisit;
@@ -28,8 +28,7 @@ import org.ocpsoft.rewrite.config.Rule;
 import org.ocpsoft.rewrite.context.EvaluationContext;
 
 /**
- * Copies configuration data from {@link GraphContext#getOptionMap()} to the graph itself for easy use by other
- * {@link Rule}s.
+ * Copies configuration data from {@link GraphContext#getOptionMap()} to the graph itself for easy use by other {@link Rule}s.
  *
  */
 public class CopyJavaConfigToGraphRuleProvider extends AbstractRuleProvider
@@ -86,8 +85,8 @@ public class CopyJavaConfigToGraphRuleProvider extends AbstractRuleProvider
                     }
                 };
 
-                FileVisit.visit(WindupPathUtil.getUserIgnoreDir().toFile(), predicate, visitor);
-                FileVisit.visit(WindupPathUtil.getWindupIgnoreDir().toFile(), predicate, visitor);
+                FileVisit.visit(PathUtil.getUserIgnoreDir().toFile(), predicate, visitor);
+                FileVisit.visit(PathUtil.getWindupIgnoreDir().toFile(), predicate, visitor);
 
                 WindupJavaConfigurationModel javaCfg = WindupJavaConfigurationService.getJavaConfigurationModel(event
                             .getGraphContext());

--- a/rules-java/impl/src/main/java/org/jboss/windup/rules/apps/java/config/GatherIgnoredFileNamesRuleProvider.java
+++ b/rules-java/impl/src/main/java/org/jboss/windup/rules/apps/java/config/GatherIgnoredFileNamesRuleProvider.java
@@ -100,7 +100,7 @@ public class GatherIgnoredFileNamesRuleProvider extends IteratingRuleProvider<Wi
         File file = filePath.toFile();
         if (file.exists())
         {
-            try (BufferedReader reader = new BufferedReader(new FileReader(file));)
+            try (BufferedReader reader = new BufferedReader(new FileReader(file)))
             {
                 String line = null;
                 while ((line = reader.readLine()) != null)

--- a/rules-xml/addon/src/main/java/org/jboss/windup/rules/apps/xml/model/DoctypeMetaModel.java
+++ b/rules-xml/addon/src/main/java/org/jboss/windup/rules/apps/xml/model/DoctypeMetaModel.java
@@ -7,14 +7,16 @@ import com.tinkerpop.frames.Adjacency;
 import com.tinkerpop.frames.Property;
 import com.tinkerpop.frames.modules.typedgraph.TypeValue;
 
-@TypeValue("DoctypeMeta")
+@TypeValue(DoctypeMetaModel.TYPE_ID)
 public interface DoctypeMetaModel extends WindupVertexFrame
 {
+    public static final String TYPE_ID = "DoctypeMeta";
+    public static final String TYPE_PREFIX = TYPE_ID + ":";
 
-    public static final String PROPERTY_BASE_URI = "baseURI";
-    public static final String PROPERTY_SYSTEM_ID = "systemId";
-    public static final String PROPERTY_PUBLIC_ID = "publicId";
-    public static final String PROPERTY_NAME = "name";
+    public static final String PROPERTY_BASE_URI  = TYPE_PREFIX + "baseURI";
+    public static final String PROPERTY_SYSTEM_ID = TYPE_PREFIX + "systemId";
+    public static final String PROPERTY_PUBLIC_ID = TYPE_PREFIX + "publicId";
+    public static final String PROPERTY_NAME      = TYPE_PREFIX + "name";
 
     @Adjacency(label = "doctype", direction = Direction.IN)
     public void addXmlResource(XmlFileModel facet);

--- a/rules-xml/addon/src/main/java/org/jboss/windup/rules/apps/xml/service/NamespaceService.java
+++ b/rules-xml/addon/src/main/java/org/jboss/windup/rules/apps/xml/service/NamespaceService.java
@@ -17,9 +17,9 @@ public class NamespaceService extends GraphService<NamespaceMetaModel>
                     .has("namespaceURI", namespaceURI).has("schemaLocation", schemaLocation)
                     .vertices(NamespaceMetaModel.class);
 
-        for (NamespaceMetaModel result : results)
+        if (results.iterator().hasNext())
         {
-            return result;
+            return results.iterator().next();
         }
 
         // otherwise, create it.

--- a/ui/addon/src/main/java/org/jboss/windup/ui/WindupCommand.java
+++ b/ui/addon/src/main/java/org/jboss/windup/ui/WindupCommand.java
@@ -34,8 +34,8 @@ import org.jboss.forge.addon.ui.result.Results;
 import org.jboss.forge.addon.ui.util.Categories;
 import org.jboss.forge.addon.ui.util.Metadata;
 import org.jboss.forge.addon.ui.validate.UIValidator;
-import org.jboss.windup.config.ValidationResult;
 import org.jboss.windup.config.ConfigurationOption;
+import org.jboss.windup.config.ValidationResult;
 import org.jboss.windup.exec.WindupProcessor;
 import org.jboss.windup.exec.WindupProgressMonitor;
 import org.jboss.windup.exec.configuration.WindupConfiguration;
@@ -44,7 +44,7 @@ import org.jboss.windup.exec.configuration.options.OutputPathOption;
 import org.jboss.windup.exec.configuration.options.OverwriteOption;
 import org.jboss.windup.graph.GraphContext;
 import org.jboss.windup.graph.GraphContextFactory;
-import org.jboss.windup.util.WindupPathUtil;
+import org.jboss.windup.util.PathUtil;
 
 /**
  * Provides a basic Forge UI implementation for running Windup from within a {@link UIProvider}.
@@ -169,7 +169,7 @@ public class WindupCommand implements UICommand
             windupConfiguration.setOptionValue(key, value);
         }
 
-        Path userRulesDir = WindupPathUtil.getUserRulesDir();
+        Path userRulesDir = PathUtil.getUserRulesDir();
         if (userRulesDir != null && !Files.isDirectory(userRulesDir))
         {
             Files.createDirectories(userRulesDir);
@@ -179,7 +179,7 @@ public class WindupCommand implements UICommand
             windupConfiguration.addDefaultUserRulesDirectory(userRulesDir);
         }
 
-        Path userIgnoreDir = WindupPathUtil.getUserIgnoreDir();
+        Path userIgnoreDir = PathUtil.getUserIgnoreDir();
         if (userIgnoreDir != null && !Files.isDirectory(userIgnoreDir))
         {
             Files.createDirectories(userIgnoreDir);
@@ -189,7 +189,7 @@ public class WindupCommand implements UICommand
             windupConfiguration.addDefaultUserIgnorePath(userIgnoreDir);
         }
 
-        Path windupHomeRulesDir = WindupPathUtil.getWindupRulesDir();
+        Path windupHomeRulesDir = PathUtil.getWindupRulesDir();
         if (windupHomeRulesDir != null && !Files.isDirectory(windupHomeRulesDir))
         {
             Files.createDirectories(windupHomeRulesDir);
@@ -199,7 +199,7 @@ public class WindupCommand implements UICommand
             windupConfiguration.addDefaultUserRulesDirectory(windupHomeRulesDir);
         }
 
-        Path windupHomeIgnoreDir = WindupPathUtil.getWindupIgnoreDir();
+        Path windupHomeIgnoreDir = PathUtil.getWindupIgnoreDir();
         if (windupHomeIgnoreDir != null && !Files.isDirectory(windupHomeIgnoreDir))
         {
             Files.createDirectories(windupHomeIgnoreDir);
@@ -286,6 +286,7 @@ public class WindupCommand implements UICommand
             case SELECT_MANY:
             {
                 UISelectMany<?> selectMany = componentFactory.createSelectMany(option.getName(), option.getType());
+                selectMany.setValueChoices((Iterable) option.getAvailableValues());
                 selectMany.setDefaultValue(new DefaultValueAdapter(option, Iterable.class));
                 inputComponent = selectMany;
                 break;
@@ -293,6 +294,7 @@ public class WindupCommand implements UICommand
             case SELECT_ONE:
             {
                 UISelectOne<?> selectOne = componentFactory.createSelectOne(option.getName(), option.getType());
+                selectOne.setValueChoices((Iterable) option.getAvailableValues());
                 selectOne.setDefaultValue(new DefaultValueAdapter(option));
                 inputComponent = selectOne;
                 break;

--- a/ui/tests/src/test/java/org/jboss/windup/addon/ui/WindupCommandTest.java
+++ b/ui/tests/src/test/java/org/jboss/windup/addon/ui/WindupCommandTest.java
@@ -37,7 +37,7 @@ import org.jboss.windup.graph.model.resource.FileModel;
 import org.jboss.windup.graph.model.resource.IgnoredFileModel;
 import org.jboss.windup.graph.service.GraphService;
 import org.jboss.windup.ui.WindupCommand;
-import org.jboss.windup.util.WindupPathUtil;
+import org.jboss.windup.util.PathUtil;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -46,7 +46,6 @@ import org.junit.runner.RunWith;
 @RunWith(Arquillian.class)
 public class WindupCommandTest
 {
-
     @Deployment
     @Dependencies({
                 @AddonDependency(name = "org.jboss.windup.ui:windup-ui"),
@@ -298,8 +297,8 @@ public class WindupCommandTest
 
                 Iterable<Path> allRulesPaths = windupConfiguration.getAllUserRulesDirectories();
 
-                Path expectedUserHomeRulesDir = WindupPathUtil.getUserRulesDir();
-                Path expectedWindupHomeRulesDir = WindupPathUtil.getWindupRulesDir();
+                Path expectedUserHomeRulesDir = PathUtil.getUserRulesDir();
+                Path expectedWindupHomeRulesDir = PathUtil.getWindupRulesDir();
 
                 boolean foundUserSpecifiedPath = false;
                 boolean foundUserHomeDirRulesPath = false;
@@ -357,7 +356,7 @@ public class WindupCommandTest
 
                 setupController(controller, outputFile, reportPath);
 
-                Path expectedUserHomeRulesDir = WindupPathUtil.getUserRulesDir();
+                Path expectedUserHomeRulesDir = PathUtil.getUserRulesDir();
                 expectedUserHomeRulesDir.toFile().mkdirs();
                 controller.setValueFor("userRulesDirectory", expectedUserHomeRulesDir.toFile());
 
@@ -373,7 +372,7 @@ public class WindupCommandTest
 
                 Iterable<Path> allRulesPaths = windupConfiguration.getAllUserRulesDirectories();
 
-                Path expectedWindupHomeRulesDir = WindupPathUtil.getWindupRulesDir();
+                Path expectedWindupHomeRulesDir = PathUtil.getWindupRulesDir();
 
                 boolean foundUserHomeDirRulesPath = false;
                 boolean foundWindupHomeDirRulesPath = false;
@@ -448,8 +447,8 @@ public class WindupCommandTest
 
                 Iterable<Path> allIgnoreDirectories = windupConfiguration.getAllIgnoreDirectories();
 
-                Path expectedUserHomeIgnoreDir = WindupPathUtil.getUserIgnoreDir();
-                Path expectedWindupHomeIgnoreDir = WindupPathUtil.getWindupIgnoreDir();
+                Path expectedUserHomeIgnoreDir = PathUtil.getUserIgnoreDir();
+                Path expectedWindupHomeIgnoreDir = PathUtil.getWindupIgnoreDir();
 
                 boolean foundUserSpecifiedPath = false;
                 boolean foundUserHomeDirIgnorePath = false;
@@ -495,7 +494,6 @@ public class WindupCommandTest
                 FileUtils.deleteDirectory(reportPath);
             }
         }
-
     }
 
     private void setupController(CommandController controller, File inputFile, File outputFile) throws Exception

--- a/utils/src/main/java/org/jboss/windup/util/PathUtil.java
+++ b/utils/src/main/java/org/jboss/windup/util/PathUtil.java
@@ -13,9 +13,9 @@ import org.apache.commons.lang3.StringUtils;
  * @author jsightler
  * @author <a href="mailto:lincolnbaxter@gmail.com">Lincoln Baxter, III</a>
  */
-public class WindupPathUtil
+public class PathUtil
 {
-    private static final Logger log = Logger.getLogger(WindupPathUtil.class.getName());
+    private static final Logger log = Logger.getLogger(PathUtil.class.getName());
 
     /**
      * The path $USER_HOME/.windup

--- a/utils/src/main/java/org/jboss/windup/util/furnace/FurnaceClasspathScanner.java
+++ b/utils/src/main/java/org/jboss/windup/util/furnace/FurnaceClasspathScanner.java
@@ -21,7 +21,7 @@ import org.jboss.forge.furnace.addons.Addon;
 import org.jboss.forge.furnace.container.simple.lifecycle.SimpleContainer;
 import org.jboss.forge.furnace.util.AddonFilters;
 import org.jboss.forge.furnace.util.Predicate;
-import org.jboss.windup.util.WindupPathUtil;
+import org.jboss.windup.util.PathUtil;
 
 /**
  * @author <a href="mailto:lincolnbaxter@gmail.com">Lincoln Baxter, III</a>
@@ -105,7 +105,7 @@ public class FurnaceClasspathScanner
             // Then try to load the classes.
             for (String discoveredFilename : discoveredFileNames)
             {
-                String clsName = WindupPathUtil.classFilePathToClassname(discoveredFilename);
+                String clsName = PathUtil.classFilePathToClassname(discoveredFilename);
                 try
                 {
                     Class<?> clazz = addon.getClassLoader().loadClass(clsName);

--- a/utils/src/test/java/org/jboss/windup/util/PathUtilTest.java
+++ b/utils/src/test/java/org/jboss/windup/util/PathUtilTest.java
@@ -7,7 +7,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-public class WindupPathUtilTest
+public class PathUtilTest
 {
     String windupHome = null;
     String userHome = null;
@@ -45,40 +45,40 @@ public class WindupPathUtilTest
     @Test
     public void testWindupHome()
     {
-        Assert.assertEquals(Paths.get(""), WindupPathUtil.getWindupHome());
+        Assert.assertEquals(Paths.get(""), PathUtil.getWindupHome());
         setWindupHome("/foo");
-        Assert.assertEquals(Paths.get("/foo"), WindupPathUtil.getWindupHome());
+        Assert.assertEquals(Paths.get("/foo"), PathUtil.getWindupHome());
     }
 
     @Test
     public void testWindupHomeRules()
     {
-        Assert.assertEquals(Paths.get("rules"), WindupPathUtil.getWindupRulesDir());
+        Assert.assertEquals(Paths.get("rules"), PathUtil.getWindupRulesDir());
         setWindupHome("/foo");
-        Assert.assertEquals(Paths.get("/foo", "rules"), WindupPathUtil.getWindupRulesDir());
+        Assert.assertEquals(Paths.get("/foo", "rules"), PathUtil.getWindupRulesDir());
     }
 
     @Test
     public void testWindupHomeIgnoreListDir()
     {
-        Assert.assertEquals(Paths.get("ignore"), WindupPathUtil.getWindupIgnoreDir());
+        Assert.assertEquals(Paths.get("ignore"), PathUtil.getWindupIgnoreDir());
         setWindupHome("/foo");
-        Assert.assertEquals(Paths.get("/foo", "ignore"), WindupPathUtil.getWindupIgnoreDir());
+        Assert.assertEquals(Paths.get("/foo", "ignore"), PathUtil.getWindupIgnoreDir());
     }
 
     @Test
     public void testWindupUserDir()
     {
-        Assert.assertEquals(Paths.get(""), WindupPathUtil.getWindupUserDir());
+        Assert.assertEquals(Paths.get(""), PathUtil.getWindupUserDir());
         setUserHome("/foo");
-        Assert.assertEquals(Paths.get("/foo", ".windup"), WindupPathUtil.getWindupUserDir());
+        Assert.assertEquals(Paths.get("/foo", ".windup"), PathUtil.getWindupUserDir());
     }
 
     @Test
     public void testWindupIgnoreDir()
     {
-        Assert.assertEquals(Paths.get("ignore"), WindupPathUtil.getUserIgnoreDir());
+        Assert.assertEquals(Paths.get("ignore"), PathUtil.getUserIgnoreDir());
         setUserHome("/foo");
-        Assert.assertEquals(Paths.get("/foo", ".windup", "ignore"), WindupPathUtil.getUserIgnoreDir());
+        Assert.assertEquals(Paths.get("/foo", ".windup", "ignore"), PathUtil.getUserIgnoreDir());
     }
 }


### PR DESCRIPTION
This PR is not complicated. I have created one MetadataRootHandler that covers all the metadata processing using the subhandlers and after each processment fills the MetadataBuilder with the processed information. The structure was followed from https://issues.jboss.org/browse/WINDUP-521 except the versionRange to be not optional but compulsory (at least for now)