### PR TITLE
Validate XSD on build.

### DIFF
--- a/config-xml/pom.xml
+++ b/config-xml/pom.xml
@@ -28,6 +28,7 @@
                 <version>1.0</version>
                 <executions>
                     <execution>
+                        <inherited>false</inherited>
                         <goals>
                             <goal>validate</goal>
                         </goals>
@@ -38,9 +39,9 @@
                     <validationSets>
                         <validationSet>
                             <includes>
-                                <include>dummy.xml</include>
+                                <include>**/*.xml</include>
                             </includes>
-                            <dir>schema</dir>
+                            <dir>src/test/resources</dir>
                             <systemId>schema/windup-jboss-ruleset.xsd</systemId>
                         </validationSet>
                     </validationSets>

--- a/config-xml/pom.xml
+++ b/config-xml/pom.xml
@@ -18,4 +18,35 @@
         <module>addon</module>
         <module>tests</module>
     </modules>
+
+    <build>
+        <plugins>
+            <!-- Validate the XSD. -->
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>xml-maven-plugin</artifactId>
+                <version>1.0</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>validate</goal>
+                        </goals>
+                        <phase>process-resources</phase>
+                    </execution>
+                </executions>
+                <configuration>
+                    <validationSets>
+                        <validationSet>
+                            <includes>
+                                <include>dummy.xml</include>
+                            </includes>
+                            <dir>schema</dir>
+                            <systemId>schema/windup-jboss-ruleset.xsd</systemId>
+                        </validationSet>
+                    </validationSets>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>

--- a/config-xml/src/test/resources/test-ruleset.windup.xml
+++ b/config-xml/src/test/resources/test-ruleset.windup.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ruleset id="websphere-mq"
+        xmlns="http://windup.jboss.org/schema/jboss-ruleset"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://windup.jboss.org/schema/jboss-ruleset http://windup.jboss.org/schema/jboss-ruleset/windup-jboss-ruleset.xsd">
+
+    <metadata>
+        <description>
+            Provides analysis of WebSphere JMS proprietary classes and constructs that may require individual attention when migrating to JBoss EAP 6+.
+        </description>
+        <dependencies>
+            <addon id="org.jboss.windup.rules,windup-rules-javaee,2.2.0.Final"/>
+            <addon id="org.jboss.windup.rules,windup-rules-java,2.2.0.Final"/>
+        </dependencies>
+    </metadata>
+    <rules></rules>
+</ruleset>


### PR DESCRIPTION
While editing the XSD schema, this comes handy - one can validate the XSD just by running the build.