### PR TITLE
WINDUP-691 register xhtml/jsf file mapping as XMLFileModel

### DIFF
--- a/rules-java-ee/addon/src/main/java/org/jboss/windup/rules/apps/javaee/rules/JspFileMappingRuleProvider.java
+++ b/rules-java-ee/addon/src/main/java/org/jboss/windup/rules/apps/javaee/rules/JspFileMappingRuleProvider.java
@@ -29,7 +29,6 @@ public class JspFileMappingRuleProvider extends AbstractRuleProvider
         return ConfigurationBuilder.begin()
                     .addRule(FileMapping.from(".*\\.jsp$").to(JspSourceFileModel.class))
                     .addRule(FileMapping.from(".*\\.jspx$").to(JspSourceFileModel.class))
-                    .addRule(FileMapping.from(".*\\.jsf$").to(JspSourceFileModel.class))
-                    .addRule(FileMapping.from(".*\\.xhtml$").to(JspSourceFileModel.class));
+                    ;
     }
 }

--- a/rules-xml/addon/src/main/java/org/jboss/windup/rules/apps/xml/DiscoverXmlFilesRuleProvider.java
+++ b/rules-xml/addon/src/main/java/org/jboss/windup/rules/apps/xml/DiscoverXmlFilesRuleProvider.java
@@ -50,6 +50,8 @@ public class DiscoverXmlFilesRuleProvider extends AbstractRuleProvider
 
                     .addRule(FileMapping.from(".*\\.xml$").to(XmlFileModel.class))
                     .addRule(FileMapping.from(".*\\.xmi$").to(XmlFileModel.class))
+                    .addRule(FileMapping.from(".*\\.jsf$").to(XmlFileModel.class))
+                    .addRule(FileMapping.from(".*\\.xhtml$").to(XmlFileModel.class))
                     .addRule()
                     .when(Query.fromType(XmlFileModel.class))
                     .perform(new AbstractIterationOperation<XmlFileModel>()


### PR DESCRIPTION
This is important to get JSF files into reports. XML rules will continue in windup-rulesets