### PR TITLE
Fix update rulesets - WINDUP-701

### DIFF
--- a/bootstrap/pom.xml
+++ b/bootstrap/pom.xml
@@ -35,6 +35,14 @@
             <version>${project.version}</version>
             <scope>compile</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.jboss.forge.addon</groupId>
+            <artifactId>dependencies</artifactId>
+            <version>2.16.2.Final</version>
+        </dependency>
+
+
         <dependency>
             <groupId>org.jboss.forge.furnace</groupId>
             <artifactId>furnace-manager</artifactId>
@@ -51,6 +59,8 @@
             <groupId>org.jboss.forge.furnace</groupId>
             <artifactId>furnace-se</artifactId>
         </dependency>
+
+
         <!-- Optional log manager dependency -->
         <dependency>
             <groupId>org.jboss.logmanager</groupId>

--- a/bootstrap/src/main/java/org/jboss/windup/bootstrap/BootstrapCommand.java
+++ b/bootstrap/src/main/java/org/jboss/windup/bootstrap/BootstrapCommand.java
@@ -13,4 +13,5 @@ public enum BootstrapCommand {
     LIST_INSTALLED_ADDONS,
     INSTALL_ADDON,
     REMOVE_ADDON,
+    UPDATE_RULESETS,
 }

--- a/exec/addon/pom.xml
+++ b/exec/addon/pom.xml
@@ -49,6 +49,20 @@
             <classifier>forge-addon</classifier>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.jboss.forge.addon</groupId>
+            <artifactId>dependencies</artifactId>
+            <classifier>forge-addon</classifier>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.forge.addon</groupId>
+            <artifactId>maven</artifactId>
+            <classifier>forge-addon</classifier>
+            <scope>provided</scope>
+        </dependency>
+
+
     </dependencies>
 
 

--- a/exec/api/pom.xml
+++ b/exec/api/pom.xml
@@ -42,5 +42,13 @@
             <artifactId>cdi-api</artifactId>
             <scope>provided</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.jboss.forge.addon</groupId>
+            <artifactId>maven</artifactId>
+            <classifier>forge-addon</classifier>
+            <scope>provided</scope>
+        </dependency>
+
     </dependencies>
 </project>

--- a/exec/api/src/main/java/org/jboss/windup/exec/configuration/options/UpdateRulesetsOption.java
+++ b/exec/api/src/main/java/org/jboss/windup/exec/configuration/options/UpdateRulesetsOption.java
@@ -1,0 +1,56 @@
+package org.jboss.windup.exec.configuration.options;
+
+import org.jboss.windup.config.AbstractConfigurationOption;
+import org.jboss.windup.config.InputType;
+import org.jboss.windup.config.ValidationResult;
+
+/**
+ * Updates the rulesets distributed with Windup.
+ * That means, Windup will check the Maven repository for releases of windup-rulesets,
+ * and if newer is available, it it downloaded and it replaces the current one.
+ */
+public class UpdateRulesetsOption extends AbstractConfigurationOption
+{
+    public static final String NAME = "updateRulesets";
+
+    @Override
+    public String getDescription()
+    {
+        return "Updates the rulesets distributed with Windup.";
+    }
+
+    @Override
+    public String getName()
+    {
+        return NAME;
+    }
+
+    @Override
+    public String getLabel()
+    {
+        return "Update rulesets";
+    }
+
+    @Override
+    public Class<?> getType()
+    {
+        return Boolean.class;
+    }
+
+    @Override
+    public InputType getUIType()
+    {
+        return InputType.SINGLE;
+    }
+
+    @Override
+    public boolean isRequired()
+    {
+        return false;
+    }
+
+    public ValidationResult validate(Object valueObj)
+    {
+        return ValidationResult.SUCCESS;
+    }
+}

