### PR TITLE
WINDUP-633 Hint-exists filter (+ test)

### DIFF
--- a/config-xml/schema/windup-jboss-ruleset.xsd
+++ b/config-xml/schema/windup-jboss-ruleset.xsd
@@ -63,7 +63,6 @@
 	</xs:complexType>
 
 
-
 	<!-- CONDITION DEFINITIONS -->
 
 
@@ -234,6 +233,16 @@
 		<xs:attribute type="xs:string" name="param" use="optional" />
 	</xs:complexType>
 
+	<xs:complexType name="hint-exists">
+		<xs:attribute type="xs:string" name="message" use="optional" />
+		<xs:attribute type="xs:string" name="in" use="optional" />
+	</xs:complexType>
+
+	<xs:complexType name="classification-exists">
+		<xs:attribute type="xs:string" name="title" use="optional" />
+		<xs:attribute type="xs:string" name="in" use="optional" />
+	</xs:complexType>
+
 	<xs:complexType name="when">
 		<!-- Conditions -->
 		<xs:choice maxOccurs="unbounded">
@@ -245,6 +254,10 @@
 			<xs:element ref="xmlfile" minOccurs="0" maxOccurs="unbounded" />
 			<xs:element ref="project" minOccurs="0" maxOccurs="unbounded" />
 			<xs:element ref="filecontent" minOccurs="0" maxOccurs="unbounded" />
+			<xs:element name="hint-exists" type="hint-exists" minOccurs="0" maxOccurs="unbounded" />
+			<xs:element name="hint-not-exists" type="hint-exists" minOccurs="0" maxOccurs="unbounded" />
+			<xs:element name="classification-exists" type="classification-exists" minOccurs="0" maxOccurs="unbounded" />
+			<xs:element name="classification-not-exists" type="classification-exists" minOccurs="0" maxOccurs="unbounded" />
 		</xs:choice>
 	</xs:complexType>
 

--- a/config/api/src/main/java/org/jboss/windup/config/condition/GraphConditionFilter.java
+++ b/config/api/src/main/java/org/jboss/windup/config/condition/GraphConditionFilter.java
@@ -1,0 +1,82 @@
+package org.jboss.windup.config.condition;
+
+import org.jboss.windup.config.GraphRewrite;
+import org.jboss.windup.config.Variables;
+import org.jboss.windup.config.operation.Iteration;
+import org.jboss.windup.graph.model.WindupVertexFrame;
+import org.ocpsoft.rewrite.context.EvaluationContext;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Filters the results from the previous conditions, or from the specified vertices
+ *
+ * @author <a href="mailto:mbriskar@gmail.com">Matej Briskar</a>
+ */
+public abstract class GraphConditionFilter<T extends WindupVertexFrame> extends GraphCondition
+{
+    Class<T> clazz;
+
+    public GraphConditionFilter(String variableName)
+    {
+        this.setInputVariablesName(variableName);
+    }
+
+    public GraphConditionFilter()
+    {
+    }
+
+    public boolean hasVariableNameSet()
+    {
+        return getInputVariablesName() != null;
+    }
+
+    @Override
+    public boolean evaluate(GraphRewrite event, EvaluationContext context)
+    {
+        checkVariableName(event, context);
+        Iterable<? extends T> payloads;
+        // 1) get the input variables
+        if(getInputVariablesName() == null) {
+            //if there is no input variable specified, we need fill vertices before filtering
+            payloads=fillIn(event,context);
+        } else {
+            Variables varStack = Variables.instance(event);
+            payloads = Iteration.getCurrentIterationPayload(varStack, getInputVariablesName());
+        }
+
+        // 2) do the filtering
+        List<WindupVertexFrame> result = new ArrayList<>();
+        for(T payload : payloads) {
+            if(accept(event, context, payload)) {
+                result.add(payload);
+            }
+        }
+        Variables.instance(event).setVariable(getOutputVariablesName(), result);
+        return !result.isEmpty();
+    }
+
+    /**
+     * Check the variable name and if not set and there is some default result from the previous condition, set it to it
+     */
+    protected void checkVariableName(GraphRewrite event, EvaluationContext context)
+    {
+        if (getInputVariablesName() == null && !Variables.instance(event).peek().isEmpty())
+        {
+            String topLayerName = Iteration.getPayloadVariableName(event, context);
+            if (topLayerName.equals(Iteration.DEFAULT_VARIABLE_LIST_STRING))
+            {
+                setInputVariablesName(Iteration.DEFAULT_VARIABLE_LIST_STRING);
+            }
+
+        }
+    }
+
+    /**
+     * In case the input variable is not specified, this method is called to return WindupVertexFrames that are going to be filtered and by accept() method and then returned
+     */
+    public abstract Iterable<? extends T> fillIn(GraphRewrite event, EvaluationContext context);
+    public abstract boolean accept(GraphRewrite event, EvaluationContext context, T payload);
+
+}

