### PR TITLE
Fighting the Out of memory exception 1.commit

### DIFF
--- a/rules-java/api/src/main/java/org/jboss/windup/rules/apps/java/scan/provider/AnalyzeJavaFilesRuleProvider.java
+++ b/rules-java/api/src/main/java/org/jboss/windup/rules/apps/java/scan/provider/AnalyzeJavaFilesRuleProvider.java
@@ -291,6 +291,7 @@ public class AnalyzeJavaFilesRuleProvider extends AbstractRuleProvider
             }
             finally
             {
+                sourcePathToFileModel.clear();
                 ExecutionStatistics.get().end("AnalyzeJavaFilesRuleProvider.analyzeFile");
             }
         }


### PR DESCRIPTION
All the field information that remains after the operation runs will stay stored throughout the whole windup execution. This is a simple fix and may have bigger impact, however the biggest problem still remains the graph database. The first point in the https://gist.github.com/mbriskar/3f2e4f502e68ad614fdd documentation of issue