--- a/exec/api/src/main/java/org/jboss/windup/exec/updater/RulesetsUpdater.java
+++ b/exec/api/src/main/java/org/jboss/windup/exec/updater/RulesetsUpdater.java
@@ -1,0 +1,135 @@
+package org.jboss.windup.exec.updater;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.logging.Logger;
+import javax.inject.Inject;
+import org.apache.commons.io.FileUtils;
+import org.jboss.forge.addon.dependencies.Coordinate;
+import org.jboss.forge.addon.dependencies.Dependency;
+import org.jboss.forge.addon.dependencies.DependencyException;
+import org.jboss.forge.addon.dependencies.DependencyResolver;
+import org.jboss.forge.addon.dependencies.builder.CoordinateBuilder;
+import org.jboss.forge.addon.dependencies.builder.DependencyQueryBuilder;
+import org.jboss.forge.addon.maven.resources.MavenModelResource;
+import org.jboss.forge.addon.resource.FileResource;
+import org.jboss.forge.addon.resource.ResourceFactory;
+import org.jboss.forge.furnace.Furnace;
+import org.jboss.forge.furnace.versions.SingleVersion;
+import org.jboss.windup.util.PathUtil;
+import org.jboss.windup.util.ZipUtil;
+import org.jboss.windup.util.exception.WindupException;
+
+/**
+ * Encloses the functionality of updating the rulesets.
+ *
+ * @author mbriskar
+ * @author Ondrej Zizka, ozizka at redhat.com
+ */
+public class RulesetsUpdater
+{
+    private static final Logger log = Logger.getLogger( RulesetsUpdater.class.getName() );
+
+    private static final String RULESETS_ARTIFACT_ID = "windup-rulesets";
+    private static final String RULES_GROUP_ID = "org.jboss.windup.rules";
+    public static final String RULESET_CORE_DIRECTORY = "migration-core";
+
+
+    @Inject
+    private Furnace furnace;
+
+    @Inject
+    private DependencyResolver depsResolver;
+
+    @Inject
+    ResourceFactory factory;
+
+
+    public boolean rulesetsNeedUpdate()
+    {
+        Coordinate lastRelease = this.getLatestReleaseOf(RULES_GROUP_ID, RULESETS_ARTIFACT_ID);
+        Path windupRulesDir = getRulesetsDir();
+        Path coreRulesPomPath = windupRulesDir.resolve(RULESET_CORE_DIRECTORY + "/META-INF/maven/org.jboss.windup.rules/windup-rulesets/pom.xml");
+        File pomXml = coreRulesPomPath.toFile();
+        if (!pomXml.exists())
+            return false;
+
+        MavenModelResource pom = (MavenModelResource) factory.create(pomXml);
+        SingleVersion installed = new SingleVersion(pom.getCurrentModel().getVersion());
+        SingleVersion latest = new SingleVersion(lastRelease.getVersion());
+        final String msg = "Core rulesets: Installed: " + installed + " Latest release: " + latest;
+        log.info(msg);
+        System.out.println(msg); // Print to both to have the info in the log too.
+        return 0 > installed.compareTo(latest);
+    }
+
+
+    /**
+     * @return The directory which this updater works with.
+     */
+    public Path getRulesetsDir()
+    {
+        Path windupRulesDir = PathUtil.getWindupRulesDir();
+        return windupRulesDir;
+    }
+
+
+    public String replaceRulesetsDirectoryWithLatestReleaseIfAny() throws IOException, DependencyException
+    {
+        if (!this.rulesetsNeedUpdate())
+            return null;
+
+        Path windupRulesDir = getRulesetsDir();
+        Path coreRulesetsDir = windupRulesDir.resolve(RULESET_CORE_DIRECTORY);
+
+        Coordinate rulesetsCoord = getLatestReleaseOf("org.jboss.windup.rules", "windup-rulesets");
+        if(rulesetsCoord == null)
+            throw new WindupException("No Windup release found.");
+
+        FileUtils.deleteDirectory(coreRulesetsDir.toFile());
+        extractArtifact(rulesetsCoord, coreRulesetsDir.toFile());
+
+        return rulesetsCoord.getVersion();
+    }
+
+
+    public void extractArtifact(Coordinate artifactCoords, File targetDir) throws IOException, DependencyException
+    {
+        final DependencyQueryBuilder query = DependencyQueryBuilder.create(artifactCoords);
+        Dependency dependency = depsResolver.resolveArtifact(query);
+        FileResource<?> artifact = dependency.getArtifact();
+        ZipUtil.unzipToFolder(new File(artifact.getFullyQualifiedName()), targetDir);
+    }
+
+    /**
+     * A convenience method.
+     * @return Finds the latest non-SNAPSHOT of given artifact.
+     */
+    public Coordinate getLatestReleaseOf(String groupId, String artifactId)
+    {
+        final CoordinateBuilder coord = CoordinateBuilder.create()
+                .setGroupId(groupId)
+                .setArtifactId(artifactId);
+        return getLatestReleaseOf(coord);
+    }
+
+
+    /**
+     * @return Finds the latest non-SNAPSHOT of given artifact.
+     */
+    public Coordinate getLatestReleaseOf(final CoordinateBuilder coord)
+    {
+        List<Coordinate> availableVersions = depsResolver.resolveVersions(DependencyQueryBuilder.create(coord));
+
+        // Find the latest non-SNAPSHOT version.
+        for(int i = availableVersions.size()-1; i >= 0; i--)
+        {
+            if(!availableVersions.get(i).isSnapshot())
+                return availableVersions.get(i);
+        }
+        return null;
+    }
+
+}

--- a/ui/addon/pom.xml
+++ b/ui/addon/pom.xml
@@ -12,9 +12,8 @@
 
     <dependencies>
 
-        <!-- Local Dependencies -->
+        <!-- Windup addons -->
 
-        <!-- Addon Dependencies -->
         <dependency>
             <groupId>org.jboss.windup.exec</groupId>
             <artifactId>windup-exec</artifactId>
@@ -28,7 +27,9 @@
             <scope>provided</scope>
         </dependency>
 
-	<dependency>
+        <!-- Forge addons -->
+
+        <dependency>
             <groupId>org.jboss.forge.addon</groupId>
             <artifactId>ui</artifactId>
             <classifier>forge-addon</classifier>
@@ -55,26 +56,26 @@
             <scope>provided</scope>
         </dependency>
 
- 	<dependency>
+        <dependency>
             <groupId>org.jboss.forge.addon</groupId>
             <artifactId>dependencies</artifactId>
             <classifier>forge-addon</classifier>
             <scope>provided</scope>
         </dependency>
 
-	<dependency>
-	    <groupId>net.lingala.zip4j</groupId>
-            <artifactId>zip4j</artifactId>
-            <version>1.3.2</version>
-        </dependency>
-	
-	<dependency>
+        <dependency>
             <groupId>org.jboss.forge.addon</groupId>
             <artifactId>addon-manager-spi</artifactId>
             <classifier>forge-addon</classifier>
             <scope>provided</scope>
         </dependency>
-  
+
+        <!-- Non-addons -->
+        <dependency>
+    	    <groupId>net.lingala.zip4j</groupId>
+            <artifactId>zip4j</artifactId>
+            <version>1.3.2</version>
+        </dependency>
 
     </dependencies>
 

