### PR TITLE
WINDUP-557? Upgrade roaster-jdt 2.12 - sync with Forge.

### DIFF
--- a/rules-java/api/pom.xml
+++ b/rules-java/api/pom.xml
@@ -17,7 +17,7 @@
         <dependency>
             <groupId>org.jboss.forge.roaster</groupId>
             <artifactId>roaster-jdt</artifactId>
-            <version>2.9.0.Final</version>
+            <version>2.12.0.Final</version>
         </dependency>
         <dependency>
             <groupId>org.apache.bcel</groupId>


### PR DESCRIPTION
It might have something in common with WINDUP-557.