### PR TITLE
WINDUP-670: Make Rexster more convenient to use

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -4,7 +4,7 @@
 
     <properties>
         <version.forge>2.16.2.Final</version.forge>
-        <version.furnace>2.18.2.Final</version.furnace>
+        <version.furnace>2.19.0.Final</version.furnace>
         <version.nexus.index>3</version.nexus.index>
     </properties>
 

--- a/config-groovy/tests/pom.xml
+++ b/config-groovy/tests/pom.xml
@@ -39,14 +39,10 @@
 
         <!-- Test Dependencies -->
         <dependency>
-            <groupId>org.jboss.forge.furnace.test</groupId>
-            <artifactId>furnace-test-harness</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.forge.furnace.test</groupId>
-            <artifactId>arquillian-furnace-classpath</artifactId>
-            <scope>test</scope>
-        </dependency>
+                <groupId>org.jboss.windup</groupId>
+                <artifactId>windup-test-harness</artifactId>
+                <version>${project.version}</version>
+		<scope>test</scope>
+        </dependency>  
     </dependencies>
 </project>

--- a/config-xml/tests/pom.xml
+++ b/config-xml/tests/pom.xml
@@ -47,15 +47,11 @@
 
         <!-- Test Dependencies -->
         <dependency>
-            <groupId>org.jboss.forge.furnace.test</groupId>
-            <artifactId>furnace-test-harness</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.forge.furnace.test</groupId>
-            <artifactId>arquillian-furnace-classpath</artifactId>
-            <scope>test</scope>
-        </dependency>
+                <groupId>org.jboss.windup</groupId>
+                <artifactId>windup-test-harness</artifactId>
+                <version>${project.version}</version>
+		<scope>test</scope>
+        </dependency>  
 
     </dependencies>
 </project>

--- a/config/tests/pom.xml
+++ b/config/tests/pom.xml
@@ -54,14 +54,10 @@
 
         <!-- Test Dependencies -->
         <dependency>
-            <groupId>org.jboss.forge.furnace.test</groupId>
-            <artifactId>furnace-test-harness</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.forge.furnace.test</groupId>
-            <artifactId>arquillian-furnace-classpath</artifactId>
-            <scope>test</scope>
-        </dependency>
+                <groupId>org.jboss.windup</groupId>
+                <artifactId>windup-test-harness</artifactId>
+                <version>${project.version}</version>
+		<scope>test</scope>
+        </dependency>  
     </dependencies>
 </project>

--- a/exec/tests/pom.xml
+++ b/exec/tests/pom.xml
@@ -37,14 +37,10 @@
 
         <!-- Test Dependencies -->
         <dependency>
-            <groupId>org.jboss.forge.furnace.test</groupId>
-            <artifactId>furnace-test-harness</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.forge.furnace.test</groupId>
-            <artifactId>arquillian-furnace-classpath</artifactId>
-            <scope>test</scope>
-        </dependency>
+                <groupId>org.jboss.windup</groupId>
+                <artifactId>windup-test-harness</artifactId>
+                <version>${project.version}</version>
+		<scope>test</scope>
+        </dependency>  
     </dependencies>
 </project>

--- a/graph/tests/pom.xml
+++ b/graph/tests/pom.xml
@@ -47,15 +47,11 @@
 
         <!-- Test Dependencies -->
         <dependency>
-            <groupId>org.jboss.forge.furnace.test</groupId>
-            <artifactId>furnace-test-harness</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.forge.furnace.test</groupId>
-            <artifactId>arquillian-furnace-classpath</artifactId>
-            <scope>test</scope>
-        </dependency>
+                <groupId>org.jboss.windup</groupId>
+                <artifactId>windup-test-harness</artifactId>
+                <version>${project.version}</version>
+		<scope>test</scope>
+        </dependency>  
 
     </dependencies>
 </project>

--- a/java-ast/tests/pom.xml
+++ b/java-ast/tests/pom.xml
@@ -31,16 +31,12 @@
         </dependency>
 
         <!-- Test Dependencies -->
-        <dependency>
-            <groupId>org.jboss.forge.furnace.test</groupId>
-            <artifactId>furnace-test-harness</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.forge.furnace.test</groupId>
-            <artifactId>arquillian-furnace-classpath</artifactId>
-            <scope>test</scope>
-        </dependency>
+       <dependency>
+                <groupId>org.jboss.windup</groupId>
+                <artifactId>windup-test-harness</artifactId>
+                <version>${project.version}</version>
+		<scope>test</scope>
+        </dependency>  
         <dependency>
             <groupId>org.jboss.windup.exec</groupId>
             <artifactId>windup-exec</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,7 @@
 
     <modules>
         <module>bom</module>
