### PR TITLE
Fixing (X)HTML markup

### DIFF
--- a/reporting/impl/src/main/resources/reports/templates/classloader.ftl
+++ b/reporting/impl/src/main/resources/reports/templates/classloader.ftl
@@ -2,11 +2,11 @@
 <html lang="en">
 
   <head>
-    <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta charset="utf-8"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
     <title>${application.applicationName} - Classloader Report</title>
-    <link href="../../resources/css/bootstrap.min.css" rel="stylesheet">
-    <link href="../../resources/css/windup.css" rel="stylesheet" media="screen">
+    <link href="../../resources/css/bootstrap.min.css" rel="stylesheet"/>
+    <link href="../../resources/css/windup.css" rel="stylesheet" media="screen"/>
   </head>
   <body role="document">
 

--- a/reporting/impl/src/main/resources/reports/templates/embedded.ftl
+++ b/reporting/impl/src/main/resources/reports/templates/embedded.ftl
@@ -4,11 +4,11 @@
 
 <html lang="en">
   <head>
-    <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta charset="utf-8"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
     <title>${reportModel.projectModel.name} - ${reportModel.reportProperties.embeddedTitle}</title>
-    <link href="resources/css/bootstrap.min.css" rel="stylesheet">
-    <link href="resources/css/windup.css" rel="stylesheet" media="screen">
+    <link href="resources/css/bootstrap.min.css" rel="stylesheet"/>
+    <link href="resources/css/windup.css" rel="stylesheet" media="screen"/>
   </head>
   <body role="document">
 	

--- a/reporting/impl/src/main/resources/reports/templates/include/userfeedback.ftl
+++ b/reporting/impl/src/main/resources/reports/templates/include/userfeedback.ftl
@@ -6,7 +6,7 @@
 </li>
 
 