--- a/config/api/src/main/java/org/jboss/windup/config/operation/Iteration.java
+++ b/config/api/src/main/java/org/jboss/windup/config/operation/Iteration.java
@@ -322,6 +322,28 @@ public class Iteration extends DefaultOperationBuilder
     }
 
     /**
+     * Get the {@link Iteration} payload with the given name.
+     *
+     * @throws IllegalArgumentException if the given variable refers to a non-payload.
+     */
+    @SuppressWarnings("unchecked")
+    public static <FRAMETYPE extends WindupVertexFrame> Iterable<? extends FRAMETYPE> getCurrentIterationPayload(Variables stack, String name)
+                throws IllegalStateException, IllegalArgumentException
+    {
+        Map<String, Iterable<? extends WindupVertexFrame>> vars = stack.peek();
+
+        Iterable<? extends WindupVertexFrame> existingValue = vars.get(name);
+        if (existingValue == null)
+        {
+            throw new IllegalArgumentException("Variable \"" + name
+                        + "\" is not an " + Iteration.class.getSimpleName() + " variable.");
+        }
+
+        Object object = stack.findVariable(name);
+        return (Iterable<? extends FRAMETYPE>) object;
+    }
+
+    /**
      * Get the {@link Iteration} payload with the given name and type.
      *
      * @throws IllegalArgumentException if the given variable refers to a non-payload.

--- a/reporting/api/src/main/java/org/jboss/windup/reporting/config/condition/ClassificationExists.java
+++ b/reporting/api/src/main/java/org/jboss/windup/reporting/config/condition/ClassificationExists.java
@@ -1,0 +1,131 @@
+package org.jboss.windup.reporting.config.condition;
+
+import com.tinkerpop.blueprints.Direction;
+import com.tinkerpop.frames.structures.FramedVertexIterable;
+import org.apache.commons.lang3.StringUtils;
+import org.jboss.windup.config.GraphRewrite;
+import org.jboss.windup.config.condition.GraphCondition;
+import org.jboss.windup.config.condition.GraphConditionFilter;
+import org.jboss.windup.config.query.Query;
+import org.jboss.windup.config.query.QueryBuilderFind;
+import org.jboss.windup.config.query.QueryGremlinCriterion;
+import org.jboss.windup.config.query.QueryPropertyComparisonType;
+import org.jboss.windup.graph.model.WindupVertexFrame;
+import org.jboss.windup.graph.model.resource.FileModel;
+import org.jboss.windup.graph.service.GraphService;
+import org.jboss.windup.reporting.model.ClassificationModel;
+import org.jboss.windup.reporting.model.InlineHintModel;
+import org.jboss.windup.rules.files.model.FileLocationModel;
+import org.jboss.windup.rules.files.model.FileReferenceModel;
+import org.ocpsoft.rewrite.context.EvaluationContext;
+
+import com.tinkerpop.blueprints.Vertex;
+import com.tinkerpop.gremlin.java.GremlinPipeline;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Returns true if there are {@link ClassificationModel} entries that match the given classification text.
+ *
+ * @author <a href="mailto:jesse.sightler@gmail.com">Jesse Sightler</a>
+ * @author <a href="mailto:mbriskar@gmail.com">Matej Briskar</a>
+ */
+public class ClassificationExists  extends GraphConditionFilter<WindupVertexFrame>
+{
+    private String filename;
+    private String classificationPattern;
+
+
+    ClassificationExists(String classificationPattern)
+    {
+        if(classificationPattern !=null) {
+            this.classificationPattern = "[\\s\\S]*" + classificationPattern + "[\\s\\S]*";
+        }
+    }
+
+    /**
+     * Specifies the regular expression to use when searching {@link ClassificationModel} entries.
+     */
+    public static ClassificationExists withClassification(String classificationPattern)
+    {
+        return new ClassificationExists(classificationPattern);
+    }
+
+    /**
+     * Only consider entries that reference a file with the given filename.
+     */
+    public ClassificationExists in(String filename)
+    {
+        this.filename = filename;
+        return this;
+    }
+
+    /**
+     * Return all fileLocations placed on a file that is classified
+     * @param event
+     * @param context
+     * @return
+     */
+    @Override public Iterable<? extends WindupVertexFrame> fillIn(GraphRewrite event, EvaluationContext context)
+    {
+        GraphService<? extends ClassificationModel> classificationService = new GraphService<>(event.getGraphContext(),ClassificationModel.class);
+        Set<FileModel> input = new HashSet<>();
+        for (ClassificationModel cmodel : classificationService.findAll())
+        {
+            for (FileModel fileModel : cmodel.getFileModels())
+            {
+                input.add(fileModel);
+
+            }
+        }
+        return input;
+    }
+
+    @Override
+    public boolean accept(GraphRewrite event, EvaluationContext context, WindupVertexFrame vertex) {
+        if(vertex instanceof FileReferenceModel) {
+            return accept(event,context,(FileReferenceModel)vertex);
+        }
+        if(vertex instanceof FileModel) {
+            return accept(event,context,(FileModel)vertex);
+        }
+        throw new IllegalArgumentException("ClassificationExists supports only FileModel and FileReferenceModels");
+    }
+
+    private boolean accept(GraphRewrite event, EvaluationContext context, FileReferenceModel vertex) {
+         return accept(event, context, vertex.getFile());
+    }
+
+
+    private boolean accept(GraphRewrite event, EvaluationContext context, FileModel file)
+    {
+        boolean result = filename==null || (file.getFileName().equals(filename));
+        FramedVertexIterable<ClassificationModel> classificationsOnFile = new FramedVertexIterable<ClassificationModel>(event.getGraphContext().getFramed(),file.asVertex().getVertices(
+                    Direction.IN, ClassificationModel.FILE_MODEL), ClassificationModel.class);
+        result = result && classificationsOnFile.iterator().hasNext();
+        if(classificationPattern !=null) {
+            boolean classificationFound = false;
+            for (ClassificationModel classificationModel : classificationsOnFile)
+            {
+                classificationFound = classificationFound || (classificationModel.getClassification().matches(classificationPattern));
+            }
+            result = result && classificationFound;
+        }
+
+        return result;
+    }
+
+    public String getFilename()
+    {
+        return filename;
+    }
+
+    public String getClassificationPattern()
+    {
+        return classificationPattern;
+    }
+
+}

--- a/reporting/api/src/main/java/org/jboss/windup/reporting/config/condition/ClassificationNotExists.java
+++ b/reporting/api/src/main/java/org/jboss/windup/reporting/config/condition/ClassificationNotExists.java
@@ -1,0 +1,34 @@
+package org.jboss.windup.reporting.config.condition;
+
+import org.jboss.windup.config.GraphRewrite;
+import org.jboss.windup.graph.model.WindupVertexFrame;
+import org.jboss.windup.graph.model.resource.FileModel;
+import org.jboss.windup.reporting.model.ClassificationModel;
+import org.jboss.windup.rules.files.model.FileLocationModel;
+import org.jboss.windup.rules.files.model.FileReferenceModel;
+import org.ocpsoft.rewrite.context.EvaluationContext;
+
+/**
+ * Filter out the locations not pointing to a file with classification
+ */
+public class ClassificationNotExists extends ClassificationExists
+{
+    private ClassificationNotExists(String messagePattern)
+    {
+        super(messagePattern);
+    }
+
+    @Override
+    public boolean accept(GraphRewrite event, EvaluationContext context, WindupVertexFrame payload)
+    {
+        return !super.accept(event, context, payload);
+    }
+
+    /**
+     * Specifies the regular expression to use when searching {@link ClassificationModel} entries.
+     */
+    public static ClassificationNotExists withClassification(String messagePattern)
+    {
+        return new ClassificationNotExists(messagePattern);
+    }
+}

--- a/reporting/api/src/main/java/org/jboss/windup/reporting/config/condition/HintExists.java
+++ b/reporting/api/src/main/java/org/jboss/windup/reporting/config/condition/HintExists.java
@@ -1,0 +1,108 @@
+package org.jboss.windup.reporting.config.condition;
+
+import com.tinkerpop.blueprints.Direction;
+import com.tinkerpop.frames.structures.FramedVertexIterable;
+import org.jboss.windup.config.GraphRewrite;
+import org.jboss.windup.config.condition.GraphConditionFilter;
+import org.jboss.windup.config.operation.Iteration;
+import org.jboss.windup.graph.service.GraphService;
+import org.jboss.windup.reporting.model.InlineHintModel;
+import org.jboss.windup.rules.files.model.FileLocationModel;
+import org.ocpsoft.rewrite.context.EvaluationContext;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Returns true if there are {@link InlineHintModel} entries that match the given message text.
+ *
+ * @author <a href="mailto:jesse.sightler@gmail.com">Jesse Sightler</a>
+ * @author <a href="mailto:mbriskar@gmail.com">Matej Briskar</a>
+ */
+public class HintExists extends GraphConditionFilter<FileLocationModel>
+{
+    private String filename;
+    private String messagePattern;
+
+
+
+    HintExists(String messagePattern)
+    {
+        if(messagePattern != null)
+        {
+            this.messagePattern = "[\\s\\S]*" + messagePattern + "[\\s\\S]*";
+        }
+    }
+
+    /**
+     * Use the given message regular expression to match against {@link InlineHintModel#getHint()} property.
+     */
+    public static HintExists withMessage(String messagePattern)
+    {
+        return new HintExists(messagePattern);
+    }
+
+    /**
+     * Only match {@link InlineHintModel}s that reference the given filename.
+     */
+    public HintExists in(String filename)
+    {
+        this.filename = filename;
+        return this;
+    }
+
+    public HintExists from(String variableName)
+    {
+        setInputVariablesName(variableName);
+        return this;
+    }
+
+    @Override public Iterable<? extends FileLocationModel> fillIn(GraphRewrite event, EvaluationContext context)
+    {
+        GraphService<? extends InlineHintModel> hintService = new GraphService<>(event.getGraphContext(),InlineHintModel.class);
+        List<FileLocationModel> input = new ArrayList<>();
+        for (InlineHintModel inlineHintModel : hintService.findAll())
+        {
+            input.add(inlineHintModel.getFileLocationReference());
+        }
+        return input;
+    }
+
+
+    /**
+     * For the given payload check if it contains Hint matching the given settings
+     * @param event
+     * @param context
+     * @param payload
+     * @return
+     */
+    @Override public boolean accept(GraphRewrite event, EvaluationContext context, FileLocationModel payload)
+    {
+        boolean result = filename==null || (payload.getFile().getFileName().equals(filename));
+        //get all hints for this fileLocation
+        FramedVertexIterable<InlineHintModel> iterable = new FramedVertexIterable<InlineHintModel>(event.getGraphContext().getFramed(),payload.asVertex().getVertices(
+                    Direction.IN, InlineHintModel.FILE_LOCATION_REFERENCE), InlineHintModel.class);
+        result = result && iterable.iterator().hasNext();
+        if(messagePattern != null) {
+            boolean messageMatch =false;
+
+            for (InlineHintModel hint : iterable)
+            {
+                messageMatch = messageMatch || hint.getHint().matches(messagePattern);
+            }
+            result = result && messageMatch;
+        }
+        return  result;
+    }
+
+    public String getFilename()
+    {
+        return filename;
+    }
+
+    public String getMessagePattern()
+    {
+        return messagePattern;
+    }
+
+}