+	<module>windup-test-harness</module>
         <module>forks/fernflower</module>
         <module>forks/frames</module>
         <module>forks/procyon</module>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     <description>Migration Tools</description>
 
     <properties>
-        <version.furnace>2.18.2.Final</version.furnace>
+        <version.furnace>2.19.0.Final</version.furnace>
         <version.titangraph>0.5.4</version.titangraph>
         <version.tinkerpop.blueprints>2.5.0</version.tinkerpop.blueprints>
         <version.freemarker>2.3.23</version.freemarker>

--- a/reporting/tests/pom.xml
+++ b/reporting/tests/pom.xml
@@ -62,15 +62,11 @@
 
         <!-- Test Dependencies -->
         <dependency>
-            <groupId>org.jboss.forge.furnace.test</groupId>
-            <artifactId>furnace-test-harness</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.forge.furnace.test</groupId>
-            <artifactId>arquillian-furnace-classpath</artifactId>
-            <scope>test</scope>
-        </dependency>
+                <groupId>org.jboss.windup</groupId>
+                <artifactId>windup-test-harness</artifactId>
+                <version>${project.version}</version>
+		<scope>test</scope>
+        </dependency>  
           <dependency>
             <groupId>org.jboss.windup.utils</groupId>
             <artifactId>windup-utils</artifactId>

--- a/rexster/tests/pom.xml
+++ b/rexster/tests/pom.xml
@@ -34,13 +34,9 @@
 
         <!-- Test Dependencies -->
         <dependency>
-            <groupId>org.jboss.forge.furnace.test</groupId>
-            <artifactId>furnace-test-harness</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.forge.furnace.test</groupId>
-            <artifactId>arquillian-furnace-classpath</artifactId>
+            <groupId>org.jboss.windup</groupId>
+            <artifactId>windup-test-harness</artifactId>
+            <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/rexster/tests/src/test/java/org/jboss/windup/graph/rexster/test/debug/RexsterDefaultDeploymentDebugTest.java
+++ b/rexster/tests/src/test/java/org/jboss/windup/graph/rexster/test/debug/RexsterDefaultDeploymentDebugTest.java
@@ -1,0 +1,74 @@
+package org.jboss.windup.graph.rexster.test.debug;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.forge.arquillian.AddonDependencies;
+import org.jboss.forge.arquillian.AddonDependency;
+import org.jboss.forge.arquillian.archive.AddonArchive;
+import org.jboss.forge.furnace.Furnace;
+import org.jboss.forge.furnace.services.Imported;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.windup.config.furnace.FurnaceHolder;
+import org.jboss.windup.graph.GraphContext;
+import org.jboss.windup.graph.GraphContextFactory;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.io.IOException;
+import java.net.Socket;
+
+/**
+ * Tests that rexster is properly deployed thanks to Arquillian addon
+ */
+@RunWith(Arquillian.class)
+public class RexsterDefaultDeploymentDebugTest
+{
+    @Deployment
+    @AddonDependencies({
+                @AddonDependency(name = "org.jboss.windup.config:windup-config"),
+                @AddonDependency(name = "org.jboss.windup.graph:windup-graph"),
+                @AddonDependency(name = "org.jboss.forge.furnace.container:simple")
+    })
+    public static AddonArchive getDeployment()
+    {
+        System.setProperty("maven.surefire.debug", "true");
+        final AddonArchive archive = ShrinkWrap.create(AddonArchive.class)
+                    .addAsLocalServices(RexsterDefaultDeploymentDebugTest.class);
+
+        return archive;
+    }
+
+    @Test
+    public void testRexsterProperStart() throws IOException, InstantiationException, IllegalAccessException
+    {
+        Furnace furnace = FurnaceHolder.getFurnace();
+        Imported<GraphContextFactory> factory = furnace.getAddonRegistry().getServices(GraphContextFactory.class);
+        //GraphContext creation will start the rexster
+        try (GraphContext context = factory.get().create())
+        {
+            Socket s = null;
+            try
+            {
+                s = new Socket("localhost", 8182);
+            }
+            catch (Exception e)
+            {
+                Assert.fail("Rexster is not listening on localhost:8182");
+            }
+            finally
+            {
+                if (s != null)
+                    try
+                    {
+                        s.close();
+                    }
+                    catch (Exception e)
+                    {
+                    }
+            }
+
+        }
+
+    }
+}