--- a/ui/addon/src/main/java/org/jboss/windup/ui/DistributionUpdater.java
+++ b/ui/addon/src/main/java/org/jboss/windup/ui/DistributionUpdater.java
@@ -1,0 +1,121 @@
+package org.jboss.windup.ui;
+
+
+import java.io.File;
+import java.io.FilenameFilter;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.logging.Logger;
+import javax.inject.Inject;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOCase;
+import org.apache.commons.io.filefilter.FileFilterUtils;
+import org.jboss.forge.addon.dependencies.Coordinate;
+import org.jboss.forge.addon.dependencies.DependencyException;
+import org.jboss.forge.addon.dependencies.builder.CoordinateBuilder;
+import org.jboss.forge.furnace.util.OperatingSystemUtils;
+import org.jboss.windup.exec.updater.RulesetsUpdater;
+import org.jboss.windup.util.PathUtil;
+import org.jboss.windup.util.exception.WindupException;
+
+/**
+ *
+ *  @author Ondrej Zizka, ozizka at redhat.com
+ */
+public class DistributionUpdater
+{
+    private static final Logger log = Logger.getLogger( DistributionUpdater.class.getName() );
+
+    @Inject
+    private RulesetsUpdater updater;
+
+    public void replaceWindupDirectoryWithLatestDistribution()
+    {
+
+        final CoordinateBuilder coords = CoordinateBuilder.create()
+                .setGroupId("org.jboss.windup")
+                .setArtifactId("windup-distribution")
+                .setClassifier("offline")
+                .setPackaging("zip");
+        Coordinate coord = updater.getLatestReleaseOf(coords);
+        if(coord == null)
+            throw new WindupException("No Windup release found.");
+        log.info("Latest windup version available: " + coord.getVersion());
+        log.fine("Latest windup version available: " + coord);
+
+        replaceWindupDirectoryWithDistribution(coord);
+    }
+
+
+    /**
+     * Downloads the given artifact, extracts it and replaces current Windup directory (as given by PathUtil)
+     * with the content from the artifact (assuming it really is a Windup distribution zip).
+     */
+    public void replaceWindupDirectoryWithDistribution(Coordinate distCoordinate)
+            throws WindupException
+    {
+        try
+        {
+            final CoordinateBuilder coord = CoordinateBuilder.create(distCoordinate);
+            File tempFolder = OperatingSystemUtils.createTempDir();
+            this.updater.extractArtifact(coord, tempFolder);
+
+            File newDistWindupDir = getWindupDistributionSubdir(tempFolder);
+
+            if (null == newDistWindupDir)
+                throw new WindupException("Distribution update failed: "
+                    + "The distribution archive did not contain the windup-distribution-* directory: " + coord.toString());
+
+
+            Path addonsDir = PathUtil.getWindupAddonsDir();
+            Path binDir = PathUtil.getWindupHome().resolve(PathUtil.BINARY_DIRECTORY_NAME);
+            Path libDir = PathUtil.getWindupHome().resolve(PathUtil.LIBRARY_DIRECTORY_NAME);
+
+            FileUtils.deleteDirectory(addonsDir.toFile());
+            FileUtils.deleteDirectory(libDir.toFile());
+            FileUtils.deleteDirectory(binDir.toFile());
+
+            FileUtils.moveDirectory(new File(newDistWindupDir, PathUtil.ADDONS_DIRECTORY_NAME), addonsDir.toFile());
+            FileUtils.moveDirectory(new File(newDistWindupDir, PathUtil.BINARY_DIRECTORY_NAME), binDir.toFile());
+            FileUtils.moveDirectory(new File(newDistWindupDir, PathUtil.LIBRARY_DIRECTORY_NAME), libDir.toFile());
+
+            // Rulesets
+            Path rulesDir = PathUtil.getWindupHome().resolve(PathUtil.RULES_DIRECTORY_NAME); //PathUtil.getWindupRulesDir();
+            File coreDir = rulesDir.resolve(RulesetsUpdater.RULESET_CORE_DIRECTORY).toFile();
+
+            // This is for testing purposes. The releases do not contain migration-core/ .
+            if (coreDir.exists())
+            {
+                // migration-core/ exists -> Only replace that one.
+                FileUtils.deleteDirectory(coreDir);
+                final File coreDirNew = newDistWindupDir.toPath().resolve(PathUtil.RULES_DIRECTORY_NAME).resolve(RulesetsUpdater.RULESET_CORE_DIRECTORY).toFile();
+                FileUtils.moveDirectory(coreDirNew, rulesDir.resolve(RulesetsUpdater.RULESET_CORE_DIRECTORY).toFile());
+            }
+            else
+            {
+                // Otherwise replace the whole rules directory (backing up the old one).
+                final String newName = "rules-" + new SimpleDateFormat("yyyy-MM-dd_HH-mm-ss").format(new Date());
+                FileUtils.moveDirectory(rulesDir.toFile(), rulesDir.getParent().resolve(newName).toFile());
+                FileUtils.moveDirectory(new File(newDistWindupDir, PathUtil.RULES_DIRECTORY_NAME), rulesDir.toFile());
+            }
+
+            FileUtils.deleteDirectory(tempFolder);
+        }
+        catch (IllegalStateException | DependencyException | IOException ex)
+        {
+            throw new WindupException("Distribution update failed: " + ex.getMessage(), ex);
+        }
+    }
+
+
+    public static File getWindupDistributionSubdir(File tempFolder) throws WindupException
+    {
+        File[] matchingDirs = tempFolder.listFiles((FilenameFilter) FileFilterUtils.prefixFileFilter("windup-distribution-", IOCase.INSENSITIVE));
+        if (matchingDirs.length == 0)
+            return null;
+        return matchingDirs[0];
+    }
+
+}

--- a/ui/addon/src/main/java/org/jboss/windup/ui/RulesetUpdateChecker.java
+++ b/ui/addon/src/main/java/org/jboss/windup/ui/RulesetUpdateChecker.java
@@ -1,97 +1,39 @@
 package org.jboss.windup.ui;
 
-import java.io.File;
-import java.nio.file.Path;
-
-import org.jboss.forge.addon.maven.resources.MavenModelResource;
-import org.jboss.forge.furnace.versions.SingleVersion;
-
-import java.util.List;
-
+import org.jboss.windup.exec.updater.RulesetsUpdater;
 import javax.enterprise.event.Observes;
 import javax.inject.Inject;
 import javax.inject.Singleton;
-
-import org.jboss.forge.addon.dependencies.Coordinate;
-import org.jboss.forge.addon.dependencies.DependencyResolver;
-import org.jboss.forge.addon.dependencies.builder.CoordinateBuilder;
-import org.jboss.forge.addon.dependencies.builder.DependencyQueryBuilder;
-import org.jboss.forge.addon.resource.ResourceFactory;
 import org.jboss.forge.furnace.Furnace;
+import org.jboss.forge.furnace.addons.AddonId;
 import org.jboss.forge.furnace.event.PostStartup;
