### PR TITLE
WINDUP-782: Specifying the same file as both an input and an output results in the input file being destroyed

### DIFF
--- a/bootstrap/src/main/java/org/jboss/windup/bootstrap/commands/windup/RunWindupCommand.java
+++ b/bootstrap/src/main/java/org/jboss/windup/bootstrap/commands/windup/RunWindupCommand.java
@@ -163,6 +163,9 @@ public class RunWindupCommand implements Command, FurnaceDependent
             windupConfiguration.setOptionValue(option.getName(), optionValues.get(option.getName()));
         }
 
+        if (!validateInputAndOutputPath(windupConfiguration.getInputPath(), windupConfiguration.getOutputDirectory()))
+            return;
+
         try
         {
             windupConfiguration.useDefaultDirectories();
@@ -213,6 +216,21 @@ public class RunWindupCommand implements Command, FurnaceDependent
         {
             System.err.println("Windup Execution failed due to: " + e.getMessage());
             e.printStackTrace();
+        }
+    }
+
+    private boolean validateInputAndOutputPath(Path inputPath, Path outputPath)
+    {
+        ValidationResult validationResult = OutputPathOption.validateInputAndOutputPath(inputPath, outputPath);
+        switch (validationResult.getLevel())
+        {
+        case ERROR:
+            System.err.println("ERROR: " + validationResult.getMessage());
+            return false;
+        case WARNING:
+            System.err.println("WARNING: " + validationResult.getMessage());
+        default:
+            return true;
         }
     }
 

--- a/exec/api/src/main/java/org/jboss/windup/exec/configuration/options/OutputPathOption.java
+++ b/exec/api/src/main/java/org/jboss/windup/exec/configuration/options/OutputPathOption.java
@@ -1,7 +1,11 @@
 package org.jboss.windup.exec.configuration.options;
 
+import java.io.File;
+import java.nio.file.Path;
+
 import org.jboss.windup.config.AbstractPathConfigurationOption;
 import org.jboss.windup.config.InputType;
+import org.jboss.windup.config.ValidationResult;
 
 /**
  * Indicates that output path for the windup report and other data produced by a Windup execution.
@@ -52,5 +56,51 @@ public class OutputPathOption extends AbstractPathConfigurationOption
     public int getPriority()
     {
         return 9000;
+    }
+
+    /**
+     * <p>
+     * This validates that the input and output options are compatible.
+     * </p>
+     * <p>
+     * Examples of incompatibilities would include:
+     * </p>
+     * <ul>
+     * <li>Input and Output path are the same</li>
+     * <li>Input is a subdirectory of the output</li>
+     * <li>Output is a subdirectory of the input</li>
+     * </ul>
+     */
+    public static ValidationResult validateInputAndOutputPath(Path inputPath, Path outputPath)
+    {
+        File inputFile = inputPath.toFile();
+        File outputFile = outputPath.toFile();
+
+        if (inputFile.equals(outputFile))
+        {
+            return new ValidationResult(ValidationResult.Level.ERROR, "Output file cannot be the same as the input file.");
+        }
+
+        File inputParent = inputFile.getParentFile();
+        while (inputParent != null)
+        {
+            if (inputParent.equals(outputFile))
+            {
+                return new ValidationResult(ValidationResult.Level.ERROR, "Output path must not be a parent of input path.");
+            }
+            inputParent = inputParent.getParentFile();
+        }
+
+        File outputParent = outputFile.getParentFile();
+        while (outputParent != null)
+        {
+            if (outputParent.equals(inputFile))
+            {
+                return new ValidationResult(ValidationResult.Level.ERROR, "Input path must not be a parent of output path.");
+            }
+            outputParent = outputParent.getParentFile();
+        }
+
+        return ValidationResult.SUCCESS;
     }
 }

--- a/exec/tests/src/test/java/org/jboss/windup/exec/test/OutputPathOptionTest.java
+++ b/exec/tests/src/test/java/org/jboss/windup/exec/test/OutputPathOptionTest.java
@@ -1,0 +1,104 @@
+package org.jboss.windup.exec.test;
+
+import java.nio.file.Path;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang.RandomStringUtils;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.forge.arquillian.AddonDependencies;
+import org.jboss.forge.arquillian.AddonDependency;
+import org.jboss.forge.arquillian.archive.AddonArchive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.windup.config.ValidationResult;
+import org.jboss.windup.exec.configuration.options.OutputPathOption;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(Arquillian.class)
+public class OutputPathOptionTest
+{
+
+    @Deployment
+    @AddonDependencies({
+                @AddonDependency(name = "org.jboss.forge.furnace.container:cdi"),
+                @AddonDependency(name = "org.jboss.windup.utils:windup-utils"),
+                @AddonDependency(name = "org.jboss.windup.graph:windup-graph"),
+                @AddonDependency(name = "org.jboss.windup.config:windup-config"),
+                @AddonDependency(name = "org.jboss.windup.exec:windup-exec"),
+    })
+    public static AddonArchive getDeployment()
+    {
+        return ShrinkWrap.create(AddonArchive.class).addBeansXML();
+    }
+
+    private Path getBasePath()
+    {
+        return FileUtils.getTempDirectory().toPath().resolve("Windup")
+                    .resolve(getClass().getSimpleName() + "_" + RandomStringUtils.randomAlphanumeric(6));
+    }
+
+    @Test
+    public void testInputAndOutputEqual()
+    {
+        Path basePath = getBasePath();
+        Path appPath = basePath.resolve("ApplicationDir");
+
+        ValidationResult result = OutputPathOption.validateInputAndOutputPath(appPath, appPath);
+        Assert.assertEquals(ValidationResult.Level.ERROR, result.getLevel());
+    }
+
+    @Test
+    public void testInputAsSubOfOutput() throws Exception
+    {
+        Path basePath = getBasePath();
+        Path appPath = basePath.resolve("myapppath");
+        FileUtils.forceMkdir(appPath.toFile());
+        try
+        {
+            ValidationResult result = OutputPathOption.validateInputAndOutputPath(appPath, basePath);
+            Assert.assertEquals(ValidationResult.Level.ERROR, result.getLevel());
+        }
+        finally
+        {
+            FileUtils.deleteDirectory(basePath.toFile());
+        }
+    }
+
+    @Test
+    public void testOutputAsSubOfInput() throws Exception
+    {
+        Path basePath = getBasePath();
+        Path subpath = basePath.resolve("subpath");
+        FileUtils.forceMkdir(subpath.toFile());
+        try
+        {
+            ValidationResult result = OutputPathOption.validateInputAndOutputPath(basePath, subpath);
+            Assert.assertEquals(ValidationResult.Level.ERROR, result.getLevel());
+        }
+        finally
+        {
+            FileUtils.deleteDirectory(basePath.toFile());
+        }
+    }
+
+    @Test
+    public void testValidConfiguration() throws Exception
+    {
+        Path basePath = getBasePath();
+        Path input = basePath.resolve("input");
+        Path output = basePath.resolve("output");
+        FileUtils.forceMkdir(input.toFile());
+        FileUtils.forceMkdir(output.toFile());
+        try
+        {
+            ValidationResult result = OutputPathOption.validateInputAndOutputPath(input, output);
+            Assert.assertEquals(ValidationResult.Level.SUCCESS, result.getLevel());
+        }
+        finally
+        {
+            FileUtils.deleteDirectory(basePath.toFile());
+        }
+    }
+}


### PR DESCRIPTION
https://issues.jboss.org/browse/WINDUP-782
