### PR TITLE
Reporting speed fixes

### DIFF
--- a/graph/api/src/main/java/org/jboss/windup/graph/Indexed.java
+++ b/graph/api/src/main/java/org/jboss/windup/graph/Indexed.java
@@ -25,4 +25,9 @@ public @interface Indexed
      * The type of index to be created.
      */
     IndexType value() default IndexType.DEFAULT;
+
+    /**
+     * Indicates the type for the property. The default is {@link String}.
+     */
+    Class<?> dataType() default String.class;
 }

--- a/graph/api/src/main/java/org/jboss/windup/graph/model/ProjectModel.java
+++ b/graph/api/src/main/java/org/jboss/windup/graph/model/ProjectModel.java
@@ -1,5 +1,8 @@
 package org.jboss.windup.graph.model;
 
+import java.util.HashSet;
+import java.util.Set;
+
 import org.jboss.windup.graph.model.resource.FileModel;
 
 import com.tinkerpop.blueprints.Direction;
@@ -194,8 +197,15 @@ public interface ProjectModel extends WindupVertexFrame
     @JavaHandler
     ProjectModel getRootProjectModel();
 
+    /**
+     * Returns this project model as well as all of its children, recursively.
+     */
+    @JavaHandler
+    Set<ProjectModel> getAllProjectModels();
+
     abstract class Impl implements ProjectModel, JavaHandlerContext<Vertex>
     {
+        @Override
         public ProjectModel getRootProjectModel()
         {
             ProjectModel projectModel = this;
@@ -209,5 +219,14 @@ public interface ProjectModel extends WindupVertexFrame
             return frame(projectModel.asVertex());
         }
 
+        @Override
+        public Set<ProjectModel> getAllProjectModels()
+        {
+            Set<ProjectModel> result = new HashSet<>();
+            result.add(frame(it(), ProjectModel.class));
+            for (ProjectModel child : getChildProjects())
+                result.addAll(child.getAllProjectModels());
+            return result;
+        }
     }
 }

--- a/reporting/api/src/main/java/org/jboss/windup/reporting/config/HasHint.java
+++ b/reporting/api/src/main/java/org/jboss/windup/reporting/config/HasHint.java
@@ -11,6 +11,7 @@ import org.jboss.windup.reporting.model.ClassificationModel;
 import org.jboss.windup.reporting.model.InlineHintModel;
 import org.jboss.windup.reporting.service.InlineHintService;
 import org.jboss.windup.rules.files.model.FileReferenceModel;
+import org.jboss.windup.util.ExecutionStatistics;
 import org.ocpsoft.rewrite.context.EvaluationContext;
 import org.ocpsoft.rewrite.param.ParameterStore;
 import org.ocpsoft.rewrite.param.Parameterized;