-import org.jboss.forge.furnace.services.Imported;
-import org.jboss.windup.config.furnace.FurnaceHolder;
-import org.jboss.windup.util.PathUtil;
+
 
 @Singleton
 public class RulesetUpdateChecker
 {
-
     @Inject
     Furnace furnace;
 
-    public static final String RULESET_CORE_DIRECTORY = "migration-core";
+    //@Inject // FORGE-2408
+    //RulesetsUpdater updater;
 
     public void perform(@Observes PostStartup event)
     {
-        boolean isDependencies = event.getAddon().getId().toString().contains("org.jboss.windup.ui:windup-ui");
-        if (isDependencies)
-        {
-            Imported<DependencyResolver> exportedTypes = furnace.getAddonRegistry().getServices(DependencyResolver.class);
-            if (!exportedTypes.isUnsatisfied() && rulesetNeedUpdate(exportedTypes.get()))
-            {
-                System.out.println("");
-                System.out.println("Your ruleset is obsolete. Consider running windup-update-ruleset or windup-update-distribution command. Press ENTER to continue.");
-                System.out.println("");
-            }
+        if (!event.getAddon().getId().getName().contains("org.jboss.windup.ui:windup-ui"))
+            return;
 
+
+        RulesetsUpdater updater = furnace.getAddonRegistry().getServices(RulesetsUpdater.class).get();
+
+        if (!event.getAddon().getRepository().isDeployed(AddonId.from("org.jboss.windup.exec:windup-exec", event.getAddon().getId().getVersion())))
+            throw new IllegalStateException("windup-exec is not deployed.");
+
+        if (updater.rulesetsNeedUpdate())
+        {
+            System.out.println("\nThe rulesets are outdated: " + updater.getRulesetsDir()
+                + "\nConsider running Windup with --updateRuleset or --updateDistribution. Press ENTER to continue.\n");
         }
     }
 
-    public static boolean rulesetNeedUpdate(DependencyResolver dependencyResolver)
-    {
-        List<Coordinate> resolveVersions = dependencyResolver.resolveVersions(DependencyQueryBuilder.create(CoordinateBuilder.create()
-                    .setGroupId("org.jboss.windup.rules")
-                    .setArtifactId("windup-rulesets")));
-        int i = 0;
-        Coordinate latestCoordinate;
-        do
-        {
-            i++;
-            latestCoordinate = resolveVersions.get(resolveVersions.size() - i);
-        }
-        while (latestCoordinate.isSnapshot());
-        Path windupRulesDir = PathUtil.getWindupRulesDir();
-        Imported<ResourceFactory> imported = FurnaceHolder.getFurnace().getAddonRegistry().getServices(ResourceFactory.class);
-        ResourceFactory factory = imported.get();
-        Path coreRulesPropertiesPath = windupRulesDir.resolve(RULESET_CORE_DIRECTORY
-                    + "/META-INF/maven/org.jboss.windup.rules/windup-rulesets/pom.xml");
-        File pomXml = coreRulesPropertiesPath.toFile();
-        if (pomXml.exists())
-        {
-            MavenModelResource pom = (MavenModelResource) factory.create(pomXml);
-            String installedVersion = pom.getCurrentModel().getVersion();
-            String latestVersion = latestCoordinate.getVersion();
-            SingleVersion installed = new SingleVersion(installedVersion);
-            SingleVersion latest = new SingleVersion(latestVersion);
-            return versionIsOld(installed, latest);
-        }
-        else
-        {
-            return false;
-        }
-    }
-
-    private static boolean versionIsOld(SingleVersion installedVersion, SingleVersion latestVersion)
-    {
-        int compareTo = installedVersion.compareTo(latestVersion);
-        if (compareTo >= 0)
-        {
-            return false;
-        }
-        else
-        {
-            return true;
-        }
-    }
 }

--- a/ui/addon/src/main/java/org/jboss/windup/ui/WindupUpdateDistributionCommand.java
+++ b/ui/addon/src/main/java/org/jboss/windup/ui/WindupUpdateDistributionCommand.java
@@ -1,26 +1,9 @@
 package org.jboss.windup.ui;
 
-import java.io.File;
-import java.io.FilenameFilter;
-import java.io.IOException;
-import java.nio.file.FileVisitResult;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.SimpleFileVisitor;
-import java.nio.file.attribute.BasicFileAttributes;
-import java.util.List;
-
+import org.jboss.windup.exec.updater.RulesetsUpdater;
 import javax.inject.Inject;
-
-import net.lingala.zip4j.core.ZipFile;
-
-import org.apache.commons.io.FileUtils;
 import org.jboss.forge.addon.dependencies.Coordinate;
-import org.jboss.forge.addon.dependencies.Dependency;
 import org.jboss.forge.addon.dependencies.DependencyResolver;
-import org.jboss.forge.addon.dependencies.builder.CoordinateBuilder;
-import org.jboss.forge.addon.dependencies.builder.DependencyQueryBuilder;
-import org.jboss.forge.addon.resource.FileResource;
 import org.jboss.forge.addon.ui.command.UICommand;
 import org.jboss.forge.addon.ui.context.UIBuilder;
 import org.jboss.forge.addon.ui.context.UIContext;
@@ -32,135 +15,65 @@ import org.jboss.forge.addon.ui.result.Results;
 import org.jboss.forge.addon.ui.util.Categories;
 import org.jboss.forge.addon.ui.util.Metadata;
 import org.jboss.forge.furnace.addons.Addon;
-import org.jboss.forge.furnace.util.OperatingSystemUtils;
 import org.jboss.forge.furnace.versions.SingleVersion;
 import org.jboss.forge.furnace.versions.Version;
-import org.jboss.windup.util.PathUtil;
+
 
 /**
  * Provides a basic UI command updating the whole windup distribution.
  *
  * @author mbriskar
+ * @author ozizka
  */
 public class WindupUpdateDistributionCommand implements UICommand
 {
 
     @Inject
     Addon currentAddon;
+
     @Inject
     private DependencyResolver dependencyResolver;
+
+    @Inject
+    private RulesetsUpdater updater;
+
+    @Inject
+    private DistributionUpdater distUpdater;
+
+
 
     @Override
     public UICommandMetadata getMetadata(UIContext ctx)
     {
-        return Metadata.forCommand(getClass()).name("Windup Update Distribution").description("Update the whole windup installation")
-                    .category(Categories.create("Platform", "Migration"));
+        return Metadata.forCommand(getClass()).name("Windup Update Distribution")
+                .description("Update the whole windup installation")
+                .category(Categories.create("Platform", "Migration"));
     }
 
     @Override
     public Result execute(UIExecutionContext context) throws Exception
     {
         if (!context.getPrompt().promptBoolean(
-                    "Are you sure you want to continue? This command will delete current directories: addons, bin, lib, rules/migration-core"))
+            "Are you sure you want to continue? This command will delete current directories: addons, bin, lib, rules/migration-core"))
         {
             return Results.fail("Updating distribution was aborted.");
+        }
 
-        }
-        List<Coordinate> distributionVersions = dependencyResolver.resolveVersions(DependencyQueryBuilder.create(CoordinateBuilder.create()
-                    .setGroupId("org.jboss.windup")
-                    .setArtifactId("windup-distribution")));
-        Coordinate latestDistributionCoordinate = distributionVersions.get(distributionVersions.size() - 1);
-        int i = 0;
-        do
-        {
-            i++;
-            latestDistributionCoordinate = distributionVersions.get(distributionVersions.size() - i);
-        }
-        while (latestDistributionCoordinate.isSnapshot());
-        Version latestVersion = new SingleVersion(latestDistributionCoordinate.getVersion());
+        // Find the latest version.
+        Coordinate latestDist = this.updater.getLatestReleaseOf("org.jboss.windup", "windup-distribution");
+        Version latestVersion = new SingleVersion(latestDist.getVersion());
         Version installedVersion = currentAddon.getId().getVersion();
         if (latestVersion.compareTo(installedVersion) <= 0)
         {
             return Results.fail("Windup is already in the most updated version.");
         }
