### PR TITLE
WINDUP-529 Performance issue: Query requires iterating over all vertices [(ClassificationModel:classification = ...)]

### DIFF
--- a/graph/impl/src/main/java/org/jboss/windup/graph/GraphContextImpl.java
+++ b/graph/impl/src/main/java/org/jboss/windup/graph/GraphContextImpl.java
@@ -77,7 +77,7 @@ public class GraphContextImpl implements GraphContext
         fireListeners();
         return this;
     }
-    
+
     private void fireListeners() {
         Imported<AfterGraphInitializationListener> afterInitializationListeners = furnace.getAddonRegistry().getServices(
                     AfterGraphInitializationListener.class);
@@ -98,7 +98,7 @@ public class GraphContextImpl implements GraphContext
             }
         }
     }
-    
+
     private void createFramed(TitanGraph titanGraph) {
         this.eventGraph = new EventGraph<TitanGraph>(titanGraph);
         this.batchGraph = new BatchGraph<TitanGraph>(titanGraph, 1000L);
@@ -142,24 +142,39 @@ public class GraphContextImpl implements GraphContext
 
     private void initializeTitanManagement(TitanGraph titanGraph)
     {
-        // TODO: This has to load dynamically.
+        // TODO: This has to load dynamically. WINDUP-198
         // E.g. get all Model classes and look for @Indexed - org.jboss.windup.graph.api.model.anno.
-        String[] keys = new String[] { "namespaceURI", "schemaLocation", "publicId", "rootTagName",
-                    "systemId", "qualifiedName", "filePath", "mavenIdentifier", "packageName", "classification" };
+        // We need to hard-code the property names here since we can't depend on rulesets' addons.
+        String[] keys = new String[] {
+            // rules/apps/xml/model/NamespaceMetaModel
+            "namespaceURI",
+            "schemaLocation",
+            // rules/apps/xml/model/XmlFileModel
+            "rootTagName",
+            // rules/apps/java/model/JavaClassModel
+            "qualifiedName",
+            // graph/model/resource/FileModel
+            "filePath",
+            // rules/apps/java/model/project/MavenProjectModel
+            "mavenIdentifier",
+            // JavaClassModel, JavaClassFileModel, JavaSourceFileModel, PackageModel - possible collision!
+            "packageName",
+
+            "DoctypeMeta:publicId", "DoctypeMeta:systemId",
+            "ClassificationModel:classification"
+        };
 
         TitanManagement mgmt = titanGraph.getManagementSystem();
 
         for (String key : keys)
         {
-            PropertyKey propKey = mgmt.makePropertyKey(key).dataType(String.class).cardinality(Cardinality.SINGLE)
-                        .make();
+            PropertyKey propKey = mgmt.makePropertyKey(key).dataType(String.class).cardinality(Cardinality.SINGLE).make();
             mgmt.buildIndex(key, Vertex.class).addKey(propKey).buildCompositeIndex();
         }
 
         for (String key : new String[] { "referenceSourceSnippit" })
         {
-            PropertyKey propKey = mgmt.makePropertyKey(key).dataType(String.class).cardinality(Cardinality.SINGLE)
-                        .make();
+            PropertyKey propKey = mgmt.makePropertyKey(key).dataType(String.class).cardinality(Cardinality.SINGLE).make();
             mgmt.buildIndex(key, Vertex.class).addKey(propKey).buildMixedIndex("search");
         }
 
@@ -192,7 +207,7 @@ public class GraphContextImpl implements GraphContext
         // turn on a db-cache that persists across txn boundaries, but make it relatively small
         conf.setProperty("cache.db-cache", true);
         conf.setProperty("cache.db-cache-clean-wait", 0);
-        conf.setProperty("cache.db-cache-size", .05);
+        conf.setProperty("cache.db-cache-size", .09);
         conf.setProperty("cache.db-cache-time", 0);
 
         conf.setProperty("index.search.backend", "lucene");
@@ -216,7 +231,7 @@ public class GraphContextImpl implements GraphContext
     @Override
     public void close()
     {
-        //TODO: This is probably not the same instance as the one gained using AfterGraphInitializationListener interface 
+        //TODO: This is probably not the same instance as the one gained using AfterGraphInitializationListener interface
         Imported<BeforeGraphCloseListener> beforeCloseListeners = furnace.getAddonRegistry().getServices(
                     BeforeGraphCloseListener.class);
         for(BeforeGraphCloseListener listener : beforeCloseListeners) {

--- a/rules-xml/addon/src/main/java/org/jboss/windup/rules/apps/xml/model/DoctypeMetaModel.java
+++ b/rules-xml/addon/src/main/java/org/jboss/windup/rules/apps/xml/model/DoctypeMetaModel.java
@@ -7,14 +7,16 @@ import com.tinkerpop.frames.Adjacency;
 import com.tinkerpop.frames.Property;
 import com.tinkerpop.frames.modules.typedgraph.TypeValue;
 
-@TypeValue("DoctypeMeta")
+@TypeValue(DoctypeMetaModel.TYPE_ID)
 public interface DoctypeMetaModel extends WindupVertexFrame
 {
+    public static final String TYPE_ID = "DoctypeMeta";
+    public static final String TYPE_PREFIX = TYPE_ID + ":";
 
-    public static final String PROPERTY_BASE_URI = "baseURI";
-    public static final String PROPERTY_SYSTEM_ID = "systemId";
-    public static final String PROPERTY_PUBLIC_ID = "publicId";
-    public static final String PROPERTY_NAME = "name";
+    public static final String PROPERTY_BASE_URI  = TYPE_PREFIX + "baseURI";
+    public static final String PROPERTY_SYSTEM_ID = TYPE_PREFIX + "systemId";
+    public static final String PROPERTY_PUBLIC_ID = TYPE_PREFIX + "publicId";
+    public static final String PROPERTY_NAME      = TYPE_PREFIX + "name";
 
     @Adjacency(label = "doctype", direction = Direction.IN)
     public void addXmlResource(XmlFileModel facet);


### PR DESCRIPTION
This speeds Windup up by 200 %. It fixes the indexed property name.
The real change we should do (IMO) is WINDUP-532.