@@ -30,51 +31,59 @@ public class HasHint extends AbstractIterationFilter<WindupVertexFrame> implemen
     @Override
     public boolean evaluate(GraphRewrite event, EvaluationContext context, WindupVertexFrame payload)
     {
-        boolean result = false;
-        InlineHintService service = new InlineHintService(event.getGraphContext());
-
-        if (payload instanceof FileReferenceModel)
+        ExecutionStatistics.get().begin(HasHint.class.getCanonicalName());
+        try
         {
-            Iterable<InlineHintModel> hints = service.getHintsForFileReference((FileReferenceModel) payload);
-            if (messagePattern == null)
+            boolean result = false;
+            InlineHintService service = new InlineHintService(event.getGraphContext());
+
+            if (payload instanceof FileReferenceModel)
             {
-                result = hints.iterator().hasNext();
-            }
-            else
-            {
-                for (InlineHintModel c : hints)
+                Iterable<InlineHintModel> hints = service.getHintsForFileReference((FileReferenceModel) payload);
+                if (messagePattern == null)
                 {
-                    ParameterizedPatternResult parseResult = messagePattern.parse(c.getHint());
-                    if (parseResult.matches() && parseResult.isValid(event, context))
+                    result = hints.iterator().hasNext();
+                }
+                else
+                {
+                    for (InlineHintModel c : hints)
                     {
-                        result = true;
-                        break;
+                        ParameterizedPatternResult parseResult = messagePattern.parse(c.getHint());
+                        if (parseResult.matches() && parseResult.isValid(event, context))
+                        {
+                            result = true;
+                            break;
+                        }
                     }
                 }
             }
-        }
 
-        if (payload instanceof FileModel)
-        {
-            Iterable<InlineHintModel> hints = service.getHintsForFile((FileModel) payload);
-            if (messagePattern == null)
+            if (payload instanceof FileModel)
             {
-                result = hints.iterator().hasNext();
-            }
-            else
-            {
-                for (InlineHintModel c : hints)
+                Iterable<InlineHintModel> hints = service.getHintsForFile((FileModel) payload);
+                if (messagePattern == null)
                 {
-                    ParameterizedPatternResult parseResult = messagePattern.parse(c.getHint());
-                    if (parseResult.matches() && parseResult.isValid(event, context))
+                    result = hints.iterator().hasNext();
+                }
+                else
+                {
+                    for (InlineHintModel c : hints)
                     {
-                        result = true;
-                        break;
+                        ParameterizedPatternResult parseResult = messagePattern.parse(c.getHint());
+                        if (parseResult.matches() && parseResult.isValid(event, context))
+                        {
+                            result = true;
+                            break;
+                        }
                     }
                 }
             }
+            return result;
         }
-        return result;
+        finally
+        {
+            ExecutionStatistics.get().end(HasHint.class.getCanonicalName());
+        }
     }
 
     /**

--- a/reporting/api/src/main/java/org/jboss/windup/reporting/freemarker/GetTagsFromFileClassificationsAndHints.java
+++ b/reporting/api/src/main/java/org/jboss/windup/reporting/freemarker/GetTagsFromFileClassificationsAndHints.java
@@ -1,24 +1,25 @@
 package org.jboss.windup.reporting.freemarker;
 
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.jboss.windup.config.GraphRewrite;
+import org.jboss.windup.graph.GraphContext;
+import org.jboss.windup.graph.model.WindupVertexFrame;
+import org.jboss.windup.graph.model.resource.FileModel;
+import org.jboss.windup.reporting.model.ClassificationModel;
+import org.jboss.windup.reporting.model.InlineHintModel;
+import org.jboss.windup.rules.files.model.FileLocationModel;
+import org.jboss.windup.util.ExecutionStatistics;
+
 import com.thinkaurelius.titan.core.attribute.Text;
 import com.tinkerpop.blueprints.Vertex;
 import com.tinkerpop.frames.structures.FramedVertexIterable;
 import com.tinkerpop.gremlin.java.GremlinPipeline;
-import java.util.List;
-
-import org.jboss.windup.config.GraphRewrite;
-import org.jboss.windup.graph.GraphContext;
-import org.jboss.windup.graph.model.resource.FileModel;
-import org.jboss.windup.util.ExecutionStatistics;
 
 import freemarker.ext.beans.StringModel;
 import freemarker.template.TemplateModelException;
-import java.util.HashSet;
-import java.util.Set;
-import org.jboss.windup.graph.model.WindupVertexFrame;
-import org.jboss.windup.reporting.model.ClassificationModel;
-import org.jboss.windup.reporting.model.InlineHintModel;
-import org.jboss.windup.rules.files.model.FileLocationModel;
 
 /**
  * Gets all tags from the classifications associated with the provided {@link FileModel}.
@@ -80,8 +81,8 @@ public class GetTagsFromFileClassificationsAndHints implements WindupFreeMarkerM
             GremlinPipeline<Vertex, Vertex> pipeline = new GremlinPipeline<>(fileModel.asVertex());
             pipeline.in(ClassificationModel.FILE_MODEL).has(WindupVertexFrame.TYPE_PROP, Text.CONTAINS, ClassificationModel.TYPE);
             FramedVertexIterable<ClassificationModel> iterable = new FramedVertexIterable<>(this.context.getFramed(), pipeline, ClassificationModel.class);
-            for(ClassificationModel clsf : iterable)
-                tags.addAll(clsf.getTags());
+            for (ClassificationModel classification : iterable)
+                tags.addAll(classification.getTags());
         }
 
         // Hints

--- a/reporting/api/src/main/java/org/jboss/windup/reporting/model/ApplicationReportModel.java
+++ b/reporting/api/src/main/java/org/jboss/windup/reporting/model/ApplicationReportModel.java
@@ -21,6 +21,7 @@ public interface ApplicationReportModel extends ReportModel
 {
     String DISPLAY_IN_APPLICATION_REPORT_INDEX = "displayInApplicationReportIndex";
     String DISPLAY_IN_APPLICATION_LIST = "displayInApplicationList";
+    String DISPLAY_IN_GLOBAL_APPLICATION_INDEX = "displayInGlobalApplicationIndex";
     String TYPE = "ApplicationReport";
     String REPORT_TO_APPLICATION_NOTE = "reportToApplicationNote";
     String REPORT_LINES = "reportLines";
@@ -51,6 +52,18 @@ public interface ApplicationReportModel extends ReportModel
      */
     @Property(REPORT_PRIORITY)
     void setReportPriority(int priority);