-        Path windupRulesDir = PathUtil.getWindupRulesDir();
-        Path addonsDir = PathUtil.getWindupAddonsDir();
-        Path binDir = PathUtil.getWindupHome().resolve(PathUtil.BINARY_DIRECTORY_NAME);
-        Path libDir = PathUtil.getWindupHome().resolve( PathUtil.LIBRARY_DIRECTORY_NAME);
-        Path coreRulesPropertiesPath = windupRulesDir.resolve(RulesetUpdateChecker.RULESET_CORE_DIRECTORY);
 
-        deleteWholeDirectory(coreRulesPropertiesPath);
-        deleteWholeDirectory(addonsDir);
-        deleteWholeDirectory(libDir);
-        deleteWholeDirectory(binDir);
-        Dependency dependency = dependencyResolver.resolveArtifact(DependencyQueryBuilder.create(CoordinateBuilder.create()
-                    .setGroupId(latestDistributionCoordinate.getGroupId()).setArtifactId(latestDistributionCoordinate.getArtifactId())
-                    .setVersion(latestDistributionCoordinate.getVersion()).setClassifier("offline").setPackaging("zip")));
-        FileResource<?> artifact = dependency.getArtifact();
-        ZipFile zipFile = new ZipFile(artifact.getFullyQualifiedName());
-        File tempFolder = OperatingSystemUtils.createTempDir();
-        String tempFolderPath = tempFolder.getAbsolutePath();
-        zipFile.extractAll(tempFolderPath);
-        FilenameFilter windupUnzipped = new FilenameFilter()
-        {
-            public boolean accept(File dir, String name)
-            {
-                String lowercaseName = name.toLowerCase();
-                if (lowercaseName.contains("windup-distribution"))
-                {
-                    return true;
-                }
-                else
-                {
-                    return false;
-                }
-            }
-        };
-        File[] windupDistrubution = new File(tempFolderPath).listFiles(windupUnzipped);
-        String distributionExctractedPath = windupDistrubution[0].getAbsolutePath();
-        FileUtils.copyDirectory(new File(distributionExctractedPath + "/" + PathUtil.ADDONS_DIRECTORY_NAME), addonsDir.toFile());
-        FileUtils.copyDirectory(new File(distributionExctractedPath + "/" + PathUtil.BINARY_DIRECTORY_NAME), binDir.toFile());
-        FileUtils.copyDirectory(new File(distributionExctractedPath + "/" + PathUtil.LIBRARY_DIRECTORY_NAME), libDir.toFile());
-        File downloadedMigrationCore = new File(distributionExctractedPath + "/" + PathUtil.RULES_DIRECTORY_NAME + "/"
-                    + RulesetUpdateChecker.RULESET_CORE_DIRECTORY);
-        if (downloadedMigrationCore.exists())
-        {
-            // copy from rules/migration-core to migration-core
-            FileUtils.copyDirectory(downloadedMigrationCore, coreRulesPropertiesPath.toFile());
-        }
-        else
-        {
-            // copy from rules/ to migration-core
-            // TODO: This else branch is just for testing purposes while the online version does not contain migration-core folder
-            FileUtils.copyDirectory(new File(distributionExctractedPath + "/" + PathUtil.RULES_DIRECTORY_NAME), coreRulesPropertiesPath.toFile());
-        }
-        return Results.success("Sucessfully updated to version " + latestDistributionCoordinate.getVersion() + ". Please restart windup.");
+        distUpdater.replaceWindupDirectoryWithDistribution(latestDist);
+
+        return Results.success("Sucessfully updated Windup to version " + latestDist.getVersion() + ". Please restart Windup.");
     }
 
