### PR TITLE
WINDUP-762: Windup is exceptionally slow to process applications in which a single rule attaches a large number of classifications

### DIFF
--- a/config/api/src/main/java/org/jboss/windup/config/operation/Commit.java
+++ b/config/api/src/main/java/org/jboss/windup/config/operation/Commit.java
@@ -22,7 +22,7 @@ public class Commit extends GraphOperation
     public void perform(GraphRewrite event, EvaluationContext context)
     {
         uncommittedIterations++;
-        if (uncommittedIterations > period)
+        if (uncommittedIterations >= period)
         {
             event.getGraphContext().getGraph().getBaseGraph().commit();
             uncommittedIterations = 0;

--- a/config/api/src/main/java/org/jboss/windup/config/operation/IterationProgress.java
+++ b/config/api/src/main/java/org/jboss/windup/config/operation/IterationProgress.java
@@ -27,7 +27,7 @@ public class IterationProgress extends AbstractIterationOperation<WindupVertexFr
     private ProgressEstimate progressEstimate;
     private String variableListName = Iteration.DEFAULT_VARIABLE_LIST_STRING;
 
-    public IterationProgress(String messagePrefix, int interval)
+    private IterationProgress(String messagePrefix, int interval)
     {
         this.messagePrefix = messagePrefix;
         this.interval = interval;

--- a/config/api/src/main/java/org/jboss/windup/config/operation/OperationUtil.java
+++ b/config/api/src/main/java/org/jboss/windup/config/operation/OperationUtil.java
@@ -1,0 +1,56 @@
+package org.jboss.windup.config.operation;
+
+import java.util.List;
+
+import org.ocpsoft.rewrite.config.CompositeOperation;
+import org.ocpsoft.rewrite.config.Operation;
+
+/**
+ * Contains useful functions for operating on Rewrite {@link Operation}s.
+ *
+ * @author <a href="mailto:jesse.sightler@gmail.com">Jesse Sightler</a>
+ */
+public class OperationUtil
+{
+    /**
+     * Indicates whether or not the provided {@link Operation} is or contains any {@link Operation}s of the specified type. This will recursively
+     * check all of the suboperations on {@link CompositeOperation}s as well.
+     */
+    public static boolean hasOperationType(Operation operation, Class<? extends Operation> operationType)
+    {
+        if (operation == null)
+            return false;
+
+        if (operationType.isAssignableFrom(operation.getClass()))
+            return true;
+
+        if (operation instanceof CompositeOperation)
+        {
+            List<Operation> operations = ((CompositeOperation) operation).getOperations();
+            for (Operation childOperation : operations)
+            {
+                if (hasOperationType(childOperation, operationType))
+                    return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Indicates whether the operation contains any {@link Commit} operations.
+     */
+    public static boolean hasCommitOperation(Operation operation)
+    {
+        return hasOperationType(operation, Commit.class);
+    }
+
+    /**
+     * Indicates whether the operation contains any {@link IterationProgress} operations.
+     */
+    public static boolean hasIterationProgress(Operation operation)
+    {
+        return hasOperationType(operation, IterationProgress.class);
+    }
+
+}

--- a/config/tests/src/test/java/org/jboss/windup/config/iteration/IterationAutomicCommitTest.java
+++ b/config/tests/src/test/java/org/jboss/windup/config/iteration/IterationAutomicCommitTest.java
@@ -1,0 +1,546 @@
+package org.jboss.windup.config.iteration;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+
+import javax.inject.Inject;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.forge.arquillian.AddonDependencies;
+import org.jboss.forge.arquillian.AddonDependency;
+import org.jboss.forge.arquillian.archive.AddonArchive;
+import org.jboss.forge.furnace.util.OperatingSystemUtils;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.windup.config.AbstractRuleProvider;
+import org.jboss.windup.config.DefaultEvaluationContext;
+import org.jboss.windup.config.GraphRewrite;
+import org.jboss.windup.config.RuleSubset;
+import org.jboss.windup.config.metadata.MetadataBuilder;
+import org.jboss.windup.config.operation.GraphOperation;
+import org.jboss.windup.config.operation.Iteration;
+import org.jboss.windup.config.query.Query;
+import org.jboss.windup.graph.GraphContext;
+import org.jboss.windup.graph.GraphContextFactory;
+import org.jboss.windup.graph.GraphTypeRegistry;
+import org.jboss.windup.graph.frames.TypeAwareFramedGraphQuery;
+import org.jboss.windup.graph.model.WindupConfigurationModel;
+import org.jboss.windup.graph.model.resource.FileModel;
+import org.jboss.windup.graph.service.FileService;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.ocpsoft.rewrite.config.Configuration;
+import org.ocpsoft.rewrite.config.ConfigurationBuilder;
+import org.ocpsoft.rewrite.context.EvaluationContext;
+import org.ocpsoft.rewrite.param.DefaultParameterValueStore;
+import org.ocpsoft.rewrite.param.ParameterValueStore;
+
+import com.thinkaurelius.titan.core.EdgeLabel;
+import com.thinkaurelius.titan.core.PropertyKey;
+import com.thinkaurelius.titan.core.RelationType;
+import com.thinkaurelius.titan.core.TitanException;
+import com.thinkaurelius.titan.core.TitanGraph;
+import com.thinkaurelius.titan.core.TitanGraphQuery;
+import com.thinkaurelius.titan.core.TitanIndexQuery;
+import com.thinkaurelius.titan.core.TitanMultiVertexQuery;
+import com.thinkaurelius.titan.core.TitanTransaction;
+import com.thinkaurelius.titan.core.TitanVertex;
+import com.thinkaurelius.titan.core.TransactionBuilder;
+import com.thinkaurelius.titan.core.VertexLabel;
+import com.thinkaurelius.titan.core.schema.EdgeLabelMaker;
+import com.thinkaurelius.titan.core.schema.PropertyKeyMaker;
+import com.thinkaurelius.titan.core.schema.TitanManagement;
+import com.thinkaurelius.titan.core.schema.VertexLabelMaker;
+import com.tinkerpop.blueprints.Edge;
+import com.tinkerpop.blueprints.Element;
+import com.tinkerpop.blueprints.Features;
+import com.tinkerpop.blueprints.Parameter;
+import com.tinkerpop.blueprints.Vertex;
+import com.tinkerpop.blueprints.util.wrappers.event.EventGraph;
+import com.tinkerpop.frames.FramedGraph;
+
+/**
+ * This tests whether or not the automatic insertion of progress tracking and commit operations is handled correctly.
+ *
+ * @author <a href="mailto:jesse.sightler@gmail.com">Jesse Sightler</a>
+ */
+@RunWith(Arquillian.class)
+public class IterationAutomicCommitTest
+{
+    @Deployment
+    @AddonDependencies({
+                @AddonDependency(name = "org.jboss.windup.config:windup-config"),
+                @AddonDependency(name = "org.jboss.windup.graph:windup-graph"),
+                @AddonDependency(name = "org.jboss.windup.rules.apps:windup-rules-java"),
+                @AddonDependency(name = "org.jboss.forge.furnace.container:cdi")
+    })
+    public static AddonArchive getDeployment()
+    {
+        return ShrinkWrap.create(AddonArchive.class).addBeansXML();
+    }
+
+    @Inject
+    private GraphContextFactory factory;
+
+    private DefaultEvaluationContext createEvalContext(GraphRewrite event)
+    {
+        final DefaultEvaluationContext evaluationContext = new DefaultEvaluationContext();
+        final DefaultParameterValueStore values = new DefaultParameterValueStore();
+        evaluationContext.put(ParameterValueStore.class, values);
+        return evaluationContext;
+    }
+
+    @Test
+    public void testAutomaticPeriodicCommit() throws Exception
+    {
+        final Path folder = OperatingSystemUtils.createTempDir().toPath();
+        try (final GraphContext baseContext = factory.create(folder))
+        {
+            CommitInterceptingGraphContext context = new CommitInterceptingGraphContext(baseContext);
+
+            GraphRewrite event = new GraphRewrite(context);
+            DefaultEvaluationContext evaluationContext = createEvalContext(event);
+
+            WindupConfigurationModel windupCfg = context.getFramed().addVertex(null, WindupConfigurationModel.class);
+            FileService fileModelService = new FileService(context);
+            windupCfg.setInputPath(fileModelService.createByFilePath(OperatingSystemUtils.createTempDir()
+                        .getAbsolutePath()));
+
+            TestRuleProvider provider = new TestRuleProvider();
+            Configuration configuration = provider.getConfiguration(context);
+
+            RuleSubset.create(configuration).perform(event, evaluationContext);
+
+            CommitInterceptingTitanGraph titanGraph = (CommitInterceptingTitanGraph) context.getGraph().getBaseGraph();
+            Assert.assertEquals(1, titanGraph.commitCount);
+
+            // Now create a few hundred FileModels to see if autocommit happens periodically
+            for (int i = 0; i < 800; i++)
+            {
+                fileModelService.create().setFilePath("foo." + i);
+            }
+            titanGraph.commitCount = 0;
+
+            RuleSubset.create(configuration).perform(event, evaluationContext);
+            Assert.assertEquals(9, titanGraph.commitCount);
+        }
+    }
+
+    public class TestRuleProvider extends AbstractRuleProvider
+    {
+        public TestRuleProvider()
+        {
+            super(MetadataBuilder.forProvider(TestRuleProvider.class));
+        }
+
+        // @formatter:off
+        @Override
+        public Configuration getConfiguration(GraphContext context)
+        {
+            Configuration configuration = ConfigurationBuilder.begin()
+                    .addRule()
+                    .when(Query.fromType(FileModel.class))
+                    .perform(Iteration
+                                    .over()
+                                    .perform(new GraphOperation() {
+                                        @Override
+                                        public void perform(GraphRewrite event, EvaluationContext context) {
+                                            // no-op
+                                        }
+                                    })
+                                    .endIteration()
+                    );
+            return configuration;
+        }
+        // @formatter:on
+
+    }
+
+    private class CommitInterceptingTitanGraph implements TitanGraph
+    {
+        private int commitCount = 0;
+        private TitanGraph delegate;
+
+        public CommitInterceptingTitanGraph(TitanGraph delegate)
+        {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public TitanTransaction newTransaction()
+        {
+            return delegate.newTransaction();
+        }
+
+        @Override
+        public TransactionBuilder buildTransaction()
+        {
+            return delegate.buildTransaction();
+        }
+
+        @Override
+        public TitanManagement getManagementSystem()
+        {
+            return delegate.getManagementSystem();
+        }
+
+        @Override
+        public boolean isOpen()
+        {
+            return delegate.isOpen();
+        }
+
+        @Override
+        public boolean isClosed()
+        {
+            return delegate.isClosed();
+        }
+
+        @Override
+        public void shutdown() throws TitanException
+        {
+            delegate.shutdown();
+        }
+
+        @Override
+        public TitanVertex addVertex()
+        {
+            return delegate.addVertex();
+        }
+
+        @Override
+        public TitanVertex addVertexWithLabel(String vertexLabel)
+        {
+            return delegate.addVertexWithLabel(vertexLabel);
+        }
+
+        @Override
+        public TitanVertex addVertexWithLabel(VertexLabel vertexLabel)
+        {
+            return delegate.addVertexWithLabel(vertexLabel);
+        }
+
+        @Override
+        public TitanVertex getVertex(long id)
+        {
+            return delegate.getVertex(id);
+        }
+
+        @Override
+        public Map<Long, TitanVertex> getVertices(long... ids)
+        {
+            return delegate.getVertices(ids);
+        }
+
+        @Override
+        public boolean containsVertex(long vertexid)
+        {
+            return delegate.containsVertex(vertexid);
+        }
+
+        @Override
+        public TitanGraphQuery<? extends TitanGraphQuery> query()
+        {
+            return delegate.query();
+        }
+
+        @Override
+        public TitanIndexQuery indexQuery(String indexName, String query)
+        {
+            return delegate.indexQuery(indexName, query);
+        }
+
+        @Override
+        public TitanMultiVertexQuery<? extends TitanMultiVertexQuery> multiQuery(TitanVertex... vertices)
+        {
+            return delegate.multiQuery(vertices);
+        }
+
+        @Override
+        public TitanMultiVertexQuery<? extends TitanMultiVertexQuery> multiQuery(Collection<TitanVertex> vertices)
+        {
+            return delegate.multiQuery(vertices);
+        }
+
+        @Override
+        @Deprecated
+        public void stopTransaction(Conclusion conclusion)
+        {
+            delegate.stopTransaction(conclusion);
+        }
+
+        @Override
+        public void commit()
+        {
+            commitCount++;
+            delegate.commit();
+        }
+
+        @Override
+        public void rollback()
+        {
+            delegate.rollback();
+        }
+
+        @Override
+        public Features getFeatures()
+        {
+            return delegate.getFeatures();
+        }
+
+        @Override
+        public Vertex addVertex(Object id)
+        {
+            return delegate.addVertex(id);
+        }
+
+        @Override
+        public Vertex getVertex(Object id)
+        {
+            return delegate.getVertex(id);
+        }
+
+        @Override
+        public void removeVertex(Vertex vertex)
+        {
+            delegate.removeVertex(vertex);
+        }
+
+        @Override
+        public Iterable<Vertex> getVertices()
+        {
+            return delegate.getVertices();
+        }
+
+        @Override
+        public Iterable<Vertex> getVertices(String key, Object value)
+        {
+            return delegate.getVertices(key, value);
+        }
+
+        @Override
+        public Edge addEdge(Object id, Vertex outVertex, Vertex inVertex, String label)
+        {
+            return delegate.addEdge(id, outVertex, inVertex, label);
+        }
+
+        @Override
+        public Edge getEdge(Object id)
+        {
+            return delegate.getEdge(id);
+        }
+
+        @Override
+        public void removeEdge(Edge edge)
+        {
+            delegate.removeEdge(edge);
+        }
+
+        @Override
+        public Iterable<Edge> getEdges()
+        {
+            return delegate.getEdges();
+        }
+
+        @Override
+        public Iterable<Edge> getEdges(String key, Object value)
+        {
+            return delegate.getEdges(key, value);
+        }
+
+        @Override
+        public <T extends Element> void dropKeyIndex(String key, Class<T> elementClass)
+        {
+            delegate.dropKeyIndex(key, elementClass);
+        }
+
+        @Override
+        public <T extends Element> void createKeyIndex(String key, Class<T> elementClass, Parameter... indexParameters)
+        {
+            delegate.createKeyIndex(key, elementClass, indexParameters);
+        }
+
+        @Override
+        public <T extends Element> Set<String> getIndexedKeys(Class<T> elementClass)
+        {
+            return delegate.getIndexedKeys(elementClass);
+        }
+
+        @Override
+        public PropertyKeyMaker makePropertyKey(String name)
+        {
+            return delegate.makePropertyKey(name);
+        }
+
+        @Override
+        public EdgeLabelMaker makeEdgeLabel(String name)
+        {
+            return delegate.makeEdgeLabel(name);
+        }
+
+        @Override
+        public VertexLabelMaker makeVertexLabel(String name)
+        {
+            return delegate.makeVertexLabel(name);
+        }
+
+        @Override
+        public boolean containsRelationType(String name)
+        {
+            return delegate.containsRelationType(name);
+        }
+
+        @Override
+        public RelationType getRelationType(String name)
+        {
+            return delegate.getRelationType(name);
+        }
+
+        @Override
+        public boolean containsPropertyKey(String name)
+        {
+            return delegate.containsPropertyKey(name);
+        }
+
+        @Override
+        public PropertyKey getOrCreatePropertyKey(String name)
+        {
+            return delegate.getOrCreatePropertyKey(name);
+        }
+
+        @Override
+        public PropertyKey getPropertyKey(String name)
+        {
+            return delegate.getPropertyKey(name);
+        }
+
+        @Override
+        public boolean containsEdgeLabel(String name)
+        {
+            return delegate.containsEdgeLabel(name);
+        }
+
+        @Override
+        public EdgeLabel getOrCreateEdgeLabel(String name)
+        {
+            return delegate.getOrCreateEdgeLabel(name);
+        }
+
+        @Override
+        public EdgeLabel getEdgeLabel(String name)
+        {
+            return delegate.getEdgeLabel(name);
+        }
+
+        @Override
+        public boolean containsVertexLabel(String name)
+        {
+            return delegate.containsVertexLabel(name);
+        }
+
+        @Override
+        public VertexLabel getVertexLabel(String name)
+        {
+            return delegate.getVertexLabel(name);
+        }
+    }
+
+    private class CommitInterceptingEventGraph extends EventGraph<TitanGraph>
+    {
+        private CommitInterceptingTitanGraph commitInterceptingTitanGraph;
+
+        public CommitInterceptingEventGraph(TitanGraph baseGraph)
+        {
+            super(baseGraph);
+            this.commitInterceptingTitanGraph = new CommitInterceptingTitanGraph(baseGraph);
+        }
+
+        @Override
+        public TitanGraph getBaseGraph()
+        {
+            return commitInterceptingTitanGraph;
+        }
+    }
+
+    private class CommitInterceptingGraphContext implements GraphContext
+    {
+        private GraphContext delegate;
+        private CommitInterceptingEventGraph commitInterceptingEventGraph;
+
+        public CommitInterceptingGraphContext(GraphContext delegate)
+        {
+            this.delegate = delegate;
+            this.commitInterceptingEventGraph = new CommitInterceptingEventGraph(delegate.getGraph().getBaseGraph());
+        }
+
+        @Override
+        public Path getGraphDirectory()
+        {
+            return delegate.getGraphDirectory();
+        }
+
+        @Override
+        public EventGraph<TitanGraph> getGraph()
+        {
+            return commitInterceptingEventGraph;
+        }
+
+        @Override
+        public GraphContext create()
+        {
+            return delegate.create();
+        }
+
+        @Override
+        public GraphContext load()
+        {
+            return delegate.load();
+        }
+
+        @Override
+        public FramedGraph<EventGraph<TitanGraph>> getFramed()
+        {
+            return delegate.getFramed();
+        }
+
+        @Override
+        public GraphTypeRegistry getGraphTypeRegistry()
+        {
+            return delegate.getGraphTypeRegistry();
+        }
+
+        @Override
+        public TypeAwareFramedGraphQuery getQuery()
+        {
+            return delegate.getQuery();
+        }
+
+        @Override
+        public void clear()
+        {
+            delegate.clear();
+        }
+
+        @Override
+        public void setOptions(Map<String, Object> options)
+        {
+            delegate.setOptions(options);
+        }
+
+        @Override
+        public Map<String, Object> getOptionMap()
+        {
+            return delegate.getOptionMap();
+        }
+
+        @Override
+        public void close() throws IOException
+        {
+            delegate.close();
+        }
+    }
+}

--- a/config/tests/src/test/java/org/jboss/windup/config/iteration/RuleIterationOverAllSpecifiedTest.java
+++ b/config/tests/src/test/java/org/jboss/windup/config/iteration/RuleIterationOverAllSpecifiedTest.java
@@ -6,8 +6,8 @@ import javax.inject.Inject;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
-import org.jboss.forge.arquillian.AddonDependency;
 import org.jboss.forge.arquillian.AddonDependencies;
+import org.jboss.forge.arquillian.AddonDependency;
 import org.jboss.forge.arquillian.archive.AddonArchive;
 import org.jboss.forge.furnace.util.OperatingSystemUtils;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -50,14 +50,9 @@ public class RuleIterationOverAllSpecifiedTest
     })
     public static AddonArchive getDeployment()
     {
-        final AddonArchive archive = ShrinkWrap.create(AddonArchive.class)
+        return ShrinkWrap.create(AddonArchive.class)
                     .addBeansXML()
-                    .addClasses(
-                                TestRuleIterationOverAllSpecifiedProvider.class,
-                                TestRuleIterationOverAllSpecifiedWithExceptionProvider.class,
-                                TestSimple1Model.class,
-                                TestSimple2Model.class);
-        return archive;
+                    .addClasses(TestSimple1Model.class, TestSimple2Model.class);
     }
 
     @Inject
@@ -241,7 +236,7 @@ public class RuleIterationOverAllSpecifiedTest
                         );
             return configuration;
         }
-        // @formatter:off
+        // @formatter:on
 
     }
 

--- a/reporting/api/src/main/java/org/jboss/windup/reporting/model/ClassificationModel.java
+++ b/reporting/api/src/main/java/org/jboss/windup/reporting/model/ClassificationModel.java
@@ -1,6 +1,9 @@
 package org.jboss.windup.reporting.model;
 
+import java.util.Set;
+
 import org.jboss.windup.graph.Indexed;
+import org.jboss.windup.graph.SetInProperties;
 import org.jboss.windup.graph.model.resource.FileModel;
 import org.jboss.windup.reporting.model.association.LinkableModel;
 import org.ocpsoft.rewrite.config.Rule;
@@ -9,8 +12,6 @@ import com.tinkerpop.blueprints.Direction;
 import com.tinkerpop.frames.Adjacency;
 import com.tinkerpop.frames.Property;
 import com.tinkerpop.frames.modules.typedgraph.TypeValue;
-import java.util.Set;
-import org.jboss.windup.graph.SetInProperties;
 
 /**
  * This classifies files and provides general background information about a specific {@link FileModel}. (For instance,
@@ -20,13 +21,13 @@ import org.jboss.windup.graph.SetInProperties;
 @TypeValue(ClassificationModel.TYPE)
 public interface ClassificationModel extends EffortReportModel, LinkableModel
 {
-    static final String TYPE = "ClassificationModel";
-    static final String TYPE_PREFIX = TYPE + ":";
-    static final String RULE_ID = TYPE_PREFIX + "ruleID";
-    static final String CLASSIFICATION = TYPE_PREFIX + "classification";
-    static final String DESCRIPTION = TYPE_PREFIX + "description";
+    String TYPE = "ClassificationModel";
+    String TYPE_PREFIX = TYPE + ":";
+    String RULE_ID = TYPE_PREFIX + "ruleID";
+    String CLASSIFICATION = TYPE_PREFIX + "classification";
+    String DESCRIPTION = TYPE_PREFIX + "description";
 
-    static final String FILE_MODEL = TYPE_PREFIX + "classificationModelToFileModel";
+    String FILE_MODEL = TYPE_PREFIX + "classificationModelToFileModel";
 
     /**
      * Add a {@link FileModel} associated with this {@link ClassificationModel}.

--- a/reporting/api/src/main/java/org/jboss/windup/reporting/service/ClassificationService.java
+++ b/reporting/api/src/main/java/org/jboss/windup/reporting/service/ClassificationService.java
@@ -138,21 +138,23 @@ public class ClassificationService extends GraphService<ClassificationModel>
         return attachClassification(rule, fileModel, classificationText, description);
     }
 
+    private boolean isClassificationLinkedToFileModel(ClassificationModel classificationModel, FileModel fileModel)
+    {
+        return ClassificationServiceCache.isClassificationLinkedToFileModel(classificationModel, fileModel);
+    }
+
     /**
      * This method just attaches the {@link ClassificationModel} to the {@link Length.FileMode}. It will only do so if this link is not already
      * present.
      */
     public ClassificationModel attachClassification(ClassificationModel classificationModel, FileModel fileModel)
     {
-        // check for duplicates
-        for (FileModel existingFileModel : classificationModel.getFileModels())
+        if (!isClassificationLinkedToFileModel(classificationModel, fileModel))
         {
-            if (existingFileModel.equals(fileModel))
-            {
-                return classificationModel;
-            }
+            classificationModel.addFileModel(fileModel);
         }
-        classificationModel.addFileModel(fileModel);
+        ClassificationServiceCache.cacheClassificationFileModel(classificationModel, fileModel, true);
+
         return classificationModel;
     }
 

--- a/reporting/api/src/main/java/org/jboss/windup/reporting/service/ClassificationServiceCache.java
+++ b/reporting/api/src/main/java/org/jboss/windup/reporting/service/ClassificationServiceCache.java
@@ -1,0 +1,81 @@
+package org.jboss.windup.reporting.service;
+
+import java.util.Collections;
+import java.util.Map;
+
+import org.apache.commons.collections.map.LRUMap;
+import org.jboss.windup.config.AbstractRuleLifecycleListener;
+import org.jboss.windup.config.GraphRewrite;
+import org.jboss.windup.config.RuleLifecycleListener;
+import org.jboss.windup.graph.model.resource.FileModel;
+import org.jboss.windup.reporting.model.ClassificationModel;
+
+import com.tinkerpop.blueprints.Vertex;
+import com.tinkerpop.gremlin.java.GremlinPipeline;
+
+/**
+ * @author <a href="mailto:jesse.sightler@gmail.com">Jesse Sightler</a>
+ */
+class ClassificationServiceCache extends AbstractRuleLifecycleListener implements RuleLifecycleListener
+{
+    /**
+     * Keep a cache of items files associated with classification in order to improve performance.
+     */
+    private static Map<String, Boolean> classificationFileModelCache = Collections.synchronizedMap(new LRUMap(30000));
+
+    /**
+     * Indicates whether or not the given {@link FileModel} is already attached to the {@link ClassificationModel}.
+     *
+     * Note that this assumes all {@link ClassificationModel} attachments are handled via the {@link ClassificationService}.
+     *
+     * Outside of tests, this should be a safe assumption to make.
+     */
+    static boolean isClassificationLinkedToFileModel(ClassificationModel classificationModel, FileModel fileModel)
+    {
+        String key = getClassificationFileModelCacheKey(classificationModel, fileModel);
+        Boolean linked = classificationFileModelCache.get(key);
+
+        if (linked == null)
+        {
+            GremlinPipeline<Vertex, Vertex> existenceCheck = new GremlinPipeline<>(classificationModel.asVertex());
+            existenceCheck.out(ClassificationModel.FILE_MODEL);
+            existenceCheck.retain(Collections.singleton(classificationModel.asVertex()));
+
+            linked = existenceCheck.iterator().hasNext();
+            cacheClassificationFileModel(classificationModel, fileModel, linked);
+        }
+        return linked;
+    }
+
+    /**
+     * Cache the status of the link between the provided {@link ClassificationModel} and the given {@link FileModel}.
+     */
+    static void cacheClassificationFileModel(ClassificationModel classificationModel, FileModel fileModel, boolean linked)
+    {
+        String key = getClassificationFileModelCacheKey(classificationModel, fileModel);
+        classificationFileModelCache.put(key, linked);
+    }
+
+    private static String getClassificationFileModelCacheKey(ClassificationModel classificationModel, FileModel fileModel)
+    {
+        StringBuilder builder = new StringBuilder();
+        if (classificationModel != null)
+            builder.append(classificationModel.asVertex().getId());
+        builder.append("_");
+        if (fileModel != null)
+            builder.append(fileModel.asVertex().getId());
+        return builder.toString();
+    }
+
+    @Override
+    public void beforeExecution(GraphRewrite event)
+    {
+        classificationFileModelCache.clear();
+    }
+
+    @Override
+    public void afterExecution(GraphRewrite event)
+    {
+        classificationFileModelCache.clear();
+    }
+}

--- a/rules-java/api/src/main/java/org/jboss/windup/rules/apps/java/scan/provider/IndexJavaClassFilesRuleProvider.java
+++ b/rules-java/api/src/main/java/org/jboss/windup/rules/apps/java/scan/provider/IndexJavaClassFilesRuleProvider.java
@@ -33,7 +33,7 @@ public class IndexJavaClassFilesRuleProvider extends AbstractRuleProvider
                     .when(Query.fromType(JavaClassFileModel.class))
                     .perform(
                         new AddClassFileMetadata()
-                        .and(Commit.every(10))
+                        .and(Commit.every(100))
                         .and(IterationProgress.monitoring("Index Class Files", 1000))
                     );
     }


### PR DESCRIPTION
This still needs:

1. Code cleanup (additional comments)
2. A Unit test
3. A full run of the Windup unit tests

This also adds implicit periodic commits and progress monitoring to any Iteration that does not already have them enabled.