+
+    /**
+     * Indicates that this report should also be attached to the global application index.
+     */
+    @Property(DISPLAY_IN_GLOBAL_APPLICATION_INDEX)
+    void setDisplayInGlobalApplicationIndex(Boolean displayInGlobalApplicationIndex);
+
+    /**
+     * Indicates that this report should also be attached to the global application index.
+     */
+    @Property(DISPLAY_IN_GLOBAL_APPLICATION_INDEX)
+    Boolean getDisplayInGlobalApplicationIndex();
 
     /**
      * Indicates whether or not to display this in the list of all applications. Usually this would be true for a main "overview" type report for a

--- a/reporting/api/src/main/java/org/jboss/windup/reporting/model/ClassificationModel.java
+++ b/reporting/api/src/main/java/org/jboss/windup/reporting/model/ClassificationModel.java
@@ -1,9 +1,6 @@
 package org.jboss.windup.reporting.model;
 
-import java.util.Set;
-
 import org.jboss.windup.graph.Indexed;
-import org.jboss.windup.graph.SetInProperties;
 import org.jboss.windup.graph.model.resource.FileModel;
 import org.jboss.windup.reporting.model.association.LinkableModel;
 import org.ocpsoft.rewrite.config.Rule;
@@ -19,7 +16,7 @@ import com.tinkerpop.frames.modules.typedgraph.TypeValue;
  * additional information, or auto-translated/generated/updated versions of the source file.
  */
 @TypeValue(ClassificationModel.TYPE)
-public interface ClassificationModel extends EffortReportModel, LinkableModel
+public interface ClassificationModel extends EffortReportModel, LinkableModel, TaggableModel
 {
     String TYPE = "ClassificationModel";
     String TYPE_PREFIX = TYPE + ":";
@@ -79,22 +76,5 @@ public interface ClassificationModel extends EffortReportModel, LinkableModel
     String getRuleID();
 
 
-    /**
-     * Add a tag associated with this {@link ClassificationModel}
-     */
-    @SetInProperties(propertyPrefix = "tag")
-    ClassificationModel addTag(String tag);
-
-    /**
-     * Set the set of tags associated with this {@link ClassificationModel}
-     */
-    @SetInProperties(propertyPrefix = "tag")
-    ClassificationModel setTags(Set<String> tags);
-
-    /**
-     * Get the set of tags associated with this {@link ClassificationModel}
-     */
-    @SetInProperties(propertyPrefix = "tag")
-    Set<String> getTags();
 
 }

--- a/reporting/api/src/main/java/org/jboss/windup/reporting/model/EffortReportModel.java
+++ b/reporting/api/src/main/java/org/jboss/windup/reporting/model/EffortReportModel.java
@@ -1,19 +1,24 @@
 package org.jboss.windup.reporting.model;
 
-import com.tinkerpop.frames.Property;
+import org.jboss.windup.graph.IndexType;
+import org.jboss.windup.graph.Indexed;
 import org.jboss.windup.graph.model.WindupVertexFrame;