--- a/rexster/tests/src/test/java/org/jboss/windup/graph/rexster/test/debug/RexsterDefaultDeploymentNoDebugTest.java
+++ b/rexster/tests/src/test/java/org/jboss/windup/graph/rexster/test/debug/RexsterDefaultDeploymentNoDebugTest.java
@@ -1,0 +1,70 @@
+package org.jboss.windup.graph.rexster.test.debug;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.forge.arquillian.AddonDependencies;
+import org.jboss.forge.arquillian.AddonDependency;
+import org.jboss.forge.arquillian.archive.AddonArchive;
+import org.jboss.forge.furnace.Furnace;
+import org.jboss.forge.furnace.services.Imported;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.windup.config.furnace.FurnaceHolder;
+import org.jboss.windup.graph.GraphContext;
+import org.jboss.windup.graph.GraphContextFactory;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.io.IOException;
+import java.net.ConnectException;
+import java.net.Socket;
+
+/**
+ * Tests that rexster is not deployed by Arquillian addon in case debug mode is OFF.
+ */
+@RunWith(Arquillian.class)
+public class RexsterDefaultDeploymentNoDebugTest
+{
+    @Deployment
+    @AddonDependencies({
+                @AddonDependency(name = "org.jboss.windup.config:windup-config"),
+                @AddonDependency(name = "org.jboss.windup.graph:windup-graph"),
+                @AddonDependency(name = "org.jboss.forge.furnace.container:simple")
+    })
+    public static AddonArchive getDeployment()
+    {
+        final AddonArchive archive = ShrinkWrap.create(AddonArchive.class)
+                    .addAsLocalServices(RexsterDefaultDeploymentNoDebugTest.class);
+
+        return archive;
+    }
+
+    @Test(expected = ConnectException.class)
+    public void testRexsterProperStart() throws IOException, InstantiationException, IllegalAccessException
+    {
+        Furnace furnace = FurnaceHolder.getFurnace();
+        Imported<GraphContextFactory> factory = furnace.getAddonRegistry().getServices(GraphContextFactory.class);
+        try (GraphContext context = factory.get().create())
+        {
+            Socket s = null;
+            try
+            {
+                s = new Socket("localhost", 8182);
+                Assert.fail("Rexster should not be registered when not in debug mode.");
+            }
+            finally
+            {
+                if (s != null)
+                    try
+                    {
+                        s.close();
+                    }
+                    catch (Exception e)
+                    {
+                    }
+            }
+
+        }
+
+    }
+}

--- a/rules-base/tests/pom.xml
+++ b/rules-base/tests/pom.xml
@@ -72,14 +72,10 @@
 
         <!-- Test Dependencies -->
         <dependency>
-            <groupId>org.jboss.forge.furnace.test</groupId>
-            <artifactId>furnace-test-harness</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.forge.furnace.test</groupId>
-            <artifactId>arquillian-furnace-classpath</artifactId>
-            <scope>test</scope>
-        </dependency>
+                <groupId>org.jboss.windup</groupId>
+                <artifactId>windup-test-harness</artifactId>
+                <version>${project.version}</version>
+		<scope>test</scope>
+        </dependency>  
     </dependencies>
 </project>

--- a/rules-java-archives/tests/pom.xml
+++ b/rules-java-archives/tests/pom.xml
@@ -30,15 +30,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.jboss.forge.furnace.test</groupId>
-            <artifactId>furnace-test-harness</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.forge.furnace.test</groupId>
-            <artifactId>arquillian-furnace-classpath</artifactId>
-            <scope>test</scope>
-        </dependency>
+                <groupId>org.jboss.windup</groupId>
+                <artifactId>windup-test-harness</artifactId>
+                <version>${project.version}</version>
+		<scope>test</scope>
+        </dependency>  
         <dependency>
             <groupId>org.jboss.windup.exec</groupId>
             <artifactId>windup-exec</artifactId>

--- a/rules-java-ee/tests/pom.xml
+++ b/rules-java-ee/tests/pom.xml
@@ -37,15 +37,11 @@
 
         <!-- Test Dependencies -->
         <dependency>