--- a/reporting/api/src/main/java/org/jboss/windup/reporting/config/condition/HintNotExists.java
+++ b/reporting/api/src/main/java/org/jboss/windup/reporting/config/condition/HintNotExists.java
@@ -1,0 +1,29 @@
+package org.jboss.windup.reporting.config.condition;
+
+import org.jboss.windup.config.GraphRewrite;
+import org.jboss.windup.reporting.model.InlineHintModel;
+import org.jboss.windup.rules.files.model.FileLocationModel;
+import org.ocpsoft.rewrite.context.EvaluationContext;
+
+/**
+ * Does exactly the opposite as {@link HintExists}
+ */
+public class HintNotExists extends HintExists
+{
+    private HintNotExists(String messagePattern)
+    {
+        super(messagePattern);
+    }
+
+    @Override public boolean accept(GraphRewrite event, EvaluationContext context, FileLocationModel payload) {
+        return !super.accept(event,context,payload);
+    }
+
+    /**
+     * Use the given message regular expression to match against {@link InlineHintModel#getHint()} property.
+     */
+    public static HintNotExists withMessage(String messagePattern)
+    {
+        return new HintNotExists(messagePattern);
+    }
+}

--- a/reporting/impl/src/main/java/org/jboss/windup/reporting/xml/ClassificationExistsHandler.java
+++ b/reporting/impl/src/main/java/org/jboss/windup/reporting/xml/ClassificationExistsHandler.java
@@ -1,0 +1,48 @@
+package org.jboss.windup.reporting.xml;
+
+import static org.joox.JOOX.$;
+
+import org.apache.commons.lang.StringUtils;
+import org.jboss.windup.config.exception.ConfigurationException;
+import org.jboss.windup.config.parser.ElementHandler;
+import org.jboss.windup.config.parser.NamespaceElementHandler;
+import org.jboss.windup.config.parser.ParserContext;
+import org.jboss.windup.reporting.config.condition.ClassificationExists;
+import org.jboss.windup.util.exception.WindupException;
+import org.w3c.dom.Element;
+
+/**
+ * Creates a {@link ClassificationExists} that searches for the given classification text. Example usage:
+ *
+ * <pre>
+ *     &lt;rule&gt;
+ *         &lt;when&gt;
+ *             &lt;not&gt;
+ *                 &lt;classification-exists title="JOnAS Web Descriptor" in="filename"/&gt;
+ *             &lt;/not&gt;
+ *         &lt;/when&gt;
+ *         &lt;perform&gt;
+ *             [...]
+ *         &lt;/perform&gt;
+ *     &lt;/rule&gt;
+ * </pre>
+ * 
+ * @author jsightler
+ *
+ */
+@NamespaceElementHandler(elementName = ClassificationExistsHandler.ELEMENT_NAME, namespace = "http://windup.jboss.org/schema/jboss-ruleset")
+public class ClassificationExistsHandler implements ElementHandler<ClassificationExists>
+{
+    static final String ELEMENT_NAME = "classification-exists";
+    private static final String CLASSIFICATION = "title";
+
+    @Override
+    public ClassificationExists processElement(ParserContext handlerManager, Element element) throws ConfigurationException
+    {
+        String classificationPattern = $(element).attr(CLASSIFICATION);
+        String in = $(element).attr("in");
+
+        ClassificationExists classificationExists = ClassificationExists.withClassification(classificationPattern);
+        return classificationExists.in(in);
+    }
+}

--- a/reporting/impl/src/main/java/org/jboss/windup/reporting/xml/ClassificationNotExistsHandler.java
+++ b/reporting/impl/src/main/java/org/jboss/windup/reporting/xml/ClassificationNotExistsHandler.java
@@ -1,0 +1,49 @@
+package org.jboss.windup.reporting.xml;
+
+import org.jboss.windup.config.exception.ConfigurationException;
+import org.jboss.windup.config.parser.ElementHandler;
+import org.jboss.windup.config.parser.NamespaceElementHandler;
+import org.jboss.windup.config.parser.ParserContext;
+import org.jboss.windup.reporting.config.condition.ClassificationExists;
+import org.jboss.windup.reporting.config.condition.ClassificationNotExists;
+import org.w3c.dom.Element;
+
+import static org.joox.JOOX.$;
+
+
+/**
+ * Creates a {@link ClassificationNotExists} that searches for the given classification text.
+ * Example usage to find all jonas web descriptors without classification:
+ *
+ * <pre>
+ *     &lt;rule&gt;
+ *         &lt;when&gt;
+ *                 &lt;xmlfile matches="//jonas" in="jonas.web.xml"/&gt;
+ *                 &lt;classification-not-exists title="JOnAS Web Descriptor"/&gt;
+ *         &lt;/when&gt;
+ *         &lt;perform&gt;
+ *             [...]
+ *         &lt;/perform&gt;
+ *     &lt;/rule&gt;
+ * </pre>
+ *
+ * @author jsightler
+ * @author mbriskar
+ *
+ */
+@NamespaceElementHandler(elementName = ClassificationNotExistsHandler.ELEMENT_NAME, namespace = "http://windup.jboss.org/schema/jboss-ruleset")
+public class ClassificationNotExistsHandler implements ElementHandler<ClassificationExists>
+{
+    static final String ELEMENT_NAME = "classification-not-exists";
+    private static final String CLASSIFICATION = "title";
+
+    @Override
+    public ClassificationExists processElement(ParserContext handlerManager, Element element) throws ConfigurationException
+    {
+        String classificationPattern = $(element).attr(CLASSIFICATION);
+        String in = $(element).attr("in");
+
+        ClassificationNotExists classificationExists = ClassificationNotExists.withClassification(classificationPattern);
+        return classificationExists.in(in);
+    }
+}

--- a/reporting/impl/src/main/java/org/jboss/windup/reporting/xml/HintExistsHandler.java
+++ b/reporting/impl/src/main/java/org/jboss/windup/reporting/xml/HintExistsHandler.java
@@ -1,0 +1,48 @@
+package org.jboss.windup.reporting.xml;
+
+import org.apache.commons.lang.StringUtils;
+import org.jboss.windup.config.exception.ConfigurationException;
+import org.jboss.windup.config.parser.ElementHandler;
+import org.jboss.windup.config.parser.NamespaceElementHandler;
+import org.jboss.windup.config.parser.ParserContext;
+import org.jboss.windup.reporting.config.condition.HintExists;
+import org.jboss.windup.util.exception.WindupException;
+import org.w3c.dom.Element;
+
+import static org.joox.JOOX.$;
+
+/**
+ * Creates a {@link HintExists} that searches for the given hint message. Example usage:
+ *
+ * <pre>
+ *     &lt;rule&gt;
+ *         &lt;when&gt;
+ *             &lt;not&gt;
+ *                 &lt;hint-exists message="JOnAS Web Descriptor" in="filename"/&gt;
+ *             &lt;/not&gt;
+ *         &lt;/when&gt;
+ *         &lt;perform&gt;
+ *             [...]
+ *         &lt;/perform&gt;
+ *     &lt;/rule&gt;
+ * </pre>
+ *
+ * @author jsightler
+ *
+ */
+@NamespaceElementHandler(elementName = HintExistsHandler.ELEMENT_NAME, namespace = "http://windup.jboss.org/schema/jboss-ruleset")
+public class HintExistsHandler implements ElementHandler<HintExists>
+{
+    static final String ELEMENT_NAME = "hint-exists";
+    private static final String MESSAGE = "message";
+
+    @Override
+    public HintExists processElement(ParserContext handlerManager, Element element) throws ConfigurationException
+    {
+        String messagePattern = $(element).attr(MESSAGE);
+        String in = $(element).attr("in");
+
+        HintExists hintExists = HintExists.withMessage(messagePattern);
+        return hintExists.in(in);
+    }
+}

