### PR TITLE
XML Caching with XmlFileService

### DIFF
--- a/rules-xml/addon/src/main/java/org/jboss/windup/rules/apps/xml/model/XmlFileModel.java
+++ b/rules-xml/addon/src/main/java/org/jboss/windup/rules/apps/xml/model/XmlFileModel.java
@@ -1,20 +1,12 @@
 package org.jboss.windup.rules.apps.xml.model;
 
-import java.io.InputStream;
-
 import org.jboss.windup.graph.Indexed;
 import org.jboss.windup.graph.model.resource.FileModel;
 import org.jboss.windup.graph.model.resource.SourceFileModel;
-import org.jboss.windup.util.exception.WindupException;
-import org.jboss.windup.util.xml.LocationAwareXmlReader;
-import org.w3c.dom.Document;
 
 import com.tinkerpop.blueprints.Direction;
-import com.tinkerpop.blueprints.Vertex;
 import com.tinkerpop.frames.Adjacency;
 import com.tinkerpop.frames.Property;
-import com.tinkerpop.frames.modules.javahandler.JavaHandler;
-import com.tinkerpop.frames.modules.javahandler.JavaHandlerContext;
 import com.tinkerpop.frames.modules.typedgraph.TypeValue;
 
 @TypeValue(XmlFileModel.TYPE)
@@ -46,27 +38,4 @@ public interface XmlFileModel extends FileModel, SourceFileModel
 
     @Property(ROOT_TAG_NAME)
     public void setRootTagName(String rootTagName);
-
-    @JavaHandler
-    public Document asDocument();
-
-    abstract class Impl implements XmlFileModel, JavaHandlerContext<Vertex>
-    {
-
-        @Override
-        public Document asDocument()
-        {
-            FileModel fileModel = frame(asVertex(), FileModel.class);
-            try (InputStream is = fileModel.asInputStream())
-            {
-                Document parsedDocument = LocationAwareXmlReader.readXML(is);
-                return parsedDocument;
-            }
-            catch (Exception e)
-            {
-                throw new WindupException("Exception reading document.", e);
-            }
-        }
-
-    }
 }

--- a/rules-xml/addon/src/main/java/org/jboss/windup/rules/apps/xml/operation/xslt/XSLTTransformation.java
+++ b/rules-xml/addon/src/main/java/org/jboss/windup/rules/apps/xml/operation/xslt/XSLTTransformation.java
@@ -35,6 +35,7 @@ import org.jboss.windup.reporting.model.LinkModel;
 import org.jboss.windup.reporting.service.ClassificationService;
 import org.jboss.windup.rules.apps.xml.model.XmlFileModel;
 import org.jboss.windup.rules.apps.xml.model.XsltTransformationModel;
+import org.jboss.windup.rules.apps.xml.service.XmlFileService;
 import org.jboss.windup.rules.apps.xml.service.XsltTransformationService;
 import org.jboss.windup.rules.files.model.FileReferenceModel;
 import org.jboss.windup.util.Logging;
@@ -243,7 +244,8 @@ public class XSLTTransformation extends AbstractIterationOperation<XmlFileModel>
 
         Path resultPath = outputPath.resolve(fileName);
 
-        Source xmlSource = new DOMSource(payload.asDocument());
+        XmlFileService xmlService = new XmlFileService(graphContext);
+        Source xmlSource = new DOMSource(xmlService.loadDocumentQuiet(payload));
         Result xmlResult = new StreamResult(resultPath.toFile());
 
         try

--- a/rules-xml/addon/src/main/java/org/jboss/windup/rules/apps/xml/service/XmlFileService.java
+++ b/rules-xml/addon/src/main/java/org/jboss/windup/rules/apps/xml/service/XmlFileService.java
@@ -2,10 +2,14 @@ package org.jboss.windup.rules.apps.xml.service;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.lang.ref.SoftReference;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import org.jboss.windup.graph.GraphContext;
+import org.jboss.windup.graph.model.resource.FileModel;
 import org.jboss.windup.graph.service.GraphService;
 import org.jboss.windup.reporting.model.ClassificationModel;
 import org.jboss.windup.reporting.service.ClassificationService;