-            <groupId>org.jboss.forge.furnace.test</groupId>
-            <artifactId>furnace-test-harness</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.forge.furnace.test</groupId>
-            <artifactId>arquillian-furnace-classpath</artifactId>
-            <scope>test</scope>
-        </dependency>
+                <groupId>org.jboss.windup</groupId>
+                <artifactId>windup-test-harness</artifactId>
+                <version>${project.version}</version>
+		<scope>test</scope>
+        </dependency>  
         <dependency>
             <groupId>org.jboss.windup.exec</groupId>
             <artifactId>windup-exec</artifactId>

--- a/rules-java-project/tests/pom.xml
+++ b/rules-java-project/tests/pom.xml
@@ -60,15 +60,11 @@
 
         <!-- Test Dependencies -->
         <dependency>
-            <groupId>org.jboss.forge.furnace.test</groupId>
-            <artifactId>furnace-test-harness</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.forge.furnace.test</groupId>
-            <artifactId>arquillian-furnace-classpath</artifactId>
-            <scope>test</scope>
-        </dependency>
+                <groupId>org.jboss.windup</groupId>
+                <artifactId>windup-test-harness</artifactId>
+                <version>${project.version}</version>
+		<scope>test</scope>
+        </dependency>  
         <dependency>
             <groupId>org.jboss.windup.exec</groupId>
             <artifactId>windup-exec</artifactId>

--- a/rules-java/addon/pom.xml
+++ b/rules-java/addon/pom.xml
@@ -110,15 +110,11 @@
 
         <!-- Test Dependencies -->
         <dependency>
-            <groupId>org.jboss.forge.furnace.test</groupId>
-            <artifactId>furnace-test-harness</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.forge.furnace.test</groupId>
-            <artifactId>arquillian-furnace-classpath</artifactId>
-            <scope>test</scope>
-        </dependency>
+                <groupId>org.jboss.windup</groupId>
+                <artifactId>windup-test-harness</artifactId>
+                <version>${project.version}</version>
+		<scope>test</scope>
+        </dependency>  
         <dependency>
             <groupId>org.jboss.windup.exec</groupId>
             <artifactId>windup-exec</artifactId>

--- a/rules-java/tests/pom.xml
+++ b/rules-java/tests/pom.xml
@@ -96,16 +96,12 @@
         </dependency>
 
         <!-- Test Dependencies -->
-        <dependency>
-            <groupId>org.jboss.forge.furnace.test</groupId>
-            <artifactId>furnace-test-harness</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.forge.furnace.test</groupId>
-            <artifactId>arquillian-furnace-classpath</artifactId>
-            <scope>test</scope>
-        </dependency>
+	<dependency>
+                <groupId>org.jboss.windup</groupId>
+                <artifactId>windup-test-harness</artifactId>
+                <version>${project.version}</version>
+		<scope>test</scope>
+        </dependency>   
         <dependency>
             <groupId>org.jboss.windup.exec</groupId>
             <artifactId>windup-exec</artifactId>

--- a/rules-tattletale/addon/pom.xml
+++ b/rules-tattletale/addon/pom.xml
@@ -55,15 +55,11 @@
 
 	<!-- Test Dependencies -->
         <dependency>
-            <groupId>org.jboss.forge.furnace.test</groupId>
-            <artifactId>furnace-test-harness</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.forge.furnace.test</groupId>
-            <artifactId>arquillian-furnace-classpath</artifactId>
-            <scope>test</scope>
-        </dependency>
+                <groupId>org.jboss.windup</groupId>
+                <artifactId>windup-test-harness</artifactId>
+                <version>${project.version}</version>
+		<scope>test</scope>
+        </dependency>  
         <dependency>
             <groupId>org.jboss.windup.exec</groupId>
             <artifactId>windup-exec</artifactId>

--- a/rules-tattletale/tests/pom.xml
+++ b/rules-tattletale/tests/pom.xml
@@ -53,16 +53,12 @@
         </dependency>
 
         <!-- Test Dependencies -->
-        <dependency>
-            <groupId>org.jboss.forge.furnace.test</groupId>
-            <artifactId>furnace-test-harness</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.forge.furnace.test</groupId>
-            <artifactId>arquillian-furnace-classpath</artifactId>
-            <scope>test</scope>
-        </dependency>
+       <dependency>
+                <groupId>org.jboss.windup</groupId>
+                <artifactId>windup-test-harness</artifactId>
+                <version>${project.version}</version>
+		<scope>test</scope>
+        </dependency>  
         <dependency>
             <groupId>org.jboss.windup.exec</groupId>
             <artifactId>windup-exec</artifactId>