--- a/reporting/impl/src/main/java/org/jboss/windup/reporting/xml/HintNotExistsHandler.java
+++ b/reporting/impl/src/main/java/org/jboss/windup/reporting/xml/HintNotExistsHandler.java
@@ -1,0 +1,48 @@
+package org.jboss.windup.reporting.xml;
+
+import org.jboss.windup.config.exception.ConfigurationException;
+import org.jboss.windup.config.parser.ElementHandler;
+import org.jboss.windup.config.parser.NamespaceElementHandler;
+import org.jboss.windup.config.parser.ParserContext;
+import org.jboss.windup.reporting.config.condition.HintExists;
+import org.jboss.windup.reporting.config.condition.HintNotExists;
+import org.w3c.dom.Element;
+
+import static org.joox.JOOX.$;
+
+/**
+ * Creates a {@link HintExists} that searches for the given hint message.
+ * Example usage to find all java class locations without hint with the given message
+ *
+ * <pre>
+ *     &lt;rule&gt;
+ *         &lt;when&gt;
+ *                 &lt;javaclass references="some.example.Jonas.descriptor"/&gt;
+ *                 &lt;hint-not-exists message="JOnAS Descriptor usage" in="filename"/&gt;
+ *         &lt;/when&gt;
+ *         &lt;perform&gt;
+ *             [...]
+ *         &lt;/perform&gt;
+ *     &lt;/rule&gt;
+ * </pre>
+ *
+ * @author jsightler
+ * @author mbriskar
+ *
+ */
+@NamespaceElementHandler(elementName = HintNotExistsHandler.ELEMENT_NAME, namespace = "http://windup.jboss.org/schema/jboss-ruleset")
+public class HintNotExistsHandler implements ElementHandler<HintExists>
+{
+    static final String ELEMENT_NAME = "hint-not-exists";
+    private static final String MESSAGE = "message";
+
+    @Override
+    public HintExists processElement(ParserContext handlerManager, Element element) throws ConfigurationException
+    {
+        String messagePattern = $(element).attr(MESSAGE);
+        String in = $(element).attr("in");
+
+        HintNotExists hintExists = HintNotExists.withMessage(messagePattern);
+        return hintExists.in(in);
+    }
+}

--- a/reporting/tests/src/test/java/org/jboss/windup/reporting/handlers/ClassificationExistsHandlerTest.java
+++ b/reporting/tests/src/test/java/org/jboss/windup/reporting/handlers/ClassificationExistsHandlerTest.java
@@ -1,0 +1,87 @@
+package org.jboss.windup.reporting.handlers;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.forge.arquillian.AddonDependencies;
+import org.jboss.forge.arquillian.AddonDependency;
+import org.jboss.forge.arquillian.archive.AddonArchive;
+import org.jboss.forge.furnace.Furnace;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.windup.config.operation.Iteration;
+import org.jboss.windup.config.parser.ParserContext;
+import org.jboss.windup.reporting.config.condition.ClassificationExists;
+import org.jboss.windup.reporting.config.condition.HintExists;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+import javax.inject.Inject;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import java.io.File;
+import java.util.List;
+
+import static org.joox.JOOX.$;
+
+/**
+ * Created by mbriskar on 6/9/15.
+ */
+@RunWith(Arquillian.class)
+public class ClassificationExistsHandlerTest
+{
+
+    private static final String HINT_XML_FILE = "src/test/resources/handler/classificationexists.windup.xml";
+
+    @Deployment
+    @AddonDependencies({
+                @AddonDependency(name = "org.jboss.windup.config:windup-config"),
+                @AddonDependency(name = "org.jboss.windup.rules.apps:windup-rules-java"),
+                @AddonDependency(name = "org.jboss.windup.config:windup-config-xml"),
+                @AddonDependency(name = "org.jboss.windup.reporting:windup-reporting"),
+                @AddonDependency(name = "org.jboss.forge.furnace.container:cdi") })
+    public static AddonArchive getDeployment()
+    {
+        return ShrinkWrap
+                    .create(AddonArchive.class)
+                    .addBeansXML();
+    }
+
+    @Inject
+    private Furnace furnace;
+
+    @Test
+    public void testHintHandler() throws Exception
+    {
+        ParserContext parser = new ParserContext(furnace);
+        File fXmlFile = new File(HINT_XML_FILE);
+        DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
+        dbFactory.setNamespaceAware(true);
+        DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
+        Document doc = dBuilder.parse(fXmlFile);
+        List<Element> classificationList = $(doc).children("classification-exists").get();
+        Element firstHint = classificationList.get(0);
+        ClassificationExists classification = parser.processElement(firstHint);
+
+        Assert.assertEquals(null, classification.getInputVariablesName());
+        Assert.assertEquals(Iteration.DEFAULT_VARIABLE_LIST_STRING, classification.getOutputVariablesName());
+        Assert.assertEquals(null, classification.getFilename());
+        Assert.assertEquals(null, classification.getClassificationPattern());
+
+        Element secondHint = classificationList.get(1);
+        classification = parser.processElement(secondHint);
+        Assert.assertEquals(null, classification.getInputVariablesName());
+        Assert.assertEquals(Iteration.DEFAULT_VARIABLE_LIST_STRING, classification.getOutputVariablesName());
+        Assert.assertTrue(classification.getClassificationPattern().contains("test-message"));
+        Assert.assertEquals(null, classification.getFilename());
+
+        Element thirdHint = classificationList.get(2);
+        classification = parser.processElement(thirdHint);
+        Assert.assertEquals(null, classification.getInputVariablesName());
+        Assert.assertEquals(Iteration.DEFAULT_VARIABLE_LIST_STRING, classification.getOutputVariablesName());
+        Assert.assertTrue(classification.getClassificationPattern().contains("test-message"));
+        Assert.assertEquals("test-in", classification.getFilename());
+
+    }
+}

