### PR TITLE
Test script to build and run the latest windup

### DIFF
--- a/test-scripts/build_all_and_run_javaee.sh
+++ b/test-scripts/build_all_and_run_javaee.sh
@@ -1,0 +1,39 @@
+#run this if you changed only the windup/windup and not distribution nor ruleset. Then it will load the appropriate versions of ruleset/distribution and run them on javaee example application
+
+cd ..
+#run the current branch
+mvn clean install -DskipTests
+#get current version
+version=`mvn org.apache.maven.plugins:maven-help-plugin:2.1.1:evaluate -Dexpression=project.version|grep -Ev '(^\[|Download\w+:)'`
+
+#build rulesets
+cd ../windup-rulesets
+git fetch --all
+git rebase upstream/master
+rulesetVersion=`mvn org.apache.maven.plugins:maven-help-plugin:2.1.1:evaluate -Dexpression=project.version|grep -Ev '(^\[|Download\w+:)'`
+if [$rulesetVersion != $version ]
+then
+    git checkout $version
+fi
+	
+mvn clean install -DskipTests
+
+#build distribution
+cd ../windup-distribution
+git fetch --all
+git rebase upstream/master
+distributionVersion=`mvn org.apache.maven.plugins:maven-help-plugin:2.1.1:evaluate -Dexpression=project.version|grep -Ev '(^\[|Download\w+:)'`
+if [$distributionVersion != $version ]
+then
+    git checkout $version
+fi
+mvn clean install -DskipTests
+
+#run the builded windup
+cd target
+unzip windup-distribution-*.zip
+cd windup-distribution-*
+cd bin
+./windup --input ../../../../windup/test-files/jee-example-app-1.0.0.ear --output output --overwrite
+cd ../../../../windup
+


### PR DESCRIPTION
Inspired after reviewing PR I had an idea of creating a common directory for the scripts that we use for testing purposes. They may be then placed in some test{?} directory along with test-files  directory.

The script that I have build builds the current windup and then executes it with the rulesets and distribution of the same version (hopefully) and run the result on javaee application. This is mainly useful **when changing the layout**, after having it done. all you need to do is to care about the code and then run the script and get the output.