--- a/rules-xml/tests/pom.xml
+++ b/rules-xml/tests/pom.xml
@@ -80,16 +80,12 @@
         </dependency>
 
         <!-- Test Dependencies -->
-        <dependency>
-            <groupId>org.jboss.forge.furnace.test</groupId>
-            <artifactId>furnace-test-harness</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.forge.furnace.test</groupId>
-            <artifactId>arquillian-furnace-classpath</artifactId>
-            <scope>test</scope>
-        </dependency>
+       <dependency>
+                <groupId>org.jboss.windup</groupId>
+                <artifactId>windup-test-harness</artifactId>
+                <version>${project.version}</version>
+		<scope>test</scope>
+        </dependency>  
         <dependency>
             <groupId>org.jboss.windup.exec</groupId>
             <artifactId>windup-exec</artifactId>

--- a/test-util/pom.xml
+++ b/test-util/pom.xml
@@ -39,15 +39,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.jboss.forge.furnace.test</groupId>
-            <artifactId>furnace-test-harness</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.forge.furnace.test</groupId>
-            <artifactId>arquillian-furnace-classpath</artifactId>
-            <scope>test</scope>
-        </dependency>
+                <groupId>org.jboss.windup</groupId>
+                <artifactId>windup-test-harness</artifactId>
+                <version>${project.version}</version>
+		<scope>test</scope>
+        </dependency>  
 
     </dependencies>
 

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -94,15 +94,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.jboss.forge.furnace.test</groupId>
-            <artifactId>furnace-test-harness</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.forge.furnace.test</groupId>
-            <artifactId>arquillian-furnace-classpath</artifactId>
-            <scope>test</scope>
-        </dependency>
+                <groupId>org.jboss.windup</groupId>
+                <artifactId>windup-test-harness</artifactId>
+                <version>${project.version}</version>
+		<scope>test</scope>
+        </dependency>  
 
     </dependencies>
 

--- a/tooling/tests/pom.xml
+++ b/tooling/tests/pom.xml
@@ -57,14 +57,10 @@
 
         <!-- Test Dependencies -->
         <dependency>
-            <groupId>org.jboss.forge.furnace.test</groupId>
-            <artifactId>furnace-test-harness</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.forge.furnace.test</groupId>
-            <artifactId>arquillian-furnace-classpath</artifactId>
-            <scope>test</scope>
-        </dependency>
+                <groupId>org.jboss.windup</groupId>
+                <artifactId>windup-test-harness</artifactId>
+                <version>${project.version}</version>
+		<scope>test</scope>
+        </dependency>  
     </dependencies>
 </project>

--- a/ui/tests/pom.xml
+++ b/ui/tests/pom.xml
@@ -74,23 +74,17 @@
 
         <!-- Test Dependencies -->
         <dependency>
-            <groupId>org.jboss.forge.furnace.test</groupId>
-            <artifactId>furnace-test-harness</artifactId>
-            <scope>test</scope>
-        </dependency>
+                <groupId>org.jboss.windup</groupId>
+                <artifactId>windup-test-harness</artifactId>
+                <version>${project.version}</version>
+		<scope>test</scope>
+        </dependency>  
         <dependency>
             <groupId>org.jboss.forge.addon</groupId>
             <artifactId>ui-test-harness</artifactId>
             <classifier>forge-addon</classifier>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.jboss.forge.furnace.test</groupId>
-            <artifactId>arquillian-furnace-classpath</artifactId>
-            <scope>test</scope>
-        </dependency>
-	
-
 
     </dependencies>
 </project>

--- a/windup-test-harness/pom.xml
+++ b/windup-test-harness/pom.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.jboss.windup</groupId>
+        <artifactId>windup-parent</artifactId>
+        <version>2.3.1-SNAPSHOT</version>
+    </parent>
+    <artifactId>windup-test-harness</artifactId>
+    
+
+    <name>Windup Engine - Arquillian extension</name>
+    <description>Used to register extensions for the furnace arquillian module so that it is possible to deploy additional
+    addons by default.</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.jboss.shrinkwrap</groupId>
+            <artifactId>shrinkwrap-impl-base</artifactId>
+	    <version>1.2.2</version>
+        </dependency>
+	<dependency>
+            <groupId>org.jboss.forge.furnace.test</groupId>
+            <artifactId>furnace-test-harness</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.forge.furnace.test</groupId>
+            <artifactId>arquillian-furnace-classpath</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/windup-test-harness/pom.xml
+++ b/windup-test-harness/pom.xml
@@ -14,11 +14,6 @@
     addons by default.</description>
 
     <dependencies>