--- a/reporting/tests/src/test/java/org/jboss/windup/reporting/handlers/HintExistsHandlerTest.java
+++ b/reporting/tests/src/test/java/org/jboss/windup/reporting/handlers/HintExistsHandlerTest.java
@@ -1,0 +1,90 @@
+package org.jboss.windup.reporting.handlers;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.forge.arquillian.AddonDependencies;
+import org.jboss.forge.arquillian.AddonDependency;
+import org.jboss.forge.arquillian.archive.AddonArchive;
+import org.jboss.forge.furnace.Furnace;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.windup.config.operation.Iteration;
+import org.jboss.windup.config.parser.ParserContext;
+import org.jboss.windup.reporting.config.Hint;
+import org.jboss.windup.reporting.config.Link;
+import org.jboss.windup.reporting.config.condition.HintExists;
+import org.jboss.windup.reporting.model.Severity;
+import org.jboss.windup.util.exception.WindupException;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+import javax.inject.Inject;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import java.io.File;
+import java.util.List;
+
+import static org.joox.JOOX.$;
+
+/**
+ * Created by mbriskar on 6/9/15.
+ */
+@RunWith(Arquillian.class)
+public class HintExistsHandlerTest
+{
+
+    private static final String HINT_XML_FILE = "src/test/resources/handler/hintexists.windup.xml";
+
+    @Deployment
+    @AddonDependencies({
+                @AddonDependency(name = "org.jboss.windup.config:windup-config"),
+                @AddonDependency(name = "org.jboss.windup.rules.apps:windup-rules-java"),
+                @AddonDependency(name = "org.jboss.windup.config:windup-config-xml"),
+                @AddonDependency(name = "org.jboss.windup.reporting:windup-reporting"),
+                @AddonDependency(name = "org.jboss.forge.furnace.container:cdi") })
+    public static AddonArchive getDeployment()
+    {
+        return ShrinkWrap
+                    .create(AddonArchive.class)
+                    .addBeansXML();
+    }
+
+    @Inject
+    private Furnace furnace;
+
+    @Test
+    public void testHintHandler() throws Exception
+    {
+        ParserContext parser = new ParserContext(furnace);
+        File fXmlFile = new File(HINT_XML_FILE);
+        DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
+        dbFactory.setNamespaceAware(true);
+        DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
+        Document doc = dBuilder.parse(fXmlFile);
+        List<Element> hintList = $(doc).children("hint-exists").get();
+        Element firstHint = hintList.get(0);
+        HintExists hint = parser.processElement(firstHint);
+
+        Assert.assertEquals(null, hint.getInputVariablesName());
+        Assert.assertEquals(Iteration.DEFAULT_VARIABLE_LIST_STRING, hint.getOutputVariablesName());
+        Assert.assertEquals(null, hint.getFilename());
+        Assert.assertEquals(null, hint.getMessagePattern());
+
+        Element secondHint = hintList.get(1);
+        hint = parser.processElement(secondHint);
+        Assert.assertEquals(null, hint.getInputVariablesName());
+        Assert.assertEquals(Iteration.DEFAULT_VARIABLE_LIST_STRING, hint.getOutputVariablesName());
+        Assert.assertTrue(hint.getMessagePattern().contains("test-message"));
+        Assert.assertEquals(null, hint.getFilename());
+
+        Element thirdHint = hintList.get(2);
+        hint = parser.processElement(thirdHint);
+        Assert.assertEquals(null, hint.getInputVariablesName());
+        Assert.assertEquals(Iteration.DEFAULT_VARIABLE_LIST_STRING, hint.getOutputVariablesName());
+        Assert.assertTrue(hint.getMessagePattern().contains("test-message"));
+        Assert.assertEquals("test-in", hint.getFilename());
+
+    }
+}

--- a/reporting/tests/src/test/resources/handler/classificationexists.windup.xml
+++ b/reporting/tests/src/test/resources/handler/classificationexists.windup.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<test xmlns="http://windup.jboss.org/schema/jboss-ruleset">
+
+    <classification-exists />
+    <classification-exists title="test-message"/>
+    <classification-exists title="test-message" in="test-in"/>
+
+</test>
+            

--- a/reporting/tests/src/test/resources/handler/hintexists.windup.xml
+++ b/reporting/tests/src/test/resources/handler/hintexists.windup.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<test xmlns="http://windup.jboss.org/schema/jboss-ruleset">
+
+    <hint-exists />
+    <hint-exists message="test-message"/>
+    <hint-exists message="test-message" in="test-in"/>
+
+</test>
+            

--- a/rules-java/tests/src/test/java/org/jboss/windup/rules/java/JavaClassWithoutClassificationTest.java
+++ b/rules-java/tests/src/test/java/org/jboss/windup/rules/java/JavaClassWithoutClassificationTest.java
@@ -1,0 +1,154 @@
+package org.jboss.windup.rules.java;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang.RandomStringUtils;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.forge.arquillian.AddonDependencies;
+import org.jboss.forge.arquillian.AddonDependency;
+import org.jboss.forge.arquillian.archive.AddonArchive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.windup.config.GraphRewrite;
+import org.jboss.windup.config.RuleLifecycleListener;
+import org.jboss.windup.exec.WindupProcessor;
+import org.jboss.windup.exec.configuration.WindupConfiguration;
+import org.jboss.windup.graph.GraphContext;
+import org.jboss.windup.graph.GraphContextFactory;
+import org.jboss.windup.graph.model.ProjectModel;
+import org.jboss.windup.graph.model.resource.FileModel;
+import org.jboss.windup.graph.service.GraphService;
+import org.jboss.windup.reporting.config.condition.ClassificationExists;
+import org.jboss.windup.reporting.config.condition.HintExists;
+import org.jboss.windup.reporting.model.ClassificationModel;
+import org.jboss.windup.rules.apps.java.config.ScanPackagesOption;
+import org.jboss.windup.rules.apps.java.scan.ast.JavaTypeReferenceModel;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.inject.Inject;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collections;
+
+/**
+ * Tests the javaclass condition along with classification-not-exists condition.
+ */
+@RunWith(Arquillian.class)
+public class JavaClassWithoutClassificationTest
+{
+    @Deployment
+    @AddonDependencies
+    public static AddonArchive getDeployment()
+    {
+        return ShrinkWrap.create(AddonArchive.class)
+                    .addBeansXML()
+                    .addAsResource("org/jboss/windup/rules/java/javaclass-withoutclassification.windup.xml");
+    }
+
+    @Inject
+    private WindupProcessor processor;
+
+    @Inject
+    private GraphContextFactory factory;
+
+    @Test
+    public void testJavaClassCondition() throws IOException, InstantiationException, IllegalAccessException
+    {
+        try (GraphContext context = factory.create(getDefaultPath()))
+        {
+            final String inputDir = "src/test/resources/org/jboss/windup/rules/java";
+
+            final Path outputPath = Paths.get(FileUtils.getTempDirectory().toString(),
+                        "windup_" + RandomStringUtils.randomAlphanumeric(6));
+            FileUtils.deleteDirectory(outputPath.toFile());
+            Files.createDirectories(outputPath);
+
+            ProjectModel pm = context.getFramed().addVertex(null, ProjectModel.class);
+            pm.setName("Main Project");
+
+            FileModel inputPathFrame = context.getFramed().addVertex(null, FileModel.class);
+            inputPathFrame.setFilePath(inputDir);
+            inputPathFrame.setProjectModel(pm);
+            pm.addFileModel(inputPathFrame);
+
+            pm.setRootFileModel(inputPathFrame);
+
+            FileModel fileModel = context.getFramed().addVertex(null, FileModel.class);
+            fileModel.setFilePath(inputDir + "/JavaClassTestFile1.java");
+            fileModel.setProjectModel(pm);
+            pm.addFileModel(fileModel);
+
+            fileModel = context.getFramed().addVertex(null, FileModel.class);
+            fileModel.setFilePath(inputDir + "/JavaClassTestFile2.java");
+            fileModel.setProjectModel(pm);
+            pm.addFileModel(fileModel);
+
+            context.getGraph().getBaseGraph().commit();
+
+            final WindupConfiguration processorConfig = new WindupConfiguration().setOutputDirectory(outputPath);
+            processorConfig.setGraphContext(context);
+            processorConfig.setInputPath(Paths.get(inputDir));
+            processorConfig.setOutputDirectory(outputPath);
+            processorConfig.setOptionValue(ScanPackagesOption.NAME, Collections.singletonList(""));
+
+            processor.execute(processorConfig);
+
+            GraphService<JavaTypeReferenceModel> typeRefService = new GraphService<>(context,
+                        JavaTypeReferenceModel.class);
+            Iterable<JavaTypeReferenceModel> typeReferences = typeRefService.findAll();
+
+            int count = 0;
+            for (JavaTypeReferenceModel ref : typeReferences)
+            {
+                String sourceSnippit = ref.getResolvedSourceSnippit();
+                Assert.assertTrue(sourceSnippit.contains("org.jboss.forge") || sourceSnippit.contains("org.jboss.windup.rules.java.JavaClassTestFile"));
+                count++;
+            }
+            Assert.assertEquals(6, count);
+
+            GraphService<ClassificationModel> classificationService = new GraphService<>(context, ClassificationModel.class);
+            Iterable<ClassificationModel> classifications = classificationService.findAll();
+
+            count = 0;
+            for (ClassificationModel cModel : classifications)
+            {
+                    count++;
+            }
+            Assert.assertEquals(2, count);
+
+            count = 0;
+            for (ClassificationModel cModel : classifications)
+            {
+                if (cModel.getClassification().contains("Rule1"))
+                    count++;
+            }
+            Assert.assertEquals(1, count);
+
+            count = 0;
+            for (ClassificationModel cModel : classifications)
+            {
+                if (cModel.getClassification().contains("Rule2"))
+                    count++;
+            }
+            Assert.assertEquals(0, count);
+
+            count = 0;
+            for (ClassificationModel cModel : classifications)
+            {
+                if (cModel.getClassification().contains("Rule3") && cModel.getFileModels().iterator().next().getFileName().contains("File1"))
+                    count++;
+            }
+            Assert.assertEquals(1, count);
+        }
+    }
+
+    private Path getDefaultPath()
+    {
+        return FileUtils.getTempDirectory().toPath().resolve("Windup")
+                    .resolve("windupgraph_javaclasstest_" + RandomStringUtils.randomAlphanumeric(6));
+    }
+}

