### PR TITLE
Fixed an issue with path selection during decompilation. Also, made the unbound references scanning functionality optional

### DIFF
--- a/bootstrap/src/main/java/org/jboss/windup/bootstrap/commands/windup/RunWindupCommand.java
+++ b/bootstrap/src/main/java/org/jboss/windup/bootstrap/commands/windup/RunWindupCommand.java
@@ -28,6 +28,7 @@ import org.jboss.windup.exec.configuration.options.OutputPathOption;
 import org.jboss.windup.exec.configuration.options.OverwriteOption;
 import org.jboss.windup.graph.GraphContext;
 import org.jboss.windup.graph.GraphContextFactory;
+import org.jboss.windup.util.exception.WindupException;
 
 public class RunWindupCommand implements Command, FurnaceDependent
 {
@@ -232,8 +233,16 @@ public class RunWindupCommand implements Command, FurnaceDependent
             File inputFile = (File) optionValues.get(InputPathOption.NAME);
             if (inputFile != null)
             {
-                File outputFile = new File(inputFile.getAbsoluteFile().getParentFile(), inputFile.getName() + ".report");
-                optionValues.put(OutputPathOption.NAME, outputFile);
+                try
+                {
+                    File canonicalInputFile = inputFile.getCanonicalFile();
+                    File outputFile = new File(canonicalInputFile.getParentFile(), canonicalInputFile.getName() + ".report");
+                    optionValues.put(OutputPathOption.NAME, outputFile);
+                }
+                catch (IOException e)
+                {
+                    throw new WindupException("Failed to get canonical path for input file: " + inputFile);
+                }
             }
         }
     }

--- a/exec/api/src/main/java/org/jboss/windup/exec/configuration/options/TargetOption.java
+++ b/exec/api/src/main/java/org/jboss/windup/exec/configuration/options/TargetOption.java
@@ -63,12 +63,16 @@ public class TargetOption extends AbstractConfigurationOption
 
     public boolean isRequired()
     {
-        return false;
+        return true;
     }
 
     @Override
     public ValidationResult validate(Object value)
     {
+        if (value == null)
+        {
+            return new ValidationResult(ValidationResult.Level.ERROR, NAME + " parameter is required!");
+        }
         return ValidationResult.SUCCESS;
     }
 

--- a/rules-java/api/src/main/java/org/jboss/windup/rules/apps/java/config/EnableClassNotFoundAnalysisOption.java
+++ b/rules-java/api/src/main/java/org/jboss/windup/rules/apps/java/config/EnableClassNotFoundAnalysisOption.java
@@ -1,0 +1,58 @@
+package org.jboss.windup.rules.apps.java.config;
+
+import org.jboss.windup.config.AbstractConfigurationOption;
+import org.jboss.windup.config.InputType;
+import org.jboss.windup.config.ValidationResult;
+
+/**
+ * Gives the user the option to skip class not found analysis.
+ *
+ * @author <a href="mailto:jesse.sightler@gmail.com">Jesse Sightler</a>
+ */
+public class EnableClassNotFoundAnalysisOption extends AbstractConfigurationOption
+{
+    public static final String NAME = "enableClassNotFoundAnalysis";
+
+    @Override
+    public String getName()
+    {
+        return NAME;
+    }
+
+    @Override
+    public String getLabel()
+    {
+        return "Enable Class Not Found Analysis";
+    }
+
+    @Override
+    public String getDescription()
+    {
+        return "Enable analysis of Java files that are not available on the Classpath. This should be left off if" +
+                    " some classes will be unavailable at analysis time.";
+    }
+
+    @Override
+    public Class<?> getType()
+    {
+        return Boolean.class;
+    }
+
+    @Override
+    public InputType getUIType()
+    {
+        return InputType.SINGLE;
+    }
+
+    @Override
+    public boolean isRequired()
+    {
+        return false;
+    }
+
+    @Override
+    public ValidationResult validate(Object value)
+    {
+        return ValidationResult.SUCCESS;
+    }
+}

--- a/rules-java/api/src/main/java/org/jboss/windup/rules/apps/java/decompiler/DecompilerUtil.java
+++ b/rules-java/api/src/main/java/org/jboss/windup/rules/apps/java/decompiler/DecompilerUtil.java
@@ -8,6 +8,7 @@ import org.jboss.windup.graph.GraphContext;
 import org.jboss.windup.graph.model.WindupConfigurationModel;
 import org.jboss.windup.graph.service.WindupConfigurationService;
 import org.jboss.windup.rules.apps.java.model.JavaClassFileModel;