-        <dependency>
-            <groupId>org.jboss.shrinkwrap</groupId>
-            <artifactId>shrinkwrap-impl-base</artifactId>
-	    <version>1.2.2</version>
-        </dependency>
 	<dependency>
             <groupId>org.jboss.forge.furnace.test</groupId>
             <artifactId>furnace-test-harness</artifactId>

--- a/windup-test-harness/src/main/java/org/jboss/windup/arquillian/WindupFurnaceAddonDeploymentEnhancer.java
+++ b/windup-test-harness/src/main/java/org/jboss/windup/arquillian/WindupFurnaceAddonDeploymentEnhancer.java
@@ -1,0 +1,75 @@
+package org.jboss.windup.arquillian;
+
+import org.jboss.arquillian.container.spi.client.deployment.DeploymentDescription;
+import org.jboss.arquillian.test.spi.TestClass;
+import org.jboss.forge.arquillian.archive.AddonDeploymentArchive;
+import org.jboss.forge.arquillian.spi.AddonDeploymentScenarioEnhancer;
+import org.jboss.forge.furnace.addons.AddonId;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Deployment service that deploys the rexster addon everytime debugging is on.
+ *
+ * @author <a href="mailto:mbriskar@gmail.com">Matej Briškár</a>
+ */
+public class WindupFurnaceAddonDeploymentEnhancer implements AddonDeploymentScenarioEnhancer
+{
+    @Override public List<DeploymentDescription> enhance(TestClass testClass, List<DeploymentDescription> deployments)
+    {
+        if(Boolean.getBoolean("maven.surefire.debug")) {
+            String version = getWindupVersion(deployments);
+            if(version != null) {
+                AddonId id = AddonId.from("org.jboss.windup.rexster:windup-rexster", version);
+                AddonDeploymentArchive archive = ShrinkWrap.create(AddonDeploymentArchive.class).setAddonId(id);
+
+                archive.setDeploymentTimeoutUnit(TimeUnit.MILLISECONDS);
+                archive.setDeploymentTimeoutQuantity(10000);
+
+                DeploymentDescription deploymentDescription = new DeploymentDescription(id.toCoordinates(), archive);
+                deploymentDescription.shouldBeTestable(false);
+                deployments.add(deploymentDescription);
+            }
+        }
+        return deployments;
+    }
+
+    /**
+     * Take the windup-config version and if not found, take the most frequent version of windup addons.
+     * @param deployments
+     * @return
+     */
+    private String getWindupVersion(List<DeploymentDescription> deployments) {
+        Map<String,Integer> versionOccurences = new HashMap<>();
+        for (DeploymentDescription deployment : deployments)
+        {
+
+            if(deployment.toString().contains("windup")) {
+                String version = deployment.toString().split(",")[1];
+
+                if(deployment.toString().contains("windup-config")) {
+                    return version;
+                }
+                if(versionOccurences.containsKey(deployment.toString().split(",")[1])) {
+                    versionOccurences.put(version,versionOccurences.get(version) +1);
+                } else {
+                    versionOccurences.put(version,1);
+                }
+            }
+        }
+        Map.Entry<String, Integer>  maxEntry = null;
+        for (Map.Entry<String, Integer> stringIntegerEntry : versionOccurences.entrySet())
+        {
+            if(maxEntry == null || stringIntegerEntry.getValue() > maxEntry.getValue()) {
+                maxEntry = stringIntegerEntry;
+            }
+        }
+
+        return maxEntry == null ? null : maxEntry.getKey();
+
+    }
+}

--- a/windup-test-harness/src/main/resources/META-INF/services/org.jboss.forge.arquillian.spi.AddonDeploymentScenarioEnhancer
+++ b/windup-test-harness/src/main/resources/META-INF/services/org.jboss.forge.arquillian.spi.AddonDeploymentScenarioEnhancer
@@ -1,0 +1,1 @@
+org.jboss.windup.arquillian.WindupFurnaceAddonDeploymentEnhancer


### PR DESCRIPTION
From now on, rexster is deployed by default everytime you debug within windup.