--- a/rules-java/tests/src/test/java/org/jboss/windup/rules/java/JavaClassWithoutHintTest.java
+++ b/rules-java/tests/src/test/java/org/jboss/windup/rules/java/JavaClassWithoutHintTest.java
@@ -1,0 +1,146 @@
+package org.jboss.windup.rules.java;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang.RandomStringUtils;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.forge.arquillian.AddonDependencies;
+import org.jboss.forge.arquillian.AddonDependency;
+import org.jboss.forge.arquillian.archive.AddonArchive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.windup.exec.WindupProcessor;
+import org.jboss.windup.exec.configuration.WindupConfiguration;
+import org.jboss.windup.graph.GraphContext;
+import org.jboss.windup.graph.GraphContextFactory;
+import org.jboss.windup.graph.model.ProjectModel;
+import org.jboss.windup.graph.model.resource.FileModel;
+import org.jboss.windup.graph.service.GraphService;
+import org.jboss.windup.reporting.model.InlineHintModel;
+import org.jboss.windup.rules.apps.java.config.ScanPackagesOption;
+import org.jboss.windup.rules.apps.java.scan.ast.JavaTypeReferenceModel;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.inject.Inject;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collections;
+
+/**
+ * Tests the javaclass condition along with hint-not-exists condition.
+ */
+@RunWith(Arquillian.class)
+public class JavaClassWithoutHintTest
+{
+    @Deployment
+    @AddonDependencies
+    public static AddonArchive getDeployment()
+    {
+        return ShrinkWrap.create(AddonArchive.class)
+                    .addBeansXML()
+                    .addAsResource("org/jboss/windup/rules/java/javaclass-withouthint.windup.xml");
+    }
+
+    @Inject
+    private WindupProcessor processor;
+
+    @Inject
+    private GraphContextFactory factory;
+
+    @Test
+    public void testJavaClassCondition() throws IOException, InstantiationException, IllegalAccessException
+    {
+        try (GraphContext context = factory.create(getDefaultPath()))
+        {
+            final String inputDir = "src/test/resources/org/jboss/windup/rules/java";
+
+            final Path outputPath = Paths.get(FileUtils.getTempDirectory().toString(),
+                        "windup_" + RandomStringUtils.randomAlphanumeric(6));
+            FileUtils.deleteDirectory(outputPath.toFile());
+            Files.createDirectories(outputPath);
+
+            ProjectModel pm = context.getFramed().addVertex(null, ProjectModel.class);
+            pm.setName("Main Project");
+
+            FileModel inputPathFrame = context.getFramed().addVertex(null, FileModel.class);
+            inputPathFrame.setFilePath(inputDir);
+            inputPathFrame.setProjectModel(pm);
+            pm.addFileModel(inputPathFrame);
+
+            pm.setRootFileModel(inputPathFrame);
+
+            FileModel fileModel = context.getFramed().addVertex(null, FileModel.class);
+            fileModel.setFilePath(inputDir + "/JavaClassTestFile1.java");
+            fileModel.setProjectModel(pm);
+            pm.addFileModel(fileModel);
+
+            fileModel = context.getFramed().addVertex(null, FileModel.class);
+            fileModel.setFilePath(inputDir + "/JavaClassTestFile2.java");
+            fileModel.setProjectModel(pm);
+            pm.addFileModel(fileModel);
+
+            context.getGraph().getBaseGraph().commit();
+
+            final WindupConfiguration processorConfig = new WindupConfiguration().setOutputDirectory(outputPath);
+            processorConfig.setGraphContext(context);
+            processorConfig.setInputPath(Paths.get(inputDir));
+            processorConfig.setOutputDirectory(outputPath);
+            processorConfig.setOptionValue(ScanPackagesOption.NAME, Collections.singletonList(""));
+
+            processor.execute(processorConfig);
+
+            GraphService<JavaTypeReferenceModel> typeRefService = new GraphService<>(context,
+                        JavaTypeReferenceModel.class);
+            Iterable<JavaTypeReferenceModel> typeReferences = typeRefService.findAll();
+
+            int count = 0;
+            for (JavaTypeReferenceModel ref : typeReferences)
+            {
+                String sourceSnippit = ref.getResolvedSourceSnippit();
+                Assert.assertTrue(sourceSnippit.contains("org.jboss.forge") || sourceSnippit.contains("org.jboss.windup.rules.java.JavaClassTestFile"));
+                count++;
+            }
+            Assert.assertEquals(6, count);
+
+            GraphService<InlineHintModel> hintService = new GraphService<>(context, InlineHintModel.class);
+            Iterable<InlineHintModel> hints = hintService.findAll();
+
+            count = 0;
+            for (InlineHintModel hint : hints)
+            {
+                if (hint.getHint().contains("Rule1"))
+                    count++;
+            }
+            Assert.assertEquals(1, count);
+
+            count = 0;
+            for (InlineHintModel hint : hints)
+            {
+                if (hint.getHint().contains("Rule2"))
+                {
+
+                    if (hint.getFileLocationReference().getSourceSnippit().contains("org.jboss.forge.furnace.util.Callables"))
+                    {
+                        count++;
+                    }
+                    else
+                    {
+                        Assert.fail("Catch-all hint should not be registered for locations that already contain hint");
+                    }
+                }
+
+            }
+            Assert.assertEquals(1, count);
+
+        }
+    }
+
+    private Path getDefaultPath()
+    {
+        return FileUtils.getTempDirectory().toPath().resolve("Windup")
+                    .resolve("windupgraph_javaclasstest_" + RandomStringUtils.randomAlphanumeric(6));
+    }
+}

--- a/rules-java/tests/src/test/resources/org/jboss/windup/rules/java/JavaClassXmlRulesTest.windup.xml
+++ b/rules-java/tests/src/test/resources/org/jboss/windup/rules/java/JavaClassXmlRulesTest.windup.xml
@@ -28,5 +28,6 @@
                 </hint>
             </perform>
         </rule>
+
     </rules>
 </ruleset>

