### PR TITLE
Performance test: String flag vs edge flag

### DIFF
--- a/graph/api/src/main/java/org/jboss/windup/graph/model/resource/ApplicationFlag.java
+++ b/graph/api/src/main/java/org/jboss/windup/graph/model/resource/ApplicationFlag.java
@@ -1,0 +1,6 @@
+package org.jboss.windup.graph.model.resource;
+
+public enum ApplicationFlag
+{
+    APPLICATION,SERVER
+}

--- a/graph/api/src/main/java/org/jboss/windup/graph/model/resource/ApplicationFlagVertex.java
+++ b/graph/api/src/main/java/org/jboss/windup/graph/model/resource/ApplicationFlagVertex.java
@@ -1,0 +1,11 @@
+package org.jboss.windup.graph.model.resource;
+
+import org.jboss.windup.graph.model.WindupVertexFrame;
+
+import com.tinkerpop.frames.modules.typedgraph.TypeValue;
+
+@TypeValue("ApplicationFlagVertex")
+public interface ApplicationFlagVertex extends WindupVertexFrame
+{
+    
+}

--- a/graph/api/src/main/java/org/jboss/windup/graph/model/resource/FileModel.java
+++ b/graph/api/src/main/java/org/jboss/windup/graph/model/resource/FileModel.java
@@ -32,6 +32,7 @@ import com.tinkerpop.frames.modules.typedgraph.TypeValue;
 public interface FileModel extends ResourceModel
 {
     public static final String ARCHIVE_FILES = "archiveFiles";
+    public static final String APPLICATION_FLAG = "ApplicationFlag";
 
     public static final String PARENT_FILE = "parentFile";
 
@@ -53,7 +54,20 @@ public interface FileModel extends ResourceModel
      */
     @Property(FILE_NAME)
     public String getFileName();
+    //test from
+    @Property(APPLICATION_FLAG)
+    public String getApplicationFlag();
+    
+    @Indexed
+    @Property(APPLICATION_FLAG)
+    public void setApplicationFlag(String applicationFlag);
+    
+    @Adjacency(label = "ApplicationFlagVertex", direction = Direction.OUT)
+    public ApplicationFlagVertex getApplicationFlagVertex();
 
+    @Adjacency(label = "ApplicationFlagVertex", direction = Direction.OUT)
+    public void setApplicationFlagVertex(ApplicationFlagVertex parentFile);
+    // test to
     /**
      * Contains the File Name (the last component of the path). Eg, a file /tmp/foo/bar/file.txt would have fileName set
      * to "file.txt"

--- a/rules-java/api/src/main/java/org/jboss/windup/rules/apps/java/scan/operation/UnzipArchiveToOutputFolder.java
+++ b/rules-java/api/src/main/java/org/jboss/windup/rules/apps/java/scan/operation/UnzipArchiveToOutputFolder.java
@@ -13,6 +13,8 @@ import org.jboss.windup.config.operation.iteration.AbstractIterationOperation;
 import org.jboss.windup.graph.GraphContext;
 import org.jboss.windup.graph.model.ArchiveModel;
 import org.jboss.windup.graph.model.WindupConfigurationModel;
+import org.jboss.windup.graph.model.resource.ApplicationFlag;
+import org.jboss.windup.graph.model.resource.ApplicationFlagVertex;
 import org.jboss.windup.graph.model.resource.FileModel;
 import org.jboss.windup.graph.model.resource.IgnoredFileModel;
 import org.jboss.windup.graph.service.FileService;
@@ -157,7 +159,14 @@ public class UnzipArchiveToOutputFolder extends AbstractIterationOperation<Archi
                 FileService fileService, ArchiveModel archiveModel,
                 FileModel parentFileModel)
     {
+        GraphService<ApplicationFlagVertex> service = new GraphService<ApplicationFlagVertex>(context,ApplicationFlagVertex.class);
+        ApplicationFlagVertex applicationFlagVertex = service.getUnique();
+        if(applicationFlagVertex == null) {
+            applicationFlagVertex = service.create();
+        }
         File fileReference = parentFileModel.asFile();
+        parentFileModel.setApplicationFlag("application");
+        parentFileModel.setApplicationFlagVertex(applicationFlagVertex);
         WindupJavaConfigurationService windupJavaConfigurationService = new WindupJavaConfigurationService(context);
         if (fileReference.isDirectory())
         {
@@ -167,6 +176,8 @@ public class UnzipArchiveToOutputFolder extends AbstractIterationOperation<Archi
                 for (File subFile : subFiles)
                 {
                     FileModel subFileModel = fileService.createByFilePath(parentFileModel, subFile.getAbsolutePath());
+                    subFileModel.setApplicationFlag("application");
+                    subFileModel.setApplicationFlagVertex(applicationFlagVertex);
                     subFileModel.setParentArchive(archiveModel);
 
                     // check if this file should be ignored

--- a/tests/src/test/java/org/jboss/windup/tests/application/WindupArchitectureTest.java
+++ b/tests/src/test/java/org/jboss/windup/tests/application/WindupArchitectureTest.java
@@ -11,6 +11,9 @@ import javax.inject.Inject;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang.RandomStringUtils;
+import org.jboss.forge.furnace.util.Predicate;
+import org.jboss.windup.config.RuleProvider;
+import org.jboss.windup.config.phase.DecompilationPhase;
 import org.jboss.windup.exec.WindupProcessor;
 import org.jboss.windup.exec.WindupProgressMonitor;
 import org.jboss.windup.exec.configuration.WindupConfiguration;
@@ -97,15 +100,20 @@ public abstract class WindupArchitectureTest
 
         RecordingWindupProgressMonitor progressMonitor = new RecordingWindupProgressMonitor();
         wpc.setProgressMonitor(progressMonitor);
+        wpc.setRuleProviderFilter(new Predicate<org.jboss.windup.config.RuleProvider>() {
 
+            @Override
+            public boolean accept(RuleProvider arg0)
+            {
+                if(arg0.getMetadata().getPhase().equals(DecompilationPhase.class)) {
+                    return false;
+                }
+                return true;
+            }
+            
+        });
         processor.execute(wpc);
-
-        Assert.assertFalse(progressMonitor.isCancelled());
-        Assert.assertTrue(progressMonitor.isDone());
-        Assert.assertFalse(progressMonitor.getSubTaskNames().isEmpty());
-        Assert.assertTrue(progressMonitor.getTotalWork() > 0);
-        Assert.assertTrue(progressMonitor.getCompletedWork() > 0);
-        Assert.assertEquals(progressMonitor.getTotalWork(), progressMonitor.getCompletedWork());
+      
     }
 
     /*


### PR DESCRIPTION
PLEASE DO NOT MERGE THIS. It is done just to provide test for string vs. edge performance test as fast as possible. According to the output, string property is faster than edge:

1st run
String flag match count: 3223 (number of vertices, is not cleared between different @Test methods. Just to check both matched the same ammount of vertices)
String flag time: 443 ms (time of the rule execution)
Edge flag match count: 3223
Edge flag time: 421 ms

String flag match count: 6446
String flag time: 300 ms
Edge flag match count: 6446
Edge flag time: 443 ms


String flag match count: 9669
String flag time: 323 ms
Edge flag match count: 9669
Edge flag time: 423 ms

2nd run
String flag match count: 3223
String flag time: 289 ms
Edge flag match count: 3223
Edge flag time: 489 ms

String flag match count: 6446
String flag time: 309 ms
Edge flag match count: 6446
Edge flag time: 650 ms


String flag match count: 9669
String flag time: 237 ms
Edge flag match count: 9669
Edge flag time: 486 ms

 * Even after using gremlin for property (``` pipeline.has() ``` ) and removing the @Index, the result is almost the same. Only the first query is slower for the property, but since then the string property match is faster in this query . 

 * Using ``` pipeline.as("result").out("ApplicationFlagVertex").back("result") ``` without fromType() (that results in starting from all vertices) is a disaster with 10-20x bigger time