+import org.jboss.windup.util.PathUtil;
 
 /**
  * @author <a href="mailto:jesse.sightler@gmail.com">Jesse Sightler</a>
@@ -26,8 +27,8 @@ public class DecompilerUtil
     {
         final File result;
         WindupConfigurationModel configuration = WindupConfigurationService.getConfigurationModel(context);
-        String inputPath = configuration.getInputPath().getFilePath();
-        if (fileModel.getFilePath().startsWith(inputPath))
+        File inputPath = configuration.getInputPath().asFile();
+        if (PathUtil.isInSubDirectory(inputPath, fileModel.asFile()))
         {
             String outputPath = configuration.getOutputPath().getFilePath();
             result = Paths.get(outputPath).resolve("classes").toFile();

--- a/rules-java/api/src/main/java/org/jboss/windup/rules/apps/java/decompiler/FernflowerDecompilerOperation.java
+++ b/rules-java/api/src/main/java/org/jboss/windup/rules/apps/java/decompiler/FernflowerDecompilerOperation.java
@@ -60,7 +60,7 @@ public class FernflowerDecompilerOperation extends GraphOperation
     @Override
     public void perform(final GraphRewrite event, final EvaluationContext context)
     {
-        ExecutionStatistics.get().begin("ProcyonDecompilationOperation.perform");
+        ExecutionStatistics.get().begin("FernflowerDecompilationOperation.perform");
         int totalCores = Runtime.getRuntime().availableProcessors();
         int threads = totalCores == 0 ? 1 : totalCores;
         LOG.info("Decompiling with " + threads + " threads");
@@ -101,7 +101,7 @@ public class FernflowerDecompilerOperation extends GraphOperation
         decompiler.decompileClassFiles(classesToDecompile, addDecompiledItemsToGraph);
         decompiler.close();
 
-        ExecutionStatistics.get().end("ProcyonDecompilationOperation.perform");
+        ExecutionStatistics.get().end("FernflowerDecompilationOperation.perform");
     }
 
     /**

--- a/rules-java/api/src/main/java/org/jboss/windup/rules/apps/java/model/WindupJavaConfigurationModel.java
+++ b/rules-java/api/src/main/java/org/jboss/windup/rules/apps/java/model/WindupJavaConfigurationModel.java
@@ -28,6 +28,7 @@ public interface WindupJavaConfigurationModel extends WindupVertexFrame
     String SCAN_JAVA_PACKAGES = "scanJavaPackages";
     String IGNORED_FILES = "ignoredFiles";
     String ADDITIONAL_CLASSPATHS = "additionalClasspath";
+    String CLASS_NOT_FOUND_ANALYSIS_ENABLED = "classNotFoundAnalysisEnabled";
 
     /**
      * Specifies which Java packages should be scanned by windup
@@ -100,6 +101,18 @@ public interface WindupJavaConfigurationModel extends WindupVertexFrame
      */
     @Property(SOURCE_MODE)
     void setSourceMode(boolean sourceMode);