-<script type="text/javascript" src="https://issues.jboss.org/s/f215932e68571747ac58d0f5d554396f-T/en_US-r7luaf/6346/82/1.4.16/_/download/batch/com.atlassian.jira.collector.plugin.jira-issue-collector-plugin:issuecollector/com.atlassian.jira.collector.plugin.jira-issue-collector-plugin:issuecollector.js?locale=en-US&collectorId=8b9e338b"></script>
+<script type="text/javascript" src="https://issues.jboss.org/s/f215932e68571747ac58d0f5d554396f-T/en_US-r7luaf/6346/82/1.4.16/_/download/batch/com.atlassian.jira.collector.plugin.jira-issue-collector-plugin:issuecollector/com.atlassian.jira.collector.plugin.jira-issue-collector-plugin:issuecollector.js?locale=en-US&amp;collectorId=8b9e338b"></script>
 <script type="text/javascript">
 	window.ATL_JQ_PAGE_PROPS = {
 		"triggerFunction": function(showCollectorDialog) {

--- a/reporting/impl/src/main/resources/reports/templates/index.ftl
+++ b/reporting/impl/src/main/resources/reports/templates/index.ftl
@@ -35,13 +35,13 @@
 </#macro>
 
 	<head>
-		<meta charset="utf-8">
-		<meta http-equiv="X-UA-Compatible" content="IE=edge">
+		<meta charset="utf-8"/>
+		<meta http-equiv="X-UA-Compatible" content="IE=edge"/>
 		<title>Overview - Profiled by Windup</title>
 
 		<!-- Bootstrap -->
-		<link href="reports/resources/css/bootstrap.min.css" rel="stylesheet">
-		<link href="reports/resources/css/windup.css" rel="stylesheet" media="screen">
+		<link href="reports/resources/css/bootstrap.min.css" rel="stylesheet"/>
+		<link href="reports/resources/css/windup.css" rel="stylesheet" media="screen"/>
 
 		<style>
 
@@ -89,7 +89,7 @@
 			<a href="reports/windup_freemarkerfunctions.html">Windup FreeMarker Methods</a>
 			    |
 			<a href="#" id="jiraFeedbackTrigger">Send Feedback</a>
-            <script type="text/javascript" src="https://issues.jboss.org/s/f215932e68571747ac58d0f5d554396f-T/en_US-r7luaf/6346/82/1.4.16/_/download/batch/com.atlassian.jira.collector.plugin.jira-issue-collector-plugin:issuecollector/com.atlassian.jira.collector.plugin.jira-issue-collector-plugin:issuecollector.js?locale=en-US&collectorId=8b9e338b"></script>
+            <script type="text/javascript" src="https://issues.jboss.org/s/f215932e68571747ac58d0f5d554396f-T/en_US-r7luaf/6346/82/1.4.16/_/download/batch/com.atlassian.jira.collector.plugin.jira-issue-collector-plugin:issuecollector/com.atlassian.jira.collector.plugin.jira-issue-collector-plugin:issuecollector.js?locale=en-US&amp;collectorId=8b9e338b"></script>
             <script type="text/javascript">
                 window.ATL_JQ_PAGE_PROPS = {
                     "triggerFunction": function(showCollectorDialog) {

--- a/reporting/impl/src/main/resources/reports/templates/ruleprovidersummary.ftl
+++ b/reporting/impl/src/main/resources/reports/templates/ruleprovidersummary.ftl
@@ -2,12 +2,12 @@
 <html lang="en">
 
   <head>
-    <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta charset="utf-8"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
     <title>Windup Rule Providers</title>
-    <link href="resources/css/bootstrap.min.css" rel="stylesheet">
-    <link href="resources/css/windup.css" rel="stylesheet" media="screen">
-    <link href="resources/css/windup.java.css" rel="stylesheet" media="screen">
+    <link href="resources/css/bootstrap.min.css" rel="stylesheet"/>
+    <link href="resources/css/windup.css" rel="stylesheet" media="screen"/>
+    <link href="resources/css/windup.java.css" rel="stylesheet" media="screen"/>
   </head>
   <body role="document">
 	    

--- a/reporting/impl/src/main/resources/reports/templates/server-resources.ftl
+++ b/reporting/impl/src/main/resources/reports/templates/server-resources.ftl
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta charset="utf-8"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
     <title>${application.applicationName} - Server Resource Report</title>
-    <link href="../../resources/css/bootstrap.min.css" rel="stylesheet">
-    <link href="../../resources/css/windup.css" rel="stylesheet" media="screen">
+    <link href="../../resources/css/bootstrap.min.css" rel="stylesheet"/>
+    <link href="../../resources/css/windup.css" rel="stylesheet" media="screen"/>
   </head>
   <body role="document">
 

--- a/reporting/impl/src/main/resources/reports/templates/source.ftl
+++ b/reporting/impl/src/main/resources/reports/templates/source.ftl
@@ -6,11 +6,11 @@
 </#if>
 
 <head>
-    <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta charset="utf-8"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
     <title>Source Report for ${reportModel.reportName?html}</title>
-    <link href="resources/css/bootstrap.min.css" rel="stylesheet">
-    <link href="resources/css/windup.css" rel="stylesheet" media="screen">
+    <link href="resources/css/bootstrap.min.css" rel="stylesheet"/>
+    <link href="resources/css/windup.css" rel="stylesheet" media="screen"/>
     <link rel='stylesheet' type='text/css' href='resources/libraries/snippet/jquery.snippet.min.css' />
     <link rel='stylesheet' type='text/css' href='resources/css/windup-source.css' />
     <link rel='stylesheet' type='text/css' href='resources/libraries/sausage/sausage.css' />

--- a/reporting/impl/src/main/resources/reports/templates/windupfreemarkerfunctions.ftl
+++ b/reporting/impl/src/main/resources/reports/templates/windupfreemarkerfunctions.ftl
@@ -2,12 +2,12 @@
 <html lang="en">
 
   <head>
-    <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta charset="utf-8"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
     <title>Windup FreeMarker Functions and Directives</title>
-    <link href="resources/css/bootstrap.min.css" rel="stylesheet">
-    <link href="resources/css/windup.css" rel="stylesheet" media="screen">
-    <link href="resources/css/windup.java.css" rel="stylesheet" media="screen">
+    <link href="resources/css/bootstrap.min.css" rel="stylesheet"/>
+    <link href="resources/css/windup.css" rel="stylesheet" media="screen"/>
+    <link href="resources/css/windup.java.css" rel="stylesheet" media="screen"/>
   </head>
   <body role="document">
 


### PR DESCRIPTION
This is a fix for having more XHTML compliant reports.
With this fix it is for example possible to process and merge the summary files using xmllint.