--- a/rules-java/tests/src/test/resources/org/jboss/windup/rules/java/javaclass-withoutclassification.windup.xml
+++ b/rules-java/tests/src/test/resources/org/jboss/windup/rules/java/javaclass-withoutclassification.windup.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0"?>
+<ruleset xmlns="http://windup.jboss.org/schema/jboss-ruleset" id="xmltestrules_1">
+    <rules>
+        <!-- Hint-exists tests -->
+        <rule>
+            <when>
+                <javaclass references="org.jboss.forge.furnace.repositories.AddonDependencyEntry" in="{*}File2">
+                    <location>IMPORT</location>
+                </javaclass>
+            </when>
+            <perform>
+                <classification title="Rule1">
+                    <link href="http://example.com" description="Description from XML Hint Link"/>
+                </classification>
+            </perform>
+        </rule>
+
+        <rule>
+            <when>
+                <javaclass references="org.jboss.forge.{*}" in="{*}File2">
+                    <location>IMPORT</location>
+                </javaclass>
+                <classification-not-exists/>
+            </when>
+            <perform>
+                <classification title="Rule2 catch-all">
+                    <link href="http://example.com" description="Description from XML Hint Link"/>
+                </classification>
+            </perform>
+        </rule>
+
+        <rule>
+            <when>
+                <javaclass references="org.jboss.forge.{*}" in="{*}File1">
+                    <location>IMPORT</location>
+                </javaclass>
+                <classification-not-exists/>
+            </when>
+            <perform>
+                <classification title="Rule3 catch-all">
+                    <link href="http://example.com" description="Description from XML Hint Link"/>
+                </classification>
+            </perform>
+        </rule>
+
+    </rules>
+</ruleset>

--- a/rules-java/tests/src/test/resources/org/jboss/windup/rules/java/javaclass-withouthint.windup.xml
+++ b/rules-java/tests/src/test/resources/org/jboss/windup/rules/java/javaclass-withouthint.windup.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0"?>
+<ruleset xmlns="http://windup.jboss.org/schema/jboss-ruleset" id="xmltestrules_1">
+<rules>
+    <!-- Hint-exists tests -->
+    <rule>
+        <when>
+            <javaclass references="org.jboss.forge.furnace.repositories.AddonDependencyEntry" in="{*}File2" as="testVariable">
+                <location>IMPORT</location>
+            </javaclass>
+        </when>
+        <perform>
+            <iteration over="testVariable">
+                <hint in="testVariable_instance" message="Rule1">
+                    <link href="http://example.com" description="Description from XML Hint Link"/>
+                </hint>
+            </iteration>
+        </perform>
+    </rule>
+
+    <rule>
+        <when>
+            <javaclass references="org.jboss.forge.{*}" in="{*}File2">
+                <location>IMPORT</location>
+            </javaclass>
+            <hint-not-exists/>
+        </when>
+        <perform>
+            <hint message="Rule2 catch-all">
+                <link href="http://example.com" description="Description from XML Hint Link"/>
+            </hint>
+        </perform>
+    </rule>
+
+</rules>
+</ruleset>

--- a/rules-xml/tests/src/test/java/org/jboss/windup/rules/xml/XMLFileWithoutClassification1Test.java
+++ b/rules-xml/tests/src/test/java/org/jboss/windup/rules/xml/XMLFileWithoutClassification1Test.java
@@ -1,0 +1,118 @@
+package org.jboss.windup.rules.xml;
+
+import org.apache.commons.io.FileUtils;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.forge.arquillian.AddonDependency;
+import org.jboss.forge.arquillian.Dependencies;
+import org.jboss.forge.arquillian.archive.ForgeArchive;
+import org.jboss.forge.furnace.repositories.AddonDependencyEntry;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.windup.config.phase.ReportGenerationPhase;
+import org.jboss.windup.config.phase.ReportRenderingPhase;
+import org.jboss.windup.exec.WindupProcessor;
+import org.jboss.windup.exec.configuration.WindupConfiguration;
+import org.jboss.windup.exec.rulefilters.NotPredicate;
+import org.jboss.windup.exec.rulefilters.RuleProviderPhasePredicate;
+import org.jboss.windup.graph.GraphContext;
+import org.jboss.windup.graph.GraphContextFactory;
+import org.jboss.windup.graph.service.GraphService;
+import org.jboss.windup.reporting.config.classification.Classification;
+import org.jboss.windup.reporting.model.ClassificationModel;
+import org.jboss.windup.rules.apps.xml.model.XsltTransformationModel;
+import org.jboss.windup.rules.apps.xml.service.XsltTransformationService;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.inject.Inject;
+import java.io.BufferedReader;
+import java.io.FileReader;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Iterator;
+import java.util.UUID;
+
+@RunWith(Arquillian.class)
+public class XMLFileWithoutClassification1Test
+{
+
+    private static final String SIMPLE_XSLT_XSL = "simpleXSLT.xsl";
+    private static final String XSLT_EXTENSION = "-test-result.html";
+
+    @Deployment
+    @Dependencies({
+                @AddonDependency(name = "org.jboss.windup.config:windup-config"),
+                @AddonDependency(name = "org.jboss.windup.exec:windup-exec"),
+                @AddonDependency(name = "org.jboss.windup.rules.apps:windup-rules-java"),
+                @AddonDependency(name = "org.jboss.windup.rules.apps:windup-rules-xml"),
+                @AddonDependency(name = "org.jboss.windup.reporting:windup-reporting"),
+                @AddonDependency(name = "org.jboss.forge.furnace.container:cdi")
+    })
+    public static ForgeArchive getDeployment()
+    {
+        final ForgeArchive archive = ShrinkWrap.create(ForgeArchive.class)
+                    .addBeansXML()
+                    .addAsResource("simpleXSLT.xsl")
+                    .addAsResource("xmlfile-withoutclassification.windup.xml")
+                    .addAsAddonDependencies(
+                                AddonDependencyEntry.create("org.jboss.windup.config:windup-config"),
+                                AddonDependencyEntry.create("org.jboss.windup.exec:windup-exec"),
+                                AddonDependencyEntry.create("org.jboss.windup.rules.apps:windup-rules-java"),
+                                AddonDependencyEntry.create("org.jboss.windup.rules.apps:windup-rules-xml"),
+                                AddonDependencyEntry.create("org.jboss.windup.reporting:windup-reporting"),
+                                AddonDependencyEntry.create("org.jboss.forge.furnace.container:cdi")
+                    );
+        return archive;
+    }
+
+    @Inject
+    private WindupProcessor processor;
+
+    @Inject
+    private GraphContextFactory factory;
+
+    @Test
+    public void testXSLTTransformation() throws IOException
+    {
+        try (GraphContext context = factory.create())
+        {
+            Path inputPath = Paths.get("src/test/resources/");
+
+            Path outputPath = Paths.get(FileUtils.getTempDirectory().toString(), "windup_"
+                        + UUID.randomUUID().toString());
+            FileUtils.deleteDirectory(outputPath.toFile());
+            Files.createDirectories(outputPath);
+
+
+            WindupConfiguration windupConfiguration = new WindupConfiguration()
+                        .setRuleProviderFilter(
+                                    new NotPredicate(new RuleProviderPhasePredicate(ReportGenerationPhase.class, ReportRenderingPhase.class)))
+                        .setGraphContext(context);
+            windupConfiguration.setInputPath(inputPath);
+            windupConfiguration.setOutputDirectory(outputPath);
+            processor.execute(windupConfiguration);
+
+            GraphService<ClassificationModel> classificationService = new GraphService<>(context, ClassificationModel.class);
+            int count = 0;
+
+            for (ClassificationModel classificationModel : classificationService.findAll())
+            {
+                if(classificationModel.getClassification().contains("rule1")) {
+                    count++;
+                }
+            }
+            Assert.assertEquals(1,count);
+            count = 0;
+            for (ClassificationModel classificationModel : classificationService.findAll())
+            {
+                if(classificationModel.getClassification().contains("rule2")) {
+                    count++;
+                }
+            }
+            Assert.assertEquals(0,count);
+        }
+    }
+}

