### PR TITLE
WINDUP-850: Responsive design in reports is broken if you change brow…

### DIFF
--- a/reporting/impl/src/main/resources/reports/resources/css/windup.css
+++ b/reporting/impl/src/main/resources/reports/resources/css/windup.css
@@ -1,3 +1,10 @@
+@media (max-width:801px) {
+    .panel.panel-boarding{
+        display:inline-block;
+    }
+}
+
+
 body {
   padding-top: 30px;
   padding-bottom: 30px;


### PR DESCRIPTION
There are more changes needed, however they will take probably longer time (I have no idea what is going on in there).
For now:

before:
![screenshot from 2015-12-08 15-37-47](https://cloud.githubusercontent.com/assets/1478315/11659210/5cb2c886-9dc7-11e5-86bd-50aef7df4527.png)
after:
![screenshot from 2015-12-08 15-38-06](https://cloud.githubusercontent.com/assets/1478315/11659209/5cb034ea-9dc7-11e5-91fc-6c1cb903ce21.png)