-    private void deleteWholeDirectory(Path directory) throws IOException
-    {
-        if (directory.toFile().exists())
-        {
-            Files.walkFileTree(directory, new SimpleFileVisitor<Path>()
-            {
-                @Override
-                public FileVisitResult visitFile(Path file, BasicFileAttributes attrs)
-                            throws IOException
-                {
-                    Files.delete(file);
-                    return FileVisitResult.CONTINUE;
-                }
 
-                @Override
-                public FileVisitResult postVisitDirectory(Path dir,
-                            IOException exc) throws IOException
-                {
-                    Files.delete(dir);
-                    return FileVisitResult.CONTINUE;
-                }
-            });
-        }
-    }
 
     @Override
     public boolean isEnabled(UIContext context)

--- a/ui/addon/src/main/java/org/jboss/windup/ui/WindupUpdateRulesetCommand.java
+++ b/ui/addon/src/main/java/org/jboss/windup/ui/WindupUpdateRulesetCommand.java
@@ -1,23 +1,10 @@
 package org.jboss.windup.ui;
 
-import java.io.IOException;
-import java.nio.file.FileVisitResult;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.SimpleFileVisitor;
-import java.nio.file.attribute.BasicFileAttributes;
-import java.util.List;
 
+import org.jboss.windup.exec.updater.RulesetsUpdater;
 import javax.inject.Inject;
 
-import net.lingala.zip4j.core.ZipFile;
-
-import org.jboss.forge.addon.dependencies.Coordinate;
-import org.jboss.forge.addon.dependencies.Dependency;
 import org.jboss.forge.addon.dependencies.DependencyResolver;
-import org.jboss.forge.addon.dependencies.builder.CoordinateBuilder;
-import org.jboss.forge.addon.dependencies.builder.DependencyQueryBuilder;
-import org.jboss.forge.addon.resource.FileResource;
 import org.jboss.forge.addon.ui.command.UICommand;
 import org.jboss.forge.addon.ui.context.UIBuilder;
 import org.jboss.forge.addon.ui.context.UIContext;
@@ -28,12 +15,12 @@ import org.jboss.forge.addon.ui.result.Result;
 import org.jboss.forge.addon.ui.result.Results;
 import org.jboss.forge.addon.ui.util.Categories;
 import org.jboss.forge.addon.ui.util.Metadata;