--- a/rules-xml/tests/src/test/java/org/jboss/windup/rules/xml/XMLFileWithoutClassification2Test.java
+++ b/rules-xml/tests/src/test/java/org/jboss/windup/rules/xml/XMLFileWithoutClassification2Test.java
@@ -1,0 +1,103 @@
+package org.jboss.windup.rules.xml;
+
+import org.apache.commons.io.FileUtils;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.forge.arquillian.AddonDependency;
+import org.jboss.forge.arquillian.Dependencies;
+import org.jboss.forge.arquillian.archive.ForgeArchive;
+import org.jboss.forge.furnace.repositories.AddonDependencyEntry;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.windup.config.phase.ReportGenerationPhase;
+import org.jboss.windup.config.phase.ReportRenderingPhase;
+import org.jboss.windup.exec.WindupProcessor;
+import org.jboss.windup.exec.configuration.WindupConfiguration;
+import org.jboss.windup.exec.rulefilters.NotPredicate;
+import org.jboss.windup.exec.rulefilters.RuleProviderPhasePredicate;
+import org.jboss.windup.graph.GraphContext;
+import org.jboss.windup.graph.GraphContextFactory;
+import org.jboss.windup.graph.service.GraphService;
+import org.jboss.windup.reporting.model.ClassificationModel;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.inject.Inject;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.UUID;
+
+@RunWith(Arquillian.class)
+public class XMLFileWithoutClassification2Test
+{
+
+    private static final String SIMPLE_XSLT_XSL = "simpleXSLT.xsl";
+    private static final String XSLT_EXTENSION = "-test-result.html";
+
+    @Deployment
+    @Dependencies({
+                @AddonDependency(name = "org.jboss.windup.config:windup-config"),
+                @AddonDependency(name = "org.jboss.windup.exec:windup-exec"),
+                @AddonDependency(name = "org.jboss.windup.rules.apps:windup-rules-java"),
+                @AddonDependency(name = "org.jboss.windup.rules.apps:windup-rules-xml"),
+                @AddonDependency(name = "org.jboss.windup.reporting:windup-reporting"),
+                @AddonDependency(name = "org.jboss.forge.furnace.container:cdi")
+    })
+    public static ForgeArchive getDeployment()
+    {
+        final ForgeArchive archive = ShrinkWrap.create(ForgeArchive.class)
+                    .addBeansXML()
+                    .addAsResource("simpleXSLT.xsl")
+                    .addAsResource("xmlfile-withoutclassification2.windup.xml")
+                    .addAsAddonDependencies(
+                                AddonDependencyEntry.create("org.jboss.windup.config:windup-config"),
+                                AddonDependencyEntry.create("org.jboss.windup.exec:windup-exec"),
+                                AddonDependencyEntry.create("org.jboss.windup.rules.apps:windup-rules-java"),
+                                AddonDependencyEntry.create("org.jboss.windup.rules.apps:windup-rules-xml"),
+                                AddonDependencyEntry.create("org.jboss.windup.reporting:windup-reporting"),
+                                AddonDependencyEntry.create("org.jboss.forge.furnace.container:cdi")
+                    );
+        return archive;
+    }
+
+    @Inject
+    private WindupProcessor processor;
+
+    @Inject
+    private GraphContextFactory factory;
+
+    @Test
+    public void testXmlFileWithoutClassification() throws IOException
+    {
+        try (GraphContext context = factory.create())
+        {
+            Path inputPath = Paths.get("src/test/resources/");
+
+            Path outputPath = Paths.get(FileUtils.getTempDirectory().toString(), "windup_"
+                        + UUID.randomUUID().toString());
+            FileUtils.deleteDirectory(outputPath.toFile());
+            Files.createDirectories(outputPath);
+
+
+            WindupConfiguration windupConfiguration = new WindupConfiguration()
+                        .setRuleProviderFilter(
+                                    new NotPredicate(new RuleProviderPhasePredicate(ReportGenerationPhase.class, ReportRenderingPhase.class)))
+                        .setGraphContext(context);
+            windupConfiguration.setInputPath(inputPath);
+            windupConfiguration.setOutputDirectory(outputPath);
+            processor.execute(windupConfiguration);
+
+            GraphService<ClassificationModel> classificationService = new GraphService<>(context, ClassificationModel.class);
+            int count = 0;
+            for (ClassificationModel classificationModel : classificationService.findAll())
+            {
+                if(classificationModel.getClassification().contains("rule1")) {
+                    count++;
+                }
+            }
+            Assert.assertEquals(1,count);
+        }
+    }
+}

--- a/rules-xml/tests/src/test/resources/jonas-example.xml
+++ b/rules-xml/tests/src/test/resources/jonas-example.xml
@@ -1,0 +1,9 @@
+<!DOCTYPE jonas-web-app PUBLIC "-//ObjectWeb//DTD JOnAS Web App 3.1//EN"
+        "http://www.objectweb.org/jonas/dtds/jonas-web-app_3_1.dtd">
+<something>
+    <something2>
+        <something3>
+        </something3>
+    </something2>
+</something>
+

--- a/rules-xml/tests/src/test/resources/xmlfile-withoutclassification.windup.xml
+++ b/rules-xml/tests/src/test/resources/xmlfile-withoutclassification.windup.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<ruleset xmlns="http://windup.jboss.org/schema/jboss-ruleset" id="xmltestrules_1">
+    <rules>
+        <rule id="XmlJonasRules_2fmb">
+            <when>
+                <xmlfile as="default" public-id=".+JOnAS Web App.+">
+                </xmlfile>
+            </when>
+            <perform>
+                <iteration>
+                    <classification title="rule1" effort="0"/>
+                </iteration>
+            </perform>
+        </rule>
+        <rule>
+            <when>
+                <xmlfile as="default" public-id=".+JOnAS Web App.+">
+                </xmlfile>
+                <classification-not-exists/>
+            </when>
+            <perform>
+                <classification title="rule2"/>
+            </perform>
+        </rule>
+    </rules>
+</ruleset>

--- a/rules-xml/tests/src/test/resources/xmlfile-withoutclassification2.windup.xml
+++ b/rules-xml/tests/src/test/resources/xmlfile-withoutclassification2.windup.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<ruleset xmlns="http://windup.jboss.org/schema/jboss-ruleset" id="xmltestrules_1">
+    <rules>
+        <rule id="XmlJonasRules_2fmb">
+            <when>
+                <xmlfile as="default" public-id=".+JOnAS Web App.+">
+                </xmlfile>
+            </when>
+            <perform>
+                <iteration>
+                    <classification title="rule1" effort="0"/>
+                </iteration>
+            </perform>
+        </rule>
+    </rules>
+</ruleset>


### PR DESCRIPTION
**Idea**: Introduce **hint-exists** element that could follow the **javaclass** condition and filter out all the filelocations that do have/ doesn't have any hint(/hint with the given message). The same then can go for the classification-exist. The current PR already **contains working** hint-exists condition.

**Changes**: I introduced a new graphcondition that would be just filtering the input to output. This is exactly what is needed for these conditions, because they will be filtering the javaclass output to only output the vertices without hints/classifications etc. In case this condition is the first one in a row, there is fillIn() method that will load vertices that are going to be filtered. This is useful for tests when checking that there is no hint registered with the given message.

**Found problems**: It is not easy to create a condition that does exactly the opposite. For example, having hint-exists that returns only the locations with hints, there is not an easy way how to negate this behaviour without introducing another condition hint-not-exists. 
We have 2 solutions:
1) introduce new condition for every negation of every filter. Maybe some other groups except not like empty/all may be useful also in the future. **For now, taken this approach.**
2) Change the way conditions work. Make it more stream-like by every condition having from="" set by the RuleSubset class.Or at least this should work internally for the filters. Then we could implement also a filter not, that would bundle multiple filters (with general conditions there is a problem that input type may be different than output type) and return Set(input) - Set(output)