### PR TITLE
WINDUP-856 added titles for technology tags in reports

### DIFF
--- a/reporting/impl/src/main/resources/reports/templates/index.ftl
+++ b/reporting/impl/src/main/resources/reports/templates/index.ftl
@@ -8,9 +8,9 @@
 
 <#macro tagRenderer tag>
 	<#if tag.level?? && tag.level == "IMPORTANT">
-		<span class="label label-danger">
+		<span class="label label-danger" title="${tag.level}">
 	<#else>
-		<span class="label label-info">
+		<span class="label label-info" title="${tag.level}">
 	</#if>
 		<#nested/></span>
 </#macro>
@@ -100,15 +100,15 @@
 
             <!-- Table -->
             <table class="table table-striped table-bordered">
-            <tr>
-                <th>Name</th><th>Technology</th><th>Effort</th>
-            </tr>
+               <tr>
+                  <th>Name</th><th>Technology</th><th>Effort</th>
+               </tr>
 
-            <#list reportModel.relatedResources.applications.list.iterator() as applicationReport>
-                <@applicationReportRenderer applicationReport/>
-            </#list>
+               <#list reportModel.relatedResources.applications.list.iterator() as applicationReport>
+                  <@applicationReportRenderer applicationReport/>
+               </#list>
+            </table>
 
-        </table>
 
         <div style="width: 100%; text-align: center">
             <a href="reports/windup_ruleproviders.html">All Rules</a>

--- a/reporting/impl/src/main/resources/reports/templates/source.ftl
+++ b/reporting/impl/src/main/resources/reports/templates/source.ftl
@@ -71,7 +71,7 @@
                             <h4>Technologies</h4>
                             <div class="technologies" style="overflow: auto"><!-- "auto" to contain all the tags. -->
                                 <#items as techTag>
-                                    <span class="label label-info">${techTag.name}</span>
+                                    <span class="label label-info" title="${techTag.level}">${techTag.name}</span>
                                 </#items>
                             </div>
                             </#list>

--- a/rules-java/api/src/main/resources/reports/templates/java_application.ftl
+++ b/rules-java/api/src/main/resources/reports/templates/java_application.ftl
@@ -5,7 +5,7 @@
 
 
 <#macro tagRenderer tag>
-    <span class="label label-${(tag.level! == 'IMPORTANT')?then('danger','info')} tag-${tag.name?replace(' ','')}">
+    <span title="${tag.level}" class="label label-${(tag.level! == 'IMPORTANT')?then('danger','info')} tag-${tag.name?replace(' ','')}">
         <#nested/>
     </span>
 </#macro>


### PR DESCRIPTION
This is an alternative to https://github.com/windup/windup/pull/798 with just titles for technology tags *without showing popup technology tag label legend*