-import org.jboss.windup.util.PathUtil;
 
 /**
  * Provides a basic UI command updating the rules/migration-core folder with the latest version.
  *
  * @author mbriskar
+ * @author Ondrej Zizka, ozizka at redhat.com
  */
 public class WindupUpdateRulesetCommand implements UICommand
 {
@@ -41,60 +28,29 @@ public class WindupUpdateRulesetCommand implements UICommand
     @Inject
     private DependencyResolver dependencyResolver;
 
+    @Inject
+    private RulesetsUpdater updater;
+    
+
     @Override
     public UICommandMetadata getMetadata(UIContext ctx)
     {
-        return Metadata.forCommand(getClass()).name("Windup Update Ruleset").description("Update the ruleset containing the migration rules")
+        return Metadata.forCommand(getClass()).name("Windup Update Ruleset")
+                    .description("Update the ruleset containing the migration rules")
                     .category(Categories.create("Platform", "Migration"));
     }
 
     @Override
     public Result execute(UIExecutionContext context) throws Exception
     {
-        if (!RulesetUpdateChecker.rulesetNeedUpdate(dependencyResolver))
-        {
-            return Results.fail("The ruleset is already in the most updated version.");
-        }
-        List<Coordinate> resolveVersions = dependencyResolver.resolveVersions(DependencyQueryBuilder.create(CoordinateBuilder.create()
-                    .setGroupId("org.jboss.windup.rules")
-                    .setArtifactId("windup-rulesets")));
-        int i = 0;
-        Coordinate latestCoordinate;
-        do{
-            i++;
-            latestCoordinate = resolveVersions.get(resolveVersions.size() - i);
-        }while(latestCoordinate.isSnapshot()); 
-        
-        Path windupRulesDir = PathUtil.getWindupRulesDir();
-        Path coreRulesPropertiesPath = windupRulesDir.resolve(RulesetUpdateChecker.RULESET_CORE_DIRECTORY);
-        // delete the previous rules
-        Files.walkFileTree(coreRulesPropertiesPath, new SimpleFileVisitor<Path>()
-        {
-            @Override
-            public FileVisitResult visitFile(Path file, BasicFileAttributes attrs)
-                        throws IOException
-            {
-                Files.delete(file);
-                return FileVisitResult.CONTINUE;
-            }
+        String updatedTo = updater.replaceRulesetsDirectoryWithLatestReleaseIfAny();
 
-            @Override
-            public FileVisitResult postVisitDirectory(Path dir,
-                        IOException exc) throws IOException
-            {
-                Files.delete(dir);
-                return FileVisitResult.CONTINUE;
-            }
-        });
-        Dependency dependency = dependencyResolver.resolveArtifact(DependencyQueryBuilder.create(CoordinateBuilder.create()
-                    .setGroupId(latestCoordinate.getGroupId()).setArtifactId(latestCoordinate.getArtifactId())
-                    .setVersion(latestCoordinate.getVersion())));
-        FileResource<?> artifact = dependency.getArtifact();
-        ZipFile zipFile = new ZipFile(artifact.getFullyQualifiedName());
-        String destinationFolder = coreRulesPropertiesPath.toAbsolutePath().toString();
-        zipFile.extractAll(destinationFolder);
-        return Results.success("Sucessfully updated to version " + latestCoordinate.getVersion());
+        if (updatedTo == null)
+            return Results.fail("The ruleset is already in the most updated version.");
+        else
+            return Results.success("Sucessfully updated the rulesets to version " + updatedTo + " .");
     }
+
 
     @Override
     public boolean isEnabled(UIContext context)

--- a/ui/tests/pom.xml
+++ b/ui/tests/pom.xml
@@ -10,17 +10,21 @@
     <artifactId>windup-ui-tests</artifactId>
     <name>Windup Engine - UI Tests</name>
 
+    <properties>
+        <version.forge>2.16.2.Final</version.forge>
+    </properties>
+
     <dependencies>
-        <!-- Addon Dependencies -->
+        <!-- Windup addons -->
         <dependency>
             <groupId>org.jboss.windup.ui</groupId>
             <artifactId>windup-ui</artifactId>
             <classifier>forge-addon</classifier>
             <scope>provided</scope>
         </dependency>
-	 <dependency>
-            <groupId>org.jboss.forge.addon</groupId>
-            <artifactId>maven</artifactId>
+        <dependency>
+            <groupId>org.jboss.windup.utils</groupId>
+            <artifactId>windup-utils</artifactId>
             <classifier>forge-addon</classifier>
             <scope>provided</scope>
         </dependency>
@@ -31,26 +35,31 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.jboss.forge.addon</groupId>
-            <artifactId>dependencies</artifactId>
-            <classifier>forge-addon</classifier>
-            <scope>provided</scope>
-        </dependency>
-
-        <dependency>
             <groupId>org.jboss.windup.exec</groupId>
             <artifactId>windup-exec</artifactId>
             <classifier>forge-addon</classifier>
             <scope>provided</scope>
         </dependency>
 
+        <!-- Other addons -->
         <dependency>
             <groupId>org.jboss.forge.addon</groupId>
             <artifactId>ui</artifactId>
             <classifier>forge-addon</classifier>
             <scope>provided</scope>
         </dependency>
-
+        <dependency>
+            <groupId>org.jboss.forge.addon</groupId>
+            <artifactId>maven</artifactId>
+            <classifier>forge-addon</classifier>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.forge.addon</groupId>
+            <artifactId>dependencies</artifactId>
+            <classifier>forge-addon</classifier>
+            <scope>provided</scope>
+        </dependency>
         <dependency>
             <groupId>org.jboss.forge.addon</groupId>
             <artifactId>resources</artifactId>
@@ -58,8 +67,8 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.jboss.windup.utils</groupId>
-            <artifactId>windup-utils</artifactId>
+            <groupId>org.jboss.forge.addon</groupId>
+            <artifactId>addon-manager</artifactId>
             <classifier>forge-addon</classifier>
             <scope>provided</scope>
         </dependency>
@@ -74,11 +83,19 @@
 
         <!-- Test Dependencies -->
         <dependency>
-                <groupId>org.jboss.windup</groupId>
-                <artifactId>windup-test-harness</artifactId>
-                <version>${project.version}</version>
-		<scope>test</scope>
-        </dependency>  
+            <groupId>org.jboss.windup</groupId>
+            <artifactId>windup-test-harness</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <!-- Trying to prevent windup-ui-tests throwing CNFEx with class from org.jboss.forge.addon:maven
+        <dependency>
+            <groupId>org.jboss.forge.addon</groupId>
+            <artifactId>maven</artifactId>
+            <version>2.16.2.Final</version>
+            <scope>test</scope>
+        </dependency>
+        -->
         <dependency>
             <groupId>org.jboss.forge.addon</groupId>
             <artifactId>ui-test-harness</artifactId>

--- a/ui/tests/src/test/java/org/jboss/windup/addon/ui/WindupUpdateRulesetCommandTest.java
+++ b/ui/tests/src/test/java/org/jboss/windup/addon/ui/WindupUpdateRulesetCommandTest.java
@@ -1,16 +1,8 @@
 package org.jboss.windup.addon.ui;
 
 import java.io.File;
-import java.io.FileOutputStream;
-import java.io.InputStream;
-import java.io.OutputStream;
-
 import javax.inject.Inject;
-
-import net.lingala.zip4j.core.ZipFile;
-
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.io.IOUtils;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.forge.addon.dependencies.DependencyResolver;
@@ -23,11 +15,14 @@ import org.jboss.forge.arquillian.AddonDependency;
 import org.jboss.forge.arquillian.archive.AddonArchive;
 import org.jboss.forge.furnace.util.OperatingSystemUtils;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.windup.ui.RulesetUpdateChecker;
+import org.jboss.windup.exec.updater.RulesetsUpdater;
 import org.jboss.windup.ui.WindupUpdateRulesetCommand;
+import org.jboss.windup.util.PathUtil;
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
 
 @RunWith(Arquillian.class)
 public class WindupUpdateRulesetCommandTest
@@ -60,42 +55,37 @@ public class WindupUpdateRulesetCommandTest
     @Inject
     private UITestHarness uiTestHarness;
 
-    @Test
-    public void testOutputDirCannotBeParentOfInputDir() throws Exception
+    @Inject
+    private RulesetsUpdater updater;
+
+
+    @Test @Ignore("Command can't be used currently as there's no way to run it from the UI."
+            + " I'm leaving it here in case we needed the command again (maybe from a GUI?).")
+    public void testUpdateRulesetCommand() throws Exception
     {
+        // Extract the windup zip to a temp dir.
         File tempDir = OperatingSystemUtils.createTempDir();
-        File inputFile = File.createTempFile("windup-old-ruleset", ".zip", tempDir);
-        inputFile.deleteOnExit();
-        try (InputStream iStream = getClass().getResourceAsStream(TEST_OLD_WINDUP))
-        {
-            try (OutputStream oStream = new FileOutputStream(inputFile))
-            {
-                IOUtils.copy(iStream, oStream);
-            }
-        }
+        PathUtil.unzipFromResource(WindupUpdateRulesetCommandTest.class, TEST_OLD_WINDUP, tempDir);
+
+        // This may cause FileNotFound in Furnace if it's already running.
+        System.setProperty("windup.home", new File(tempDir, "windup-old-ruleset").getAbsolutePath());
+
         try (CommandController controller = uiTestHarness.createCommandController(WindupUpdateRulesetCommand.class))
         {
-            ZipFile zipFile = new ZipFile(inputFile.getAbsolutePath());
-            String extractedFolderPath = tempDir.getAbsolutePath() + "/extracted-windup";
-            new File(extractedFolderPath).mkdirs();
-            zipFile.extractAll(extractedFolderPath);
-            String windupHome = extractedFolderPath + "/windup-old-ruleset";
-            System.setProperty("windup.home", windupHome);
-            boolean rulesetNeedUpdate = RulesetUpdateChecker.rulesetNeedUpdate(resolver);
-            Assert.assertTrue(rulesetNeedUpdate);
-            try
-            {
-                controller.initialize();
-                Assert.assertTrue(controller.isEnabled());
-                Result result = controller.execute();
-                Assert.assertFalse(result instanceof Failed);
-                rulesetNeedUpdate = RulesetUpdateChecker.rulesetNeedUpdate(resolver);
-                Assert.assertFalse(rulesetNeedUpdate);
-            }
-            finally
-            {
-                FileUtils.deleteDirectory(tempDir);
-            }
+            boolean rulesetNeedUpdate = updater.rulesetsNeedUpdate();
+            Assert.assertTrue("Rulesets should need an update.", rulesetNeedUpdate);
+
+            controller.initialize();
+            Assert.assertTrue(controller.isEnabled());
+            Result result = controller.execute();
+            Assert.assertFalse(result instanceof Failed);
+            rulesetNeedUpdate = updater.rulesetsNeedUpdate();
+            Assert.assertFalse(rulesetNeedUpdate);
+        }
+        finally
+        {
+            FileUtils.deleteDirectory(tempDir);
+            System.getProperties().remove("windup.home");
         }
     }
 

--- a/ui/tests/src/test/java/org/jboss/windup/addon/ui/WindupUpdateRulesetTest.java
+++ b/ui/tests/src/test/java/org/jboss/windup/addon/ui/WindupUpdateRulesetTest.java
@@ -1,0 +1,90 @@
+package org.jboss.windup.addon.ui;
+
+import java.io.File;
+import java.lang.reflect.InvocationTargetException;
+import javax.inject.Inject;
+import org.apache.commons.io.FileUtils;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.forge.addon.dependencies.DependencyResolver;
+import org.jboss.forge.arquillian.AddonDependencies;
+import org.jboss.forge.arquillian.AddonDependency;
+import org.jboss.forge.arquillian.archive.AddonArchive;
+import org.jboss.forge.furnace.util.OperatingSystemUtils;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.windup.exec.updater.RulesetsUpdater;
+import org.jboss.windup.util.PathUtil;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class WindupUpdateRulesetTest
+{
+    @Deployment
+    @AddonDependencies({
+        @AddonDependency(name = "org.jboss.forge.furnace.container:cdi"),
+        @AddonDependency(name = "org.jboss.windup.utils:windup-utils"),
+        @AddonDependency(name = "org.jboss.windup.exec:windup-exec"),
+        @AddonDependency(name = "org.jboss.windup.graph:windup-graph"),
+        @AddonDependency(name = "org.jboss.windup.ui:windup-ui"),
+        @AddonDependency(name = "org.jboss.windup.rules.apps:windup-rules-java"),
+        @AddonDependency(name = "org.jboss.forge.addon:maven"),
+        //@AddonDependency(name = "org.jboss.forge.addon:ui-test-harness"),
+    })
+    public static AddonArchive getDeployment()
+    {
+        AddonArchive archive = ShrinkWrap
+            .create(AddonArchive.class)
+            .addBeansXML()
+            .addAsResource(WindupUpdateRulesetTest.class.getResource(TEST_OLD_WINDUP), TEST_OLD_WINDUP);
+        return archive;
+    }
+
+    private static String TEST_OLD_WINDUP = "/windup-old-ruleset.zip";
+
+    @Inject
+    private DependencyResolver resolver;
+
+    @Inject
+    private RulesetsUpdater updater;
+
+
+    @Test
+    public void testUpdateRuleset() throws Exception
+    {
+        // Extract the rulesets to a temp dir and move the rules/ to target/rules/ .
+        File tempDir = OperatingSystemUtils.createTempDir();
+
+        PathUtil.unzipFromResource(WindupUpdateRulesetTest.class, TEST_OLD_WINDUP, tempDir);
+        final File targetDir = PathUtil.getWindupHome().resolve("target").toAbsolutePath().toFile();
+        final File rulesetsDir = new File(targetDir, "rules");
+        FileUtils.deleteDirectory(rulesetsDir);
+        FileUtils.moveDirectoryToDirectory(new File(tempDir, "windup-old-ruleset/rules"), targetDir, false);
+        System.setProperty(PathUtil.WINDUP_RULESETS_DIR_SYSPROP, rulesetsDir.getAbsolutePath());
+        FileUtils.deleteDirectory(tempDir);
+
+        try
+        {
+            boolean rulesetNeedUpdate = this.updater.rulesetsNeedUpdate();
+            Assert.assertTrue("Rulesets should need an update.", rulesetNeedUpdate);
+            updater.replaceRulesetsDirectoryWithLatestReleaseIfAny();
+            Assert.assertFalse("Rulesets should not need an update.", this.updater.rulesetsNeedUpdate());
+        }
+        catch (Throwable ex){
+            if(ex.getClass().getSimpleName().equals("InvocationTargetException"))
+            {
+                final Throwable wrappedEx = ((InvocationTargetException)ex).getTargetException();
+                throw new RuntimeException(wrappedEx.getClass().getSimpleName() + " " + wrappedEx.getMessage(), wrappedEx);
+            }
+            else
+                throw ex;
+        }
+        finally
+        {
+            System.getProperties().remove("windup.home");
+        }
+    }
+
+}


### PR DESCRIPTION
I refactored the whole code and made the tests to work, and now I am going to check how it works practically.

The command will be removed. Instead it will be --updateRulesets, handled either in Bootstrap or as an ConfigurationOption and a rule, if that works.

I had to add this to the windup-ui-tests POM to prevent CNFEx,
but it's wrong since threre already is this one with forge-addon, only as <scope>provided which is then not picked up in tests (despite         @AddonDependency(name = "org.jboss.forge.addon:maven") .)

        <!-- Trying to prevent windup-ui-tests throwing CNFEx with class from org.jboss.forge.addon:maven -->
        <dependency>
            <groupId>org.jboss.forge.addon</groupId>
            <artifactId>maven</artifactId>
            <version>2.16.2.Final</version>
            <scope>test</scope>
        </dependency>