+
+import com.tinkerpop.frames.Property;
+import com.tinkerpop.frames.modules.typedgraph.TypeValue;
 
 /**
  *  Aggregates the common properties of all the items generating effort for the Application.
  *
  *  @author <a href="mailto:mbriskar@gmail.com">Matej Briskar</a>
  */
+@TypeValue(EffortReportModel.TYPE)
 public interface EffortReportModel extends WindupVertexFrame
 {
-    static final String TYPE = "ClassificationModel";
-    static final String TYPE_PREFIX = TYPE + ":";
-    static final String EFFORT = TYPE_PREFIX + "effort";
-    static final String SEVERITY = TYPE_PREFIX + TYPE_PREFIX + "severity";
+    String TYPE = "EffortReportModel";
+    String TYPE_PREFIX = TYPE + ":";
+    String EFFORT = "EffortReportModelEffort"; // don't use the prefix as we can't name the index with an "_"
+    String SEVERITY = TYPE_PREFIX + "severity";
 
     /**
      * Set the effort weight (E.g. How difficult is it to fix the issue?)
@@ -25,6 +30,7 @@ public interface EffortReportModel extends WindupVertexFrame
      * Get the effort weight (E.g. How difficult is it to fix the issue?)
      */
     @Property(EFFORT)
+    @Indexed(value = IndexType.SEARCH, dataType = Integer.class)
     int getEffort();
 
     /**

--- a/reporting/api/src/main/java/org/jboss/windup/reporting/model/InlineHintModel.java
+++ b/reporting/api/src/main/java/org/jboss/windup/reporting/model/InlineHintModel.java
@@ -1,8 +1,5 @@
 package org.jboss.windup.reporting.model;
 
-import java.util.Set;
-
-import org.jboss.windup.graph.SetInProperties;
 import org.jboss.windup.graph.model.LinkModel;
 import org.jboss.windup.graph.model.resource.FileModel;
 import org.jboss.windup.reporting.config.Link;
@@ -18,7 +15,7 @@ import com.tinkerpop.frames.modules.typedgraph.TypeValue;
  * positions within those files.
  */
 @TypeValue(InlineHintModel.TYPE)
-public interface InlineHintModel extends EffortReportModel,FileLocationModel
+public interface InlineHintModel extends EffortReportModel, FileLocationModel, TaggableModel
 {
     String TYPE = "Hint";
     String TYPE_PREFIX = TYPE + ":";
@@ -27,7 +24,6 @@ public interface InlineHintModel extends EffortReportModel,FileLocationModel
     String RULE_ID = TYPE_PREFIX + "ruleID";
     String LINKS = TYPE_PREFIX + "links";
     String FILE_LOCATION_REFERENCE = TYPE_PREFIX + "fileLocationReference";
-    String TAG = "tag";
 
     /**
      * A short descriptive text describing the problem covered by this hint
@@ -76,24 +72,6 @@ public interface InlineHintModel extends EffortReportModel,FileLocationModel
      */
     @Adjacency(label = LINKS, direction = Direction.OUT)
     Iterable<LinkModel> getLinks();
-
-    /**
-     * Add a tag associated with this {@link InlineHintModel}
-     */
-    @SetInProperties(propertyPrefix = TAG)
-    InlineHintModel addTag(String tag);
-
-    /**
-     * Set the set of tags associated with this {@link InlineHintModel}
-     */
-    @SetInProperties(propertyPrefix = TAG)
-    InlineHintModel setTags(Set<String> tags);
-
-    /**
-     * Get the set of tags associated with this {@link InlineHintModel}
-     */
-    @SetInProperties(propertyPrefix = TAG)
-    Set<String> getTags();
 
     /**
      * Set the ID of the rule that triggered this particular blacklist entry

--- a/reporting/api/src/main/java/org/jboss/windup/reporting/model/TagSetModel.java
+++ b/reporting/api/src/main/java/org/jboss/windup/reporting/model/TagSetModel.java
@@ -1,0 +1,33 @@
+package org.jboss.windup.reporting.model;
+
+import java.util.Set;
+
+import org.jboss.windup.graph.SetInProperties;
+import org.jboss.windup.graph.model.WindupVertexFrame;
+
+import com.tinkerpop.blueprints.Vertex;
+import com.tinkerpop.frames.modules.typedgraph.TypeValue;
+
+/**
+ * Represents that a model has tags, and also contains the methods for accessing those tags.
+ *
+ * @author <a href="mailto:jesse.sightler@gmail.com">Jesse Sightler</a>
+ */
+@TypeValue(TagSetModel.TYPE)
+public interface TagSetModel extends WindupVertexFrame
+{
+    String TYPE = "TagSetModel";
+    String PREFIX = "TAGS";
+
+    /**
+     * Sets the tags associated with this {@link Vertex}.
+     */
+    @SetInProperties(propertyPrefix = PREFIX)
+    TagSetModel setTags(Set<String> tags);
+
+    /**
+     * Gets the tags associated with this {@link Vertex}.
+     */
+    @SetInProperties(propertyPrefix = PREFIX)
+    Set<String> getTags();
+}

--- a/reporting/api/src/main/java/org/jboss/windup/reporting/model/TaggableModel.java
+++ b/reporting/api/src/main/java/org/jboss/windup/reporting/model/TaggableModel.java
@@ -1,0 +1,50 @@
+package org.jboss.windup.reporting.model;
+
+import java.util.Collections;
+import java.util.Set;
+
+import org.jboss.windup.graph.model.WindupVertexFrame;
+
+import com.tinkerpop.blueprints.Direction;
+import com.tinkerpop.blueprints.Vertex;
+import com.tinkerpop.frames.Adjacency;
+import com.tinkerpop.frames.modules.javahandler.JavaHandler;
+import com.tinkerpop.frames.modules.javahandler.JavaHandlerContext;
+import com.tinkerpop.frames.modules.typedgraph.TypeValue;
+
+/**
+ * @author <a href="mailto:jesse.sightler@gmail.com">Jesse Sightler</a>
+ */
+@TypeValue(TaggableModel.TYPE)
+public interface TaggableModel extends WindupVertexFrame
+{
+    String TYPE = "TaggableModel";
+    String TAG = "tag";
+
+    /**
+     * Set the set of tags associated with this {@link ClassificationModel}
+     */
+    @Adjacency(label = TAG, direction = Direction.OUT)
+    void setTagModel(TagSetModel tags);
+
+    /**
+     * Get the set of tags associated with this {@link ClassificationModel}
+     */
+    @Adjacency(label = TAG, direction = Direction.OUT)
+    TagSetModel getTagModel();
+
+    @JavaHandler
+    Set<String> getTags();
+
+    abstract class Impl implements TaggableModel, JavaHandlerContext<Vertex>
+    {
+        @Override
+        public Set<String> getTags()
+        {
+            TagSetModel tagSetModel = getTagModel();
+            if (tagSetModel == null)
+                return Collections.emptySet();
+            return tagSetModel.getTags();
+        }
+    }
+}

--- a/reporting/api/src/main/java/org/jboss/windup/reporting/rules/AttachApplicationReportsToIndexRuleProvider.java
+++ b/reporting/api/src/main/java/org/jboss/windup/reporting/rules/AttachApplicationReportsToIndexRuleProvider.java
@@ -51,13 +51,19 @@ public class AttachApplicationReportsToIndexRuleProvider extends AbstractRulePro
             {
                 final ApplicationReportIndexService applicationReportIndexService = new ApplicationReportIndexService(event.getGraphContext());
                 final ProjectModel projectModel = payload.getProjectModel();
-                final ApplicationReportIndexModel index;
-                if (projectModel == null)
-                    index = applicationReportIndexService.getOrCreateGlobalApplicationIndex();
-                else
-                    index = applicationReportIndexService.getApplicationReportIndexForProjectModel(payload.getProjectModel());
 
-                index.addApplicationReportModel(payload);
+                if (projectModel == null || Boolean.TRUE == payload.getDisplayInGlobalApplicationIndex())
+                {
+                    ApplicationReportIndexModel index = applicationReportIndexService.getOrCreateGlobalApplicationIndex();
+                    index.addApplicationReportModel(payload);
+                }
+
+                if (projectModel != null)
+                {
+                    ApplicationReportIndexModel index = applicationReportIndexService
+                                .getApplicationReportIndexForProjectModel(payload.getProjectModel());
+                    index.addApplicationReportModel(payload);
+                }
             }
         }
 

--- a/reporting/api/src/main/java/org/jboss/windup/reporting/service/TagSetService.java
+++ b/reporting/api/src/main/java/org/jboss/windup/reporting/service/TagSetService.java
@@ -1,0 +1,59 @@
+package org.jboss.windup.reporting.service;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import org.jboss.windup.config.GraphRewrite;
+import org.jboss.windup.graph.GraphContext;
+import org.jboss.windup.graph.service.GraphService;
+import org.jboss.windup.reporting.model.TagSetModel;
+
+import com.tinkerpop.blueprints.Vertex;
+
+/**
+ * Contains methods for getting tag set models as well as maintaining a cache.
+ *
+ * @author <a href="mailto:jesse.sightler@gmail.com">Jesse Sightler</a>
+ */
+public class TagSetService extends GraphService<TagSetModel>
+{
+    private static final String TAG_CACHE_KEY = TagSetService.class.getCanonicalName() + "_Cache";
+
+    public TagSetService(GraphContext context)
+    {
+        super(context, TagSetModel.class);
+    }
+
+    private Map<Set<String>, Vertex> getCache(GraphRewrite event)
+    {
+        @SuppressWarnings("unchecked")
+        Map<Set<String>, Vertex> result = (Map<Set<String>, Vertex>) event.getRewriteContext().get(TAG_CACHE_KEY);
+        if (result == null)
+        {
+            result = new HashMap<>();
+            event.getRewriteContext().put(TAG_CACHE_KEY, result);
+        }
+        return result;
+    }
+
+    /**
+     * This essentially ensures that we only store a single Vertex for each unique "Set" of tags.
+     */
+    public TagSetModel getOrCreate(GraphRewrite event, Set<String> tags)
+    {
+        Map<Set<String>, Vertex> cache = getCache(event);
+        Vertex vertex = cache.get(tags);
+        if (vertex == null)
+        {
+            TagSetModel model = create();
+            model.setTags(tags);
+            cache.put(tags, model.asVertex());
+            return model;
+        }
+        else
+        {
+            return frame(vertex);
+        }
+    }
+}

--- a/reporting/impl/src/main/java/org/jboss/windup/reporting/rules/rendering/RenderReportRuleProvider.java
+++ b/reporting/impl/src/main/java/org/jboss/windup/reporting/rules/rendering/RenderReportRuleProvider.java
@@ -9,6 +9,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import javax.inject.Inject;
@@ -132,12 +133,19 @@ public class RenderReportRuleProvider extends AbstractRuleProvider
                             WindupVertexFrame reportModelObject = reportModels.remove();
                             if (reportModelObject == null)
                                 return null;
-
                             reportModel = (ReportModel) reportModelObject;
-                            Thread.currentThread().setName(reportModel.getTemplatePath() + "_" + reportModel.getReportFilename());
 
-                            iterationProgress.perform(event, context);
-                            freeMarkerIterationOperation.perform(event, context, reportModel);
+                            try
+                            {
+                                Thread.currentThread().setName(reportModel.getTemplatePath() + "_" + reportModel.getReportFilename());
+
+                                iterationProgress.perform(event, context);
+                                freeMarkerIterationOperation.perform(event, context, reportModel);
+                            }
+                            catch (Throwable t)
+                            {
+                                LOG.log(Level.WARNING, "Failed to render freemarker report: " + reportModel + " due to: " + t.getMessage(), t);
+                            }
                         }
                     }
                 });