+
+    /**
+     * Indicates that we should skip analyzing which classes will not be available at runtime for this application.
+     */
+    @Property(CLASS_NOT_FOUND_ANALYSIS_ENABLED)
+    boolean isClassNotFoundAnalysisEnabled();
+
+    /**
+     * Indicates that we should skip analyzing which classes will not be available at runtime for this application.
+     */
+    @Property(CLASS_NOT_FOUND_ANALYSIS_ENABLED)
+    void setClassNotFoundAnalysisEnabled(boolean classNotFoundAnalysisEnabled);
 
     /**
      * These additional files will be used to aid in resolving references in the application.

--- a/rules-java/api/src/main/java/org/jboss/windup/rules/apps/java/scan/provider/FindUnboundJavaReferencesRuleProvider.java
+++ b/rules-java/api/src/main/java/org/jboss/windup/rules/apps/java/scan/provider/FindUnboundJavaReferencesRuleProvider.java
@@ -8,6 +8,7 @@ import org.jboss.windup.config.operation.GraphOperation;
 import org.jboss.windup.config.phase.DependentPhase;
 import org.jboss.windup.config.phase.PostMigrationRulesPhase;
 import org.jboss.windup.config.phase.PreReportGenerationPhase;
+import org.jboss.windup.config.query.Query;
 import org.jboss.windup.graph.GraphContext;
 import org.jboss.windup.graph.model.WindupVertexFrame;
 import org.jboss.windup.graph.model.resource.SourceFileModel;
@@ -16,6 +17,7 @@ import org.jboss.windup.reporting.config.HasHint;
 import org.jboss.windup.reporting.model.InlineHintModel;
 import org.jboss.windup.reporting.model.Severity;
 import org.jboss.windup.reporting.service.InlineHintService;
+import org.jboss.windup.rules.apps.java.model.WindupJavaConfigurationModel;
 import org.jboss.windup.rules.apps.java.scan.ast.JavaTypeReferenceModel;
 import org.ocpsoft.rewrite.config.Configuration;
 import org.ocpsoft.rewrite.config.ConfigurationBuilder;
@@ -50,6 +52,7 @@ public class FindUnboundJavaReferencesRuleProvider extends AbstractRuleProvider
     {
         return ConfigurationBuilder.begin()
                 .addRule()
+                .when(Query.fromType(WindupJavaConfigurationModel.class).withProperty(WindupJavaConfigurationModel.CLASS_NOT_FOUND_ANALYSIS_ENABLED, true))
                 .perform(new AttachHintOperation())
                 .withId(RULE_ID);
     }

--- a/rules-java/impl/src/main/java/org/jboss/windup/rules/apps/java/config/CopyJavaConfigToGraphRuleProvider.java
+++ b/rules-java/impl/src/main/java/org/jboss/windup/rules/apps/java/config/CopyJavaConfigToGraphRuleProvider.java
@@ -51,6 +51,7 @@ public class CopyJavaConfigToGraphRuleProvider extends AbstractRuleProvider
             {
                 Map<String, Object> config = event.getGraphContext().getOptionMap();
                 Boolean sourceMode = (Boolean) config.get(SourceModeOption.NAME);
+                Boolean enableClassFoundFoundAnalysis = (Boolean) config.get(EnableClassNotFoundAnalysisOption.NAME);
 
                 @SuppressWarnings("unchecked")
                 List<String> includeJavaPackages = (List<String>) config.get(ScanPackagesOption.NAME);
@@ -95,6 +96,7 @@ public class CopyJavaConfigToGraphRuleProvider extends AbstractRuleProvider
                 javaConfiguration.setSourceMode(sourceMode == null ? false : sourceMode);
                 javaConfiguration.setScanJavaPackageList(includeJavaPackages);
                 javaConfiguration.setExcludeJavaPackageList(excludeJavaPackages);
+                javaConfiguration.setClassNotFoundAnalysisEnabled(enableClassFoundFoundAnalysis == null ? false : enableClassFoundFoundAnalysis);
 
                 List<File> additionalClasspaths = (List<File>) config.get(AdditionalClasspathOption.NAME);
                 if (additionalClasspaths != null)

--- a/rules-java/tests/src/test/java/org/jboss/windup/rules/java/JavaClassBindingStatusTest.java
+++ b/rules-java/tests/src/test/java/org/jboss/windup/rules/java/JavaClassBindingStatusTest.java
@@ -36,6 +36,7 @@ import org.jboss.windup.graph.service.GraphService;
 import org.jboss.windup.graph.service.WindupConfigurationService;
 import org.jboss.windup.reporting.config.Hint;
 import org.jboss.windup.rules.apps.java.condition.JavaClass;
+import org.jboss.windup.rules.apps.java.config.EnableClassNotFoundAnalysisOption;
 import org.jboss.windup.rules.apps.java.config.ScanPackagesOption;
 import org.jboss.windup.rules.apps.java.scan.ast.JavaTypeReferenceModel;
 import org.jboss.windup.rules.apps.java.scan.provider.AnalyzeJavaFilesRuleProvider;
@@ -119,6 +120,7 @@ public class JavaClassBindingStatusTest
             processorConfig.setInputPath(Paths.get(inputDir));
             processorConfig.setOutputDirectory(outputPath);
             processorConfig.setOptionValue(ScanPackagesOption.NAME, Collections.singletonList(""));
+            processorConfig.setOptionValue(EnableClassNotFoundAnalysisOption.NAME, true);
 
             processor.execute(processorConfig);
 

--- a/rules-java/tests/src/test/java/org/jboss/windup/rules/java/JavaClassWithoutHintTest.java
+++ b/rules-java/tests/src/test/java/org/jboss/windup/rules/java/JavaClassWithoutHintTest.java
@@ -23,6 +23,7 @@ import org.jboss.windup.graph.GraphContext;
 import org.jboss.windup.graph.GraphContextFactory;
 import org.jboss.windup.graph.service.GraphService;
 import org.jboss.windup.reporting.model.InlineHintModel;
+import org.jboss.windup.rules.apps.java.config.EnableClassNotFoundAnalysisOption;
 import org.jboss.windup.rules.apps.java.config.ScanPackagesOption;
 import org.jboss.windup.rules.apps.java.scan.ast.JavaTypeReferenceModel;
 import org.jboss.windup.rules.apps.java.scan.provider.FindUnboundJavaReferencesRuleProvider;
@@ -67,6 +68,7 @@ public class JavaClassWithoutHintTest
             processorConfig.setInputPath(Paths.get(inputDir));
             processorConfig.setOutputDirectory(outputPath);
             processorConfig.setOptionValue(ScanPackagesOption.NAME, Collections.singletonList(""));
+            processorConfig.setOptionValue(EnableClassNotFoundAnalysisOption.NAME, true);
             processorConfig.setRuleProviderFilter(new NotPredicate(new EnumeratedRuleProviderPredicate(FindUnboundJavaReferencesRuleProvider.class)));
 
             processor.execute(processorConfig);

--- a/ui/tests/src/test/java/org/jboss/windup/addon/ui/WindupCommandRuleFilteringTest.java
+++ b/ui/tests/src/test/java/org/jboss/windup/addon/ui/WindupCommandRuleFilteringTest.java
@@ -96,9 +96,9 @@ public class WindupCommandRuleFilteringTest
     @Test
     public void testRuleFilteringSourceGlassfish() throws Exception
     {
-        setupAndRun(null, null, Collections.singleton("glassfish"), null);
+        setupAndRun(null, null, Collections.singleton("glassfish"), Collections.singleton("jboss"));
         Assert.assertTrue(this.tag1SourceGlassfishRuleProvider.executed);
-        Assert.assertTrue(this.tag1SourceGlassfishTargetFooRuleProvider.executed);
+        Assert.assertFalse(this.tag1SourceGlassfishTargetFooRuleProvider.executed);
         Assert.assertTrue(this.tag2SourceGlassfishTargetJBossRuleProvider.executed);
         Assert.assertFalse(this.tag3SourceOrionServerRuleProvider.executed);
     }
@@ -116,17 +116,17 @@ public class WindupCommandRuleFilteringTest
     @Test
     public void testRuleFilteringExcludeTag3() throws Exception
     {
-        setupAndRun(null, Collections.singleton("tag3"), null, null);
-        Assert.assertTrue(this.tag1SourceGlassfishRuleProvider.executed);
+        setupAndRun(null, Collections.singleton("tag3"), Collections.singleton("glassfish"), Collections.singleton("foo"));
+        Assert.assertFalse(this.tag1SourceGlassfishRuleProvider.executed);
         Assert.assertTrue(this.tag1SourceGlassfishTargetFooRuleProvider.executed);
-        Assert.assertTrue(this.tag2SourceGlassfishTargetJBossRuleProvider.executed);
+        Assert.assertFalse(this.tag2SourceGlassfishTargetJBossRuleProvider.executed);
         Assert.assertFalse(this.tag3SourceOrionServerRuleProvider.executed);
     }
 
     @Test
     public void testRuleFilteringIncludeTag2() throws Exception
     {
-        setupAndRun(Collections.singleton("tag2"), null, null, null);
+        setupAndRun(Collections.singleton("tag2"), null, null, Collections.singleton("jboss"));
         Assert.assertFalse(this.tag1SourceGlassfishRuleProvider.executed);
         Assert.assertFalse(this.tag1SourceGlassfishTargetFooRuleProvider.executed);
         Assert.assertTrue(this.tag2SourceGlassfishTargetJBossRuleProvider.executed);
@@ -164,12 +164,10 @@ public class WindupCommandRuleFilteringTest
                 controller.initialize();
                 Assert.assertTrue(controller.isEnabled());
                 controller.setValueFor("input", inputFile);
-                Assert.assertTrue(controller.canExecute());
                 if (outputFile != null)
                 {
                     controller.setValueFor("output", outputFile);
                 }
-                Assert.assertTrue(controller.canExecute());
 
                 if (includeTags != null)
                 {
@@ -190,6 +188,7 @@ public class WindupCommandRuleFilteringTest
                 {
                     controller.setValueFor(TargetOption.NAME, targets);
                 }
+                Assert.assertTrue(controller.canExecute());
 
                 Result result = controller.execute();
                 final String msg = "controller.execute() 'Failed': " + result.getMessage();
@@ -212,7 +211,8 @@ public class WindupCommandRuleFilteringTest
         {
             super(MetadataBuilder.forProvider(Tag1SourceGlassfishRuleProvider.class)
                         .addTag("tag1")
-                        .addSourceTechnology(new TechnologyReference("glassfish", "[1.0,)")));
+                        .addSourceTechnology(new TechnologyReference("glassfish", "[1.0,)"))
+                        .addTargetTechnology(new TechnologyReference("jboss", "[1.0,)")));
         }
 
         @Override
@@ -301,7 +301,8 @@ public class WindupCommandRuleFilteringTest
         {
             super(MetadataBuilder.forProvider(Tag3SourceOrionServerRuleProvider.class)
                         .addTag("tag3")
-                        .addSourceTechnology(new TechnologyReference("orion", "[1.0,)")));
+                        .addSourceTechnology(new TechnologyReference("orion", "[1.0,)"))
+                        .addTargetTechnology(new TechnologyReference("foo", "[1.0,)")));
         }
 
         @Override

--- a/ui/tests/src/test/java/org/jboss/windup/addon/ui/WindupCommandTest.java
+++ b/ui/tests/src/test/java/org/jboss/windup/addon/ui/WindupCommandTest.java
@@ -6,6 +6,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Collections;
 import java.util.List;
 
 import javax.inject.Inject;
@@ -29,6 +30,7 @@ import org.jboss.forge.arquillian.archive.AddonArchive;
 import org.jboss.forge.furnace.util.OperatingSystemUtils;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.windup.exec.configuration.WindupConfiguration;
+import org.jboss.windup.exec.configuration.options.TargetOption;
 import org.jboss.windup.exec.configuration.options.UserIgnorePathOption;
 import org.jboss.windup.exec.configuration.options.UserRulesDirectoryOption;
 import org.jboss.windup.graph.GraphContext;
@@ -101,6 +103,7 @@ public class WindupCommandTest
             {
                 controller.initialize();
                 Assert.assertTrue(controller.isEnabled());
+                controller.setValueFor(TargetOption.NAME, Collections.singletonList("jboss"));
                 controller.setValueFor("input", inputFile);
                 Assert.assertTrue(controller.canExecute());
                 controller.setValueFor("output", tempDir);
@@ -490,11 +493,11 @@ public class WindupCommandTest
         controller.initialize();
         Assert.assertTrue(controller.isEnabled());
         controller.setValueFor("input", inputFile);
-        Assert.assertTrue(controller.canExecute());
         if (outputFile != null)
         {
             controller.setValueFor("output", outputFile);
         }
+        controller.setValueFor(TargetOption.NAME, Collections.singletonList("jboss"));
         Assert.assertTrue(controller.canExecute());
         controller.setValueFor("packages", "org.jboss");
         Assert.assertTrue(controller.canExecute());

--- a/utils/src/main/java/org/jboss/windup/util/PathUtil.java
+++ b/utils/src/main/java/org/jboss/windup/util/PathUtil.java
@@ -192,6 +192,25 @@ public class PathUtil
         return currentPath;
     }
 
+    /**
+     * Returns true if "file" is a subfile or subdirectory of "dir".
+     *
+     * For example with the directory /path/to/a, the following return values would occur:
+     *
+     * /path/to/a/foo.txt - true /path/to/a/bar/zoo/boo/team.txt - true /path/to/b/foo.txt - false
+     *
+     */
+    public static boolean isInSubDirectory(File dir, File file)
+    {
+        if (file == null)
+            return false;
+
+        if (file.equals(dir))
+            return true;
+
+        return isInSubDirectory(dir, file.getParentFile());
+    }
+
     /*
      * Helpers
      */


### PR DESCRIPTION
This also makes "target" a required parameter.