### PR TITLE
Change misleading "not-executed" to "not-performed"

### DIFF
--- a/reporting/impl/src/main/resources/reports/templates/ruleprovidersummary.ftl
+++ b/reporting/impl/src/main/resources/reports/templates/ruleprovidersummary.ftl
@@ -76,7 +76,7 @@
 										<div>Edges Removed: ${ruleExecutionInfo.edgeIDsRemoved}</div>
 									</td>					
 									<td>
-										${ruleExecutionInfo.executed?string("executed", "not-executed")}
+										${ruleExecutionInfo.executed?string("performed", "not-performed")}
 									</td>
 									<td>
 										${ruleExecutionInfo.failed?string("failed", "success")}

--- a/reporting/impl/src/main/resources/reports/templates/ruleprovidersummary.ftl
+++ b/reporting/impl/src/main/resources/reports/templates/ruleprovidersummary.ftl
@@ -76,7 +76,7 @@
 										<div>Edges Removed: ${ruleExecutionInfo.edgeIDsRemoved}</div>
 									</td>					
 									<td>
-										${ruleExecutionInfo.executed?string("Satisfied and performed.", "Condition not satisfied.")}
+										${ruleExecutionInfo.executed?string("Condition met.", "Condition not met.")}
 									</td>
 									<td>
 										${ruleExecutionInfo.failed?string("failed", "success")}

--- a/reporting/impl/src/main/resources/reports/templates/ruleprovidersummary.ftl
+++ b/reporting/impl/src/main/resources/reports/templates/ruleprovidersummary.ftl
@@ -76,7 +76,7 @@
 										<div>Edges Removed: ${ruleExecutionInfo.edgeIDsRemoved}</div>
 									</td>					
 									<td>
-										${ruleExecutionInfo.executed?string("performed", "not-performed")}
+										${ruleExecutionInfo.executed?string("Satisfied and performed.", "Condition not satisfied.")}
 									</td>
 									<td>
 										${ruleExecutionInfo.failed?string("failed", "success")}


### PR DESCRIPTION
not-executed makes people think that the rule was not executed at all, including the condition.

16:44:33) jsightler: ozizka: Maybe "not-matched" would be better than "not-performed"?
(16:44:54) jsightler: To me, not-performed and not-executed are essentially synonymous 
(16:45:21) rruss: +1
(16:45:46) ozizka-FN: maybe
(16:46:00) marekn: jsightler: +1
(16:46:05) ozizka-FN: but it's right next to  the rule sounding like "when( ... ) perform( ... )
(16:46:29) ozizka-FN: And the other would be "matched"?
(16:46:51) ozizka-FN: I am okay with not-matched and performed
(16:47:00) jsightler: Yeah, I get your point. Maybe there is a better term?