--- a/rules-java/api/src/main/java/org/jboss/windup/rules/apps/java/service/TypeReferenceService.java
+++ b/rules-java/api/src/main/java/org/jboss/windup/rules/apps/java/service/TypeReferenceService.java
@@ -1,7 +1,6 @@
 package org.jboss.windup.rules.apps.java.service;
 
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 
@@ -69,25 +68,8 @@ public class TypeReferenceService extends GraphService<JavaTypeReferenceModel>
 
         // 2. Organize them by package name
         // summarize results.
-        Iterator<Vertex> pipelineIterator = pipeline.iterator();
-        while (true)
+        for (Vertex inlineHintVertex : pipeline)
         {
-            ExecutionStatistics.get().begin("TypeReferenceService.getPackageUseFrequencies(data,projectModel,nameDepth,recursive):hasNext");
-            try
-            {
-                if (!pipelineIterator.hasNext())
-                    break;
-            }
-            finally
-            {
-                ExecutionStatistics.get().end("TypeReferenceService.getPackageUseFrequencies(data,projectModel,nameDepth,recursive):hasNext");
-            }
-
-            ExecutionStatistics.get().begin("TypeReferenceService.getPackageUseFrequencies(data,projectModel,nameDepth,recursive):next");
-            Vertex inlineHintVertex = pipelineIterator.next();
-            ExecutionStatistics.get().end("TypeReferenceService.getPackageUseFrequencies(data,projectModel,nameDepth,recursive):next");
-
-            ExecutionStatistics.get().begin("TypeReferenceService.getPackageUseFrequencies(data,projectModel,nameDepth,recursive):tagCheck");
             InlineHintModel javaInlineHint = hintService.frame(inlineHintVertex);
             // only check tags if we have some passed in
             if (!includeTags.isEmpty() || !excludeTags.isEmpty())
@@ -95,9 +77,7 @@ public class TypeReferenceService extends GraphService<JavaTypeReferenceModel>
                 if (!TagUtil.isTagsMatch(javaInlineHint.getTags(), includeTags, excludeTags))
                     continue;
             }