@@ -21,13 +25,15 @@ import org.xml.sax.SAXException;
  */
 public class XmlFileService extends GraphService<XmlFileModel>
 {
+	private static final Map<String, SoftReference<Document>> XML_CACHE = new HashMap<>();
+	
     private static final Logger LOG = Logger.getLogger(XmlFileService.class.getSimpleName());
 
     public XmlFileService(GraphContext ctx)
     {
         super(ctx, XmlFileModel.class);
     }
-
+    
     /**
      * Loads and parses the provided XML file. This will quietly fail (not throwing an {@link Exception}) and return
      * null if it is unable to parse the provided {@link XmlFileModel}. A {@link ClassificationModel} will be created to
@@ -44,23 +50,36 @@ public class XmlFileService extends GraphService<XmlFileModel>
             return null;
         }
 
-        try (InputStream is = model.asInputStream())
-        {
-            Document doc = LocationAwareXmlReader.readXML(is);
-            return doc;
-        }
-        catch (SAXException e)
-        {
-            LOG.log(Level.WARNING,
-                        "Failed to parse xml entity: " + model.getFilePath() + ", due to: " + e.getMessage());
-            classificationService.attachClassification(model, XmlFileModel.UNPARSEABLE_XML_CLASSIFICATION, XmlFileModel.UNPARSEABLE_XML_DESCRIPTION);
-        }
-        catch (IOException e)
-        {
-            LOG.log(Level.WARNING,
-                        "Failed to parse xml entity: " + model.getFilePath() + ", due to: " + e.getMessage());
-            classificationService.attachClassification(model, XmlFileModel.UNPARSEABLE_XML_CLASSIFICATION, XmlFileModel.UNPARSEABLE_XML_DESCRIPTION);
-        }
-        return null;
+        Document document = null;
+    	SoftReference<Document> cache = XML_CACHE.get(model.getFilePath());
+    	
+    	
+    	if(cache == null || cache.get() == null) {
+            FileModel fileModel = model;
+            try (InputStream is = fileModel.asInputStream())
+            {
+            	LOG.log(Level.INFO, "Hydrating XML File: "+fileModel.getFilePath());
+            	document = LocationAwareXmlReader.readXML(is);
+            	cache = new SoftReference<Document>(document);
+            	XML_CACHE.put(model.getFilePath(), cache);
+            }
+            catch (SAXException e)
+            {
+                LOG.log(Level.WARNING,
+                            "Failed to parse xml entity: " + model.getFilePath());
+                classificationService.attachClassification(model, XmlFileModel.UNPARSEABLE_XML_CLASSIFICATION, XmlFileModel.UNPARSEABLE_XML_DESCRIPTION);
+            }
+            catch (IOException e)
+            {
+                LOG.log(Level.WARNING,
+                            "Failed to parse xml entity: " + model.getFilePath() + ", due to: " + e.getMessage());
+                classificationService.attachClassification(model, XmlFileModel.UNPARSEABLE_XML_CLASSIFICATION, XmlFileModel.UNPARSEABLE_XML_DESCRIPTION);
+            }
+    	}
+    	else {
+    		LOG.log(Level.INFO, "Cached XML File: "+model.getFilePath());
+    		document = cache.get();
+    	}
+    	return document;
     }
 }

--- a/utils/src/main/java/org/jboss/windup/util/xml/XmlUtil.java
+++ b/utils/src/main/java/org/jboss/windup/util/xml/XmlUtil.java
@@ -31,7 +31,8 @@ import org.w3c.dom.NodeList;
 
 public class XmlUtil
 {
-    private static Logger LOG = Logging.get(XmlUtil.class);
+	private static final XPathFactory XPATH_FACTORY = XPathFactory.newInstance();
+    private static final Logger LOG = Logging.get(XmlUtil.class);
     protected static final Map<String, String> objs;
 
     static
@@ -149,8 +150,7 @@ public class XmlUtil
         NamespaceMapContext mapContext = new NamespaceMapContext(namespaceMapping);
         try
         {
-            XPathFactory xPathfactory = XPathFactory.newInstance();
-            XPath xpath = xPathfactory.newXPath();
+            XPath xpath = XPATH_FACTORY.newXPath();
             xpath.setNamespaceContext(mapContext);
             XPathExpression expr = xpath.compile(xpathExpression);
 


### PR DESCRIPTION
Keeps a map of SoftReferences to the XML Document objects.  This allows the garbage collector to force a collection of the parsed XML Document objects, but otherwise allows the existing parsed document to be loaded from the cache.