-            ExecutionStatistics.get().end("TypeReferenceService.getPackageUseFrequencies(data,projectModel,nameDepth,recursive):tagCheck");
 
-            ExecutionStatistics.get().begin("TypeReferenceService.getPackageUseFrequencies(data,projectModel,nameDepth,recursive):referenceCalc");
             int val = 1;
             FileLocationModel fileLocationModel = javaInlineHint.getFileLocationReference();
             if (fileLocationModel == null || !(fileLocationModel instanceof JavaTypeReferenceModel))
@@ -115,7 +95,7 @@ public class TypeReferenceService extends GraphService<JavaTypeReferenceModel>
                 for (int i = 0; i < nameDepth; i++)
                 {
                     String subElement = keyArray[i];
-                    // FIXME/TODO - This shouldn't be necessary, but is at the moment due to some stuff emitted by our
+                    // FIXME/TODO - This shouldn't be necessary, but is at the moment due to some stuff emmitted by our
                     // AST
                     if (subElement.contains("(") || subElement.contains(")"))
                     {
@@ -146,7 +126,6 @@ public class TypeReferenceService extends GraphService<JavaTypeReferenceModel>
             }
             data.put(pattern, val);
         }
-        ExecutionStatistics.get().end("TypeReferenceService.getPackageUseFrequencies(data,projectModel,nameDepth,recursive):referenceCalc");
 
         if (recursive)
         {

--- a/rules-java/api/src/main/java/org/jboss/windup/rules/apps/java/service/TypeReferenceService.java
+++ b/rules-java/api/src/main/java/org/jboss/windup/rules/apps/java/service/TypeReferenceService.java
@@ -1,6 +1,7 @@
 package org.jboss.windup.rules.apps.java.service;
 
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 
@@ -68,8 +69,25 @@ public class TypeReferenceService extends GraphService<JavaTypeReferenceModel>
 
         // 2. Organize them by package name
         // summarize results.
-        for (Vertex inlineHintVertex : pipeline)
+        Iterator<Vertex> pipelineIterator = pipeline.iterator();
+        while (true)
         {
+            ExecutionStatistics.get().begin("TypeReferenceService.getPackageUseFrequencies(data,projectModel,nameDepth,recursive):hasNext");
+            try
+            {
+                if (!pipelineIterator.hasNext())
+                    break;
+            }
+            finally
+            {
+                ExecutionStatistics.get().end("TypeReferenceService.getPackageUseFrequencies(data,projectModel,nameDepth,recursive):hasNext");
+            }
+
+            ExecutionStatistics.get().begin("TypeReferenceService.getPackageUseFrequencies(data,projectModel,nameDepth,recursive):next");
+            Vertex inlineHintVertex = pipelineIterator.next();
+            ExecutionStatistics.get().end("TypeReferenceService.getPackageUseFrequencies(data,projectModel,nameDepth,recursive):next");
+
+            ExecutionStatistics.get().begin("TypeReferenceService.getPackageUseFrequencies(data,projectModel,nameDepth,recursive):tagCheck");
             InlineHintModel javaInlineHint = hintService.frame(inlineHintVertex);
             // only check tags if we have some passed in
             if (!includeTags.isEmpty() || !excludeTags.isEmpty())
@@ -77,7 +95,9 @@ public class TypeReferenceService extends GraphService<JavaTypeReferenceModel>
                 if (!TagUtil.isTagsMatch(javaInlineHint.getTags(), includeTags, excludeTags))
                     continue;
             }
+            ExecutionStatistics.get().end("TypeReferenceService.getPackageUseFrequencies(data,projectModel,nameDepth,recursive):tagCheck");
 
+            ExecutionStatistics.get().begin("TypeReferenceService.getPackageUseFrequencies(data,projectModel,nameDepth,recursive):referenceCalc");
             int val = 1;
             FileLocationModel fileLocationModel = javaInlineHint.getFileLocationReference();
             if (fileLocationModel == null || !(fileLocationModel instanceof JavaTypeReferenceModel))
@@ -95,7 +115,7 @@ public class TypeReferenceService extends GraphService<JavaTypeReferenceModel>
                 for (int i = 0; i < nameDepth; i++)
                 {
                     String subElement = keyArray[i];
-                    // FIXME/TODO - This shouldn't be necessary, but is at the moment due to some stuff emmitted by our
+                    // FIXME/TODO - This shouldn't be necessary, but is at the moment due to some stuff emitted by our
                     // AST
                     if (subElement.contains("(") || subElement.contains(")"))
                     {
@@ -126,6 +146,7 @@ public class TypeReferenceService extends GraphService<JavaTypeReferenceModel>
             }
             data.put(pattern, val);
         }
+        ExecutionStatistics.get().end("TypeReferenceService.getPackageUseFrequencies(data,projectModel,nameDepth,recursive):referenceCalc");
 
         if (recursive)
         {

--- a/rules-java/tests/src/test/java/org/jboss/windup/rules/apps/java/service/TypeReferenceServiceTest.java
+++ b/rules-java/tests/src/test/java/org/jboss/windup/rules/apps/java/service/TypeReferenceServiceTest.java
@@ -58,7 +58,8 @@ public class TypeReferenceServiceTest
             ProjectModel projectModel = fillData(context);
 
             Set<String> emptySet = Collections.emptySet();
-            Map<String, Integer> data = typeReferenceService.getPackageUseFrequencies(projectModel, emptySet, emptySet, 2, false);
+            Map<String, Integer> data = typeReferenceService.getPackageUseFrequencies(projectModel, emptySet, emptySet, 2,
+                        false);
             Assert.assertEquals(1, data.size());
             Assert.assertEquals("com.example.*", data.keySet().iterator().next());
             Assert.assertEquals(Integer.valueOf(2), data.values().iterator().next());
@@ -83,6 +84,7 @@ public class TypeReferenceServiceTest
 
         InlineHintModel b1 = inlineHintService.create();
         InlineHintModel b1b = inlineHintService.create();
+
         b1.setFile(f1);
         b1.setFileLocationReference(t1);
         b1b.setFile(f1);


### PR DESCRIPTION
The main change is that EffortReportModel now does a range index on effort.
The effort calculation queries now use this and run much quicker.
(also, hint and classification operations now show their timings in the detailed_stats.csv)