### PR TITLE
add tests for the bootstrap module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ atlassian-ide-plugin.xml
 /nbactions.xml
 *-test-result.html
 rexster.xml
+/tests/cache/

--- a/bootstrap/src/main/resources/META-INF/services/org.jboss.forge.furnace.spi.ContainerLifecycleListener
+++ b/bootstrap/src/main/resources/META-INF/services/org.jboss.forge.furnace.spi.ContainerLifecycleListener
@@ -1,1 +1,1 @@
-org.jboss.windup.bootstrap.GreetingListener
+org.jboss.windup.bootstrap.listener.GreetingListener

--- a/coverage-report/README.md
+++ b/coverage-report/README.md
@@ -8,9 +8,9 @@ data files that this module consumes.
 
 To enable collecting coverage data and producing the report,
 just enable the `jacoco` Maven profile and execute the Maven build
-at least up to the `package` phase from the top-level directory:
+to the `install` phase from the top-level directory:
 
-    mvn clean package -Pjacoco
+    mvn clean install -Pjacoco
 
 The coverage report will then be present in
 

--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,7 @@
     <description>Migration Tools</description>
 
     <properties>
+        <version.forge>2.20.1.Final</version.forge>
         <version.furnace>2.22.7.Final</version.furnace>
         <version.titangraph>0.5.4</version.titangraph>
         <version.tinkerpop.blueprints>2.5.0</version.tinkerpop.blueprints>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -88,6 +88,13 @@
 
         <!-- Test Dependencies -->
         <dependency>
+            <groupId>org.jboss.windup</groupId>
+            <artifactId>windup-bootstrap</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.jboss.forge.furnace.container</groupId>
             <artifactId>cdi</artifactId>
             <classifier>forge-addon</classifier>
@@ -101,5 +108,41 @@
         </dependency>  
 
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.jboss.forge.furnace</groupId>
+                <artifactId>furnace-maven-plugin</artifactId>
+                <version>${version.furnace}</version>
+                <executions>
+                    <execution>
+                        <id>deploy-addons-for-bootstrap-tests</id>
+                        <phase>process-test-resources</phase>
+                        <goals>
+                            <goal>addon-install</goal>
+                        </goals>
+                        <inherited>false</inherited>
+                        <configuration>
+                            <!-- obtained from windup-distribution/pom.xml -->
+                            <addonRepository>${project.build.directory}/forge-addons-for-bootstrap-tests</addonRepository>
+                            <addonIds>
+                                <addonId>org.jboss.forge.addon:addon-manager,${version.forge}</addonId>
+                                <addonId>org.jboss.forge.addon:maven,${version.forge}</addonId>
+                                <addonId>org.jboss.forge.addon:projects,${version.forge}</addonId>
+                                <addonId>org.jboss.windup.ui:windup-ui,${project.version}</addonId>
+                                <addonId>org.jboss.windup.rules.apps:windup-rules-java,${project.version}</addonId>
+                                <addonId>org.jboss.windup.rules.apps:windup-rules-java-project,${project.version}</addonId>
+                                <addonId>org.jboss.windup.rules.apps:windup-rules-java-ee,${project.version}</addonId>
+                                <addonId>org.jboss.windup:windup-tooling,${project.version}</addonId>
+                                <!-- this will be used in the tests, see InstallRemoveAddonCommandTest -->
+                                <!--<addonId>org.jboss.windup.rules.apps:windup-rules-tattletale,${project.version}</addonId>-->
+                            </addonIds>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/tests/src/test/java/org/jboss/windup/tests/bootstrap/AbstractBootstrapTest.java
+++ b/tests/src/test/java/org/jboss/windup/tests/bootstrap/AbstractBootstrapTest.java
@@ -1,0 +1,58 @@
+package org.jboss.windup.tests.bootstrap;
+
+import org.apache.commons.io.output.TeeOutputStream;
+import org.jboss.windup.bootstrap.Bootstrap;
+import org.junit.After;
+import org.junit.Before;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.io.UnsupportedEncodingException;
+
+public abstract class AbstractBootstrapTest {
+    // see tests/pom.xml
+    protected static final String ADDON_REPOSITORY = "target/forge-addons-for-bootstrap-tests";
+
+    private PrintStream originalStdout;
+    private PrintStream originalStderr;
+
+    private ByteArrayOutputStream capturedOutputBytes;
+
+    @Before
+    public final void captureStdout() {
+        originalStdout = System.out;
+        originalStderr = System.err;
+
+        capturedOutputBytes = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(new TeeOutputStream(originalStdout, capturedOutputBytes)));
+        System.setErr(new PrintStream(new TeeOutputStream(originalStderr, capturedOutputBytes)));
+    }
+
+    @After
+    public final void restoreStdout() {
+        System.out.flush();
+        System.err.flush();
+
+        System.setOut(originalStdout);
+        System.setErr(originalStderr);
+    }
+
+    protected final String capturedOutput() {
+        try {
+            return capturedOutputBytes.toString("UTF-8");
+        } catch (UnsupportedEncodingException e) {
+            throw new AssertionError("UTF-8 must be supported");
+        }
+    }
+
+    protected final void bootstrap(String... args) {
+        int newArgumentsCount = 3;
+        String[] realArgs = new String[args.length + newArgumentsCount];
+        realArgs[0] = "--batchMode";
+        realArgs[1] = "--immutableAddonDir";
+        realArgs[2] = ADDON_REPOSITORY;
+        System.arraycopy(args, 0, realArgs, newArgumentsCount, args.length);
+
+        Bootstrap.main(realArgs);
+    }
+}

--- a/tests/src/test/java/org/jboss/windup/tests/bootstrap/AbstractBootstrapTestWithRules.java
+++ b/tests/src/test/java/org/jboss/windup/tests/bootstrap/AbstractBootstrapTestWithRules.java
@@ -1,0 +1,89 @@
+package org.jboss.windup.tests.bootstrap;
+
+import com.google.common.base.Charsets;
+import com.google.common.io.Files;
+import org.jboss.windup.bootstrap.Bootstrap;
+import org.jboss.windup.util.PathUtil;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+
+public abstract class AbstractBootstrapTestWithRules extends AbstractBootstrapTest {
+    private static final String TESTING_MIGRATION_RULES = "<?xml version=\"1.0\"?>\n"
+            + "<ruleset xmlns=\"http://windup.jboss.org/schema/jboss-ruleset\" id=\"BootstrapTests_Eap6to7\" "
+            + "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" "
+            + "xsi:schemaLocation=\"http://windup.jboss.org/schema/jboss-ruleset "
+            + "http://windup.jboss.org/schema/jboss-ruleset/windup-jboss-ruleset.xsd \">\n"
+            + "    <metadata>\n"
+            + "        <description>Only for bootstrap tests.</description>\n"
+            + "        <dependencies>\n"
+            + "            <addon id=\"org.jboss.windup.rules,windup-rules-xml," + Bootstrap.getRuntimeAPIVersion() + "\" />\n"
+            + "        </dependencies>\n"
+            + "        <sourceTechnology id=\"eap6\" versionRange=\"[6,7)\" />\n"
+            + "        <targetTechnology id=\"eap7\" versionRange=\"[7,)\" />\n"
+            + "        <tag>test-tag-eap</tag>\n"
+            + "    </metadata>\n"
+            + "\n"
+            + "    <rules>\n"
+            + "        <rule id=\"testing-rule\">\n"
+            + "            <when>\n"
+            + "                <file filename=\"jboss-web.xml\"/>\n"
+            + "            </when>\n"
+            + "            <perform>\n"
+            + "                <classification title=\"jboss-web.xml\" effort=\"3\" severity=\"mandatory\"/>\n"
+            + "            </perform>\n"
+            + "        </rule>\n"
+            + "    </rules>\n"
+            + "</ruleset>";
+
+    // has a different tag, which is needed for some tests
+    private static final String MORE_TESTING_MIGRATION_RULES = "<?xml version=\"1.0\"?>\n"
+            + "<ruleset xmlns=\"http://windup.jboss.org/schema/jboss-ruleset\" id=\"BootstrapTests_More_Eap6to7\" "
+            + "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" "
+            + "xsi:schemaLocation=\"http://windup.jboss.org/schema/jboss-ruleset "
+            + "http://windup.jboss.org/schema/jboss-ruleset/windup-jboss-ruleset.xsd \">\n"
+            + "    <metadata>\n"
+            + "        <description>Only for bootstrap tests.</description>\n"
+            + "        <dependencies>\n"
+            + "            <addon id=\"org.jboss.windup.rules,windup-rules-xml," + Bootstrap.getRuntimeAPIVersion() + "\" />\n"
+            + "        </dependencies>\n"
+            + "        <sourceTechnology id=\"eap6\" versionRange=\"[6,7)\" />\n"
+            + "        <targetTechnology id=\"eap7\" versionRange=\"[7,)\" />\n"
+            + "        <tag>another-test-tag-eap</tag>\n"
+            + "    </metadata>\n"
+            + "\n"
+            + "    <rules>\n"
+            + "        <rule id=\"another-testing-rule\">\n"
+            + "            <when>\n"
+            + "                <file filename=\"jboss-ejb3.xml\"/>\n"
+            + "            </when>\n"
+            + "            <perform>\n"
+            + "                <classification title=\"jboss-ejb3.xml\" effort=\"3\" severity=\"mandatory\"/>\n"
+            + "            </perform>\n"
+            + "        </rule>\n"
+            + "    </rules>\n"
+            + "</ruleset>";
+
+    @Rule
+    public final TemporaryFolder rulesDir = new TemporaryFolder();
+
+    @Before
+    public void setUpRulesDirectory() throws IOException {
+        File rules = rulesDir.newFile("test-eap6to7-rules.windup.xml");
+        Files.write(TESTING_MIGRATION_RULES, rules, Charsets.UTF_8);
+
+        File moreRules = rulesDir.newFile("test-eap6to7-more-rules.windup.xml");
+        Files.write(MORE_TESTING_MIGRATION_RULES, moreRules, Charsets.UTF_8);
+
+        System.setProperty(PathUtil.WINDUP_RULESETS_DIR_SYSPROP, rulesDir.getRoot().getAbsolutePath());
+    }
+
+    @After
+    public void cleanSystemProperty() {
+        System.clearProperty(PathUtil.WINDUP_RULESETS_DIR_SYSPROP);
+    }
+}

--- a/tests/src/test/java/org/jboss/windup/tests/bootstrap/AddAddonDirectoryCommandTest.java
+++ b/tests/src/test/java/org/jboss/windup/tests/bootstrap/AddAddonDirectoryCommandTest.java
@@ -1,0 +1,42 @@
+package org.jboss.windup.tests.bootstrap;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertTrue;
+
+public class AddAddonDirectoryCommandTest extends AbstractBootstrapTest {
+    @Rule
+    public final TemporaryFolder tmp = new TemporaryFolder();
+
+    @Test
+    public void mutable_longArgument() throws IOException {
+        test("--addonDir");
+    }
+
+    @Test
+    public void mutable_shortArgument() throws IOException {
+        test("-a");
+    }
+
+    @Test
+    public void immutable_longArgument() throws IOException {
+        test("--immutableAddonDir");
+    }
+
+    @Test
+    public void immutable_shortArgument() throws IOException {
+        test("-m");
+    }
+
+    private void test(String arg) throws IOException {
+        String tmpPath = tmp.getRoot().getAbsolutePath();
+
+        bootstrap(arg, tmpPath, "--list");
+
+        assertTrue(capturedOutput().contains(tmpPath));
+    }
+}

--- a/tests/src/test/java/org/jboss/windup/tests/bootstrap/DiscoverPackagesCommandTest.java
+++ b/tests/src/test/java/org/jboss/windup/tests/bootstrap/DiscoverPackagesCommandTest.java
@@ -1,0 +1,82 @@
+package org.jboss.windup.tests.bootstrap;
+
+import com.google.common.base.Charsets;
+import com.google.common.io.Files;
+import org.jboss.windup.bootstrap.Bootstrap;
+import org.jboss.windup.util.PathUtil;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+
+import static org.junit.Assert.assertTrue;
+
+public class DiscoverPackagesCommandTest extends AbstractBootstrapTest {
+    private static final String TESTING_FILE_MAPPING_RULES = "<?xml version=\"1.0\"?>\n"
+            + "<ruleset xmlns=\"http://windup.jboss.org/schema/jboss-ruleset\" "
+            + "id=\"BootstrapTests_PackageToVendorNames\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" "
+            + "xsi:schemaLocation=\"http://windup.jboss.org/schema/jboss-ruleset "
+            + "http://windup.jboss.org/schema/jboss-ruleset/windup-jboss-ruleset.xsd\">\n"
+            + "    <metadata>\n"
+            + "        <description>Only for bootstrap tests.</description>\n"
+            + "        <dependencies>\n"
+            + "            <addon id=\"org.jboss.windup.rules,windup-rules-java," + Bootstrap.getRuntimeAPIVersion() + "\" />\n"
+            + "        </dependencies>\n"
+            + "    </metadata>\n"
+            + "\n"
+            + "    <rules>\n"
+            + "        <package-mapping from=\"org.apache\" to=\"Apache\" />\n"
+            + "    </rules>\n"
+            + "</ruleset>";
+
+    @Rule
+    public final TemporaryFolder rulesDir = new TemporaryFolder();
+
+    @Before
+    public void setUpRulesDirectory() throws IOException {
+        File rules = rulesDir.newFile("test-filemapping-rules.windup.xml");
+        Files.write(TESTING_FILE_MAPPING_RULES, rules, Charsets.UTF_8);
+
+        System.setProperty(PathUtil.WINDUP_RULESETS_DIR_SYSPROP, rulesDir.getRoot().getAbsolutePath());
+    }
+
+    @After
+    public void cleanSystemProperty() {
+        System.clearProperty(PathUtil.WINDUP_RULESETS_DIR_SYSPROP);
+    }
+
+    @Test
+    public void withoutInput() {
+        bootstrap("--discoverPackages");
+        assertTrue(capturedOutput().contains("ERROR: --input must be specified"));
+    }
+
+    @Test
+    public void withValuelessInput() {
+        bootstrap("--discoverPackages", "--input");
+        assertTrue(capturedOutput().contains("ERROR: --input must be specified"));
+    }
+
+    @Ignore("WINDUP-852")
+    @Test
+    public void withIncorrectInput() {
+        bootstrap("--discoverPackages", "--input", "doesntExist.war");
+        assertTrue(capturedOutput().contains("ERROR"));
+    }
+
+    @Test
+    public void withCorrectInput() {
+        bootstrap("--discoverPackages", "--input", "../test-files/jee-example-app-1.0.0.ear");
+        assertTrue(capturedOutput().contains("Known Packages:"));
+        assertTrue(capturedOutput().contains("org.apache"));
+        assertTrue(capturedOutput().contains("Apache"));
+        assertTrue(capturedOutput().contains("Unknown Packages:"));
+        assertTrue(capturedOutput().contains("weblogic"));
+        assertTrue(capturedOutput().contains("Classes"));
+    }
+}

--- a/tests/src/test/java/org/jboss/windup/tests/bootstrap/DisplayHelpCommandTest.java
+++ b/tests/src/test/java/org/jboss/windup/tests/bootstrap/DisplayHelpCommandTest.java
@@ -1,0 +1,31 @@
+package org.jboss.windup.tests.bootstrap;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+
+public class DisplayHelpCommandTest extends AbstractBootstrapTest {
+    @Test
+    public void noArgument() {
+        test();
+    }
+
+    @Test
+    public void longArgument() {
+        test("--help");
+    }
+
+    @Test
+    public void shortArgument() {
+        test("-h");
+    }
+
+    private void test(String... args) {
+        bootstrap(args);
+
+        assertTrue(capturedOutput().contains("Windup Options:"));
+        assertTrue(capturedOutput().contains("--updateRulesets"));
+        assertTrue(capturedOutput().contains("Forge Options:"));
+        assertTrue(capturedOutput().contains("--version"));
+    }
+}

--- a/tests/src/test/java/org/jboss/windup/tests/bootstrap/DisplayVersionCommandTest.java
+++ b/tests/src/test/java/org/jboss/windup/tests/bootstrap/DisplayVersionCommandTest.java
@@ -1,0 +1,24 @@
+package org.jboss.windup.tests.bootstrap;
+
+import org.jboss.windup.bootstrap.Bootstrap;
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+
+public class DisplayVersionCommandTest extends AbstractBootstrapTest {
+    @Test
+    public void longArgument() {
+        test("--version");
+    }
+
+    @Test
+    public void shortArgument() {
+        test("-v");
+    }
+
+    private void test(String... args) {
+        bootstrap(args);
+
+        assertTrue(capturedOutput().contains(Bootstrap.getVersion()));
+    }
+}

--- a/tests/src/test/java/org/jboss/windup/tests/bootstrap/GenerateCompletionDataCommandTest.java
+++ b/tests/src/test/java/org/jboss/windup/tests/bootstrap/GenerateCompletionDataCommandTest.java
@@ -1,0 +1,55 @@
+package org.jboss.windup.tests.bootstrap;
+
+import com.google.common.base.Charsets;
+import org.jboss.windup.util.PathUtil;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class GenerateCompletionDataCommandTest extends AbstractBootstrapTest {
+    @Rule
+    public final TemporaryFolder homeDir = new TemporaryFolder();
+
+    @Before
+    public void setUpHomeDirectory() throws IOException {
+        // the windup.home system property is only read by the GenerateCompletionDataCommand class; this relies on
+        // the Bootstrap class not using the windup.home system property, which fortunately seems to be the case
+        System.setProperty(PathUtil.WINDUP_HOME, homeDir.getRoot().getAbsolutePath());
+    }
+
+    @After
+    public void cleanSystemProperty() {
+        System.clearProperty(PathUtil.WINDUP_HOME);
+    }
+
+
+    @Test
+    public void test() throws IOException {
+        Path data = Paths.get(homeDir.getRoot().getAbsolutePath(), "cache", "bash-completion", "bash-completion.data");
+
+        assertFalse(data.toFile().isFile());
+
+        bootstrap("--generateCompletionData");
+
+        assertTrue(data.toFile().isFile());
+
+        String content = new String(Files.readAllBytes(data), Charsets.UTF_8);
+        assertTrue(content.contains("install"));
+        assertTrue(content.contains("remove"));
+        assertTrue(content.contains("listSourceTechnologies"));
+        assertTrue(content.contains("listTargetTechnologies"));
+        assertTrue(content.contains("listTags"));
+        assertTrue(content.contains("help"));
+        assertTrue(content.contains("version"));
+    }
+}

--- a/tests/src/test/java/org/jboss/windup/tests/bootstrap/InstallRemoveAddonCommandsTest.java
+++ b/tests/src/test/java/org/jboss/windup/tests/bootstrap/InstallRemoveAddonCommandsTest.java
@@ -1,0 +1,103 @@
+package org.jboss.windup.tests.bootstrap;
+
+import org.jboss.windup.bootstrap.Bootstrap;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
+
+@RunWith(Parameterized.class)
+public class InstallRemoveAddonCommandsTest extends AbstractBootstrapTest {
+    private static final String ADDON = "org.jboss.windup.rules.apps:windup-rules-tattletale";
+    private static final String ADDON_WITH_VERSION = ADDON + "," + Bootstrap.getVersion();
+    private static final String BAD_FORMAT = "doesnt.exist";
+    private static final String DOESNT_EXIST = "doesnt:exist";
+
+    private static final String INSTALL = "--install";
+    private static final String REMOVE = "--remove";
+    private static final String I = "-i";
+    private static final String R = "-r";
+
+    @Parameters
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][] {
+                {I,       ADDON,              R,      ADDON,              true},
+                {I,       ADDON,              R,      ADDON_WITH_VERSION, true},
+                {I,       ADDON,              REMOVE, ADDON,              true},
+                {I,       ADDON,              REMOVE, ADDON_WITH_VERSION, true},
+                {I,       ADDON_WITH_VERSION, R,      ADDON,              true},
+                {I,       ADDON_WITH_VERSION, R,      ADDON_WITH_VERSION, true},
+                {I,       ADDON_WITH_VERSION, REMOVE, ADDON,              true},
+                {I,       ADDON_WITH_VERSION, REMOVE, ADDON_WITH_VERSION, true},
+                {INSTALL, ADDON,              R,      ADDON,              true},
+                {INSTALL, ADDON,              R,      ADDON_WITH_VERSION, true},
+                {INSTALL, ADDON,              REMOVE, ADDON,              true},
+                {INSTALL, ADDON,              REMOVE, ADDON_WITH_VERSION, true},
+                {INSTALL, ADDON_WITH_VERSION, R,      ADDON,              true},
+                {INSTALL, ADDON_WITH_VERSION, R,      ADDON_WITH_VERSION, true},
+                {INSTALL, ADDON_WITH_VERSION, REMOVE, ADDON,              true},
+                {INSTALL, ADDON_WITH_VERSION, REMOVE, ADDON_WITH_VERSION, true},
+
+                {INSTALL, BAD_FORMAT,         REMOVE, BAD_FORMAT,         false},
+                {INSTALL, DOESNT_EXIST,       REMOVE, DOESNT_EXIST,       false},
+        });
+    }
+
+    private final String installOption;
+    private final String installAddonId;
+    private final String removeOption;
+    private final String removeAddonId;
+    private final boolean successExpected;
+
+    public InstallRemoveAddonCommandsTest(String installOption, String installAddonId, String removeOption,
+                                          String removeAddonId, boolean successExpected) {
+        this.installOption = installOption;
+        this.installAddonId = installAddonId;
+        this.removeOption = removeOption;
+        this.removeAddonId = removeAddonId;
+        this.successExpected = successExpected;
+    }
+
+    @Test
+    public void commaSeparatedVersion() throws IOException {
+        // installAddonId without version fails because of WINDUP-834
+        assumeTrue(ADDON_WITH_VERSION.equals(installAddonId));
+
+        bootstrap(installOption, installAddonId, removeOption, removeAddonId);
+        checkExpectations();
+    }
+
+    @Test
+    public void colonSeparatedVersion() throws IOException {
+        // installAddonId without version fails because of WINDUP-834
+        assumeTrue(ADDON_WITH_VERSION.equals(installAddonId));
+
+        String installAddonId = this.installAddonId.replace(',', ':');
+        String removeAddonId = this.removeAddonId.replace(',', ':');
+
+        bootstrap(installOption, installAddonId, removeOption, removeAddonId);
+        checkExpectations();
+    }
+
+    private void checkExpectations() {
+        if (successExpected) {
+            assertTrue(capturedOutput().contains("Installation completed successfully"));
+            assertTrue(capturedOutput().contains("Uninstallation completed successfully"));
+        } else {
+            if (BAD_FORMAT.equals(installAddonId)) {
+                assertTrue(capturedOutput().contains("Unrecognized format"));
+            } else {
+                assertTrue(capturedOutput().contains("No Artifact version found"));
+            }
+
+            assertTrue(capturedOutput().contains("No addon exists"));
+        }
+    }
+}

--- a/tests/src/test/java/org/jboss/windup/tests/bootstrap/ListAddonsCommandTest.java
+++ b/tests/src/test/java/org/jboss/windup/tests/bootstrap/ListAddonsCommandTest.java
@@ -1,0 +1,19 @@
+package org.jboss.windup.tests.bootstrap;
+
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertTrue;
+
+public class ListAddonsCommandTest extends AbstractBootstrapTest {
+    @Test
+    public void test() throws IOException {
+        bootstrap("--list");
+
+        assertTrue(capturedOutput().contains(ADDON_REPOSITORY));
+        assertTrue(capturedOutput().contains("Enabled addons:"));
+        assertTrue(capturedOutput().contains("org.jboss.forge.addon"));
+        assertTrue(capturedOutput().contains("org.jboss.windup"));
+    }
+}

--- a/tests/src/test/java/org/jboss/windup/tests/bootstrap/ListTechnologiesAndTagsCommandsTest.java
+++ b/tests/src/test/java/org/jboss/windup/tests/bootstrap/ListTechnologiesAndTagsCommandsTest.java
@@ -1,0 +1,25 @@
+package org.jboss.windup.tests.bootstrap;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+
+public class ListTechnologiesAndTagsCommandsTest extends AbstractBootstrapTestWithRules {
+    @Test
+    public void sourceTechnologies() {
+        bootstrap("--listSourceTechnologies");
+        assertTrue(capturedOutput().contains("eap6"));
+    }
+
+    @Test
+    public void targetTechnologies() {
+        bootstrap("--listTargetTechnologies");
+        assertTrue(capturedOutput().contains("eap7"));
+    }
+
+    @Test
+    public void tags() {
+        bootstrap("--listTags");
+        assertTrue(capturedOutput().contains("test-tag-eap"));
+    }
+}

--- a/tests/src/test/java/org/jboss/windup/tests/bootstrap/UnknownCommandLineArgumentTest.java
+++ b/tests/src/test/java/org/jboss/windup/tests/bootstrap/UnknownCommandLineArgumentTest.java
@@ -1,0 +1,13 @@
+package org.jboss.windup.tests.bootstrap;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+
+public class UnknownCommandLineArgumentTest extends AbstractBootstrapTest {
+    @Test
+    public void test() {
+        bootstrap("--foobar");
+        assertTrue(capturedOutput().contains("WARNING: Unrecognized command-line argument: --foobar"));
+    }
+}

--- a/tests/src/test/java/org/jboss/windup/tests/bootstrap/migrate/CorrectSourceParameterTest.java
+++ b/tests/src/test/java/org/jboss/windup/tests/bootstrap/migrate/CorrectSourceParameterTest.java
@@ -1,0 +1,33 @@
+package org.jboss.windup.tests.bootstrap.migrate;
+
+import org.jboss.windup.tests.bootstrap.AbstractBootstrapTestWithRules;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.IOException;
+import java.nio.file.Files;
+
+import static org.junit.Assert.assertTrue;
+
+public class CorrectSourceParameterTest extends AbstractBootstrapTestWithRules {
+    @Rule
+    public final TemporaryFolder tmp = new TemporaryFolder();
+
+    @Test
+    public void correctSourceParameter() throws IOException {
+        bootstrap("--input", "../test-files/Windup1x-javaee-example-tiny.war",
+                "--output", tmp.getRoot().getAbsolutePath(),
+                "--source", "eap6",
+                "--target", "eap7");
+
+        assertTrue(capturedOutput().contains("WARNING: No packages were set in --packages."));
+        assertTrue(capturedOutput().contains("Executing Windup"));
+        assertTrue(capturedOutput().contains("Windup report created"));
+
+        String indexHtml = new String(Files.readAllBytes(tmp.getRoot().toPath().resolve("index.html")), "UTF-8");
+        assertTrue(indexHtml.contains("Windup1x-javaee-example-tiny.war"));
+        assertTrue(indexHtml.contains("Decompiled Java File"));
+        assertTrue(indexHtml.contains("Maven XML"));
+    }
+}

--- a/tests/src/test/java/org/jboss/windup/tests/bootstrap/migrate/CorrectTargetParameterTest.java
+++ b/tests/src/test/java/org/jboss/windup/tests/bootstrap/migrate/CorrectTargetParameterTest.java
@@ -1,0 +1,32 @@
+package org.jboss.windup.tests.bootstrap.migrate;
+
+import org.jboss.windup.tests.bootstrap.AbstractBootstrapTestWithRules;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.IOException;
+import java.nio.file.Files;
+
+import static org.junit.Assert.assertTrue;
+
+public class CorrectTargetParameterTest extends AbstractBootstrapTestWithRules {
+    @Rule
+    public final TemporaryFolder tmp = new TemporaryFolder();
+
+    @Test
+    public void correctTargetParameter() throws IOException {
+        bootstrap("--input", "../test-files/Windup1x-javaee-example-tiny.war",
+                "--output", tmp.getRoot().getAbsolutePath(),
+                "--target", "eap7");
+
+        assertTrue(capturedOutput().contains("WARNING: No packages were set in --packages."));
+        assertTrue(capturedOutput().contains("Executing Windup"));
+        assertTrue(capturedOutput().contains("Windup report created"));
+
+        String indexHtml = new String(Files.readAllBytes(tmp.getRoot().toPath().resolve("index.html")), "UTF-8");
+        assertTrue(indexHtml.contains("Windup1x-javaee-example-tiny.war"));
+        assertTrue(indexHtml.contains("Decompiled Java File"));
+        assertTrue(indexHtml.contains("Maven XML"));
+    }
+}

--- a/tests/src/test/java/org/jboss/windup/tests/bootstrap/migrate/CorrectValueOfPackagesParameterTest.java
+++ b/tests/src/test/java/org/jboss/windup/tests/bootstrap/migrate/CorrectValueOfPackagesParameterTest.java
@@ -1,0 +1,32 @@
+package org.jboss.windup.tests.bootstrap.migrate;
+
+import org.jboss.windup.tests.bootstrap.AbstractBootstrapTestWithRules;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.IOException;
+import java.nio.file.Files;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class CorrectValueOfPackagesParameterTest extends AbstractBootstrapTestWithRules {
+    @Rule
+    public final TemporaryFolder tmp = new TemporaryFolder();
+
+    @Test
+    public void correctValueOfPackagesParameter() throws IOException {
+        bootstrap("--input", "../test-files/Windup1x-javaee-example-tiny.war",
+                "--output", tmp.getRoot().getAbsolutePath(),
+                "--source", "eap6",
+                "--target", "eap7",
+                "--packages", "org.windup");
+
+        assertFalse(capturedOutput().contains("WARNING: No packages were set in --packages."));
+        assertFalse(capturedOutput().contains("WARNING: The packages specified to scan are very broad."));
+
+        String indexHtml = new String(Files.readAllBytes(tmp.getRoot().toPath().resolve("index.html")), "UTF-8");
+        assertTrue(indexHtml.contains("Decompiled Java File"));
+    }
+}

--- a/tests/src/test/java/org/jboss/windup/tests/bootstrap/migrate/ExcludeMultipleTagsTest.java
+++ b/tests/src/test/java/org/jboss/windup/tests/bootstrap/migrate/ExcludeMultipleTagsTest.java
@@ -1,0 +1,26 @@
+package org.jboss.windup.tests.bootstrap.migrate;
+
+import org.jboss.windup.tests.bootstrap.AbstractBootstrapTestWithRules;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertFalse;
+
+public class ExcludeMultipleTagsTest extends AbstractBootstrapTestWithRules {
+    @Rule
+    public final TemporaryFolder tmp = new TemporaryFolder();
+
+    @Test
+    public void excludeMultipleTags() throws IOException {
+        bootstrap("--input", "../test-files/Windup1x-javaee-example-tiny.war",
+                "--output", tmp.getRoot().getAbsolutePath(),
+                "--target", "eap7",
+                "--excludeTags", "test-tag-eap", "another-test-tag-eap");
+
+        assertFalse(capturedOutput().contains("BootstrapTests_Eap6to7"));
+        assertFalse(capturedOutput().contains("BootstrapTests_More_Eap6to7"));
+    }
+}

--- a/tests/src/test/java/org/jboss/windup/tests/bootstrap/migrate/ExcludePackagesSameAsPackagesTest.java
+++ b/tests/src/test/java/org/jboss/windup/tests/bootstrap/migrate/ExcludePackagesSameAsPackagesTest.java
@@ -1,0 +1,29 @@
+package org.jboss.windup.tests.bootstrap.migrate;
+
+import org.jboss.windup.tests.bootstrap.AbstractBootstrapTestWithRules;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.IOException;
+import java.nio.file.Files;
+
+import static org.junit.Assert.assertFalse;
+
+public class ExcludePackagesSameAsPackagesTest extends AbstractBootstrapTestWithRules {
+    @Rule
+    public final TemporaryFolder tmp = new TemporaryFolder();
+
+    @Test
+    public void excludePackagesSameAsPackages() throws IOException {
+        bootstrap("--input", "../test-files/Windup1x-javaee-example-tiny.war",
+                "--output", tmp.getRoot().getAbsolutePath(),
+                "--source", "eap6",
+                "--target", "eap7",
+                "--packages", "org.windup",
+                "--excludePackages", "org.windup");
+
+        String indexHtml = new String(Files.readAllBytes(tmp.getRoot().toPath().resolve("index.html")), "UTF-8");
+        assertFalse(indexHtml.contains("Decompiled Java File"));
+    }
+}

--- a/tests/src/test/java/org/jboss/windup/tests/bootstrap/migrate/ExcludeTagsTest.java
+++ b/tests/src/test/java/org/jboss/windup/tests/bootstrap/migrate/ExcludeTagsTest.java
@@ -1,0 +1,27 @@
+package org.jboss.windup.tests.bootstrap.migrate;
+
+import org.jboss.windup.tests.bootstrap.AbstractBootstrapTestWithRules;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class ExcludeTagsTest extends AbstractBootstrapTestWithRules {
+    @Rule
+    public final TemporaryFolder tmp = new TemporaryFolder();
+
+    @Test
+    public void excludeTags() throws IOException {
+        bootstrap("--input", "../test-files/Windup1x-javaee-example-tiny.war",
+                "--output", tmp.getRoot().getAbsolutePath(),
+                "--target", "eap7",
+                "--excludeTags", "test-tag-eap");
+
+        assertFalse(capturedOutput().contains("BootstrapTests_Eap6to7"));
+        assertTrue(capturedOutput().contains("BootstrapTests_More_Eap6to7"));
+    }
+}

--- a/tests/src/test/java/org/jboss/windup/tests/bootstrap/migrate/ExplodedAppTest.java
+++ b/tests/src/test/java/org/jboss/windup/tests/bootstrap/migrate/ExplodedAppTest.java
@@ -1,0 +1,37 @@
+package org.jboss.windup.tests.bootstrap.migrate;
+
+import org.jboss.windup.tests.bootstrap.AbstractBootstrapTestWithRules;
+import org.jboss.windup.util.ZipUtil;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+
+import static org.junit.Assert.assertTrue;
+
+public class ExplodedAppTest extends AbstractBootstrapTestWithRules {
+    @Rule
+    public final TemporaryFolder tmp = new TemporaryFolder();
+
+    @Test
+    public void explodedApp() throws IOException {
+        File explodedAppDir = tmp.newFolder("exploded-app-directory");
+        ZipUtil.unzipToFolder(new File("../test-files/Windup1x-javaee-example-tiny.war"), explodedAppDir);
+
+        File output = tmp.newFolder("output");
+
+        bootstrap("--input", explodedAppDir.getAbsolutePath(),
+                "--output", output.getAbsolutePath(),
+                "--source", "eap6",
+                "--target", "eap7",
+                "--explodedApp");
+
+        String indexHtml = new String(Files.readAllBytes(output.toPath().resolve("index.html")), "UTF-8");
+        assertTrue(indexHtml.contains("exploded-app-directory"));
+        assertTrue(indexHtml.contains("Decompiled Java File"));
+        assertTrue(indexHtml.contains("Maven XML"));
+    }
+}

--- a/tests/src/test/java/org/jboss/windup/tests/bootstrap/migrate/ExportCsvTest.java
+++ b/tests/src/test/java/org/jboss/windup/tests/bootstrap/migrate/ExportCsvTest.java
@@ -1,0 +1,33 @@
+package org.jboss.windup.tests.bootstrap.migrate;
+
+import org.jboss.windup.tests.bootstrap.AbstractBootstrapTestWithRules;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+
+import static org.junit.Assert.assertTrue;
+
+public class ExportCsvTest extends AbstractBootstrapTestWithRules {
+    @Rule
+    public final TemporaryFolder tmp = new TemporaryFolder();
+
+    @Test
+    public void exportCsv() throws IOException {
+        bootstrap("--input", "../test-files/Windup1x-javaee-example-tiny.war",
+                "--output", tmp.getRoot().getAbsolutePath(),
+                "--target", "eap7",
+                "--exportCSV");
+
+        File csv = new File(tmp.getRoot(), "Windup_Source_based_example__org_windup_examples_windup_src_example_1_0_0_.csv");
+
+        assertTrue(csv.exists());
+
+        String csvContent = new String(Files.readAllBytes(csv.toPath()), "UTF-8");
+
+        assertTrue(csvContent.contains("Windup1x-javaee-example-tiny.war"));
+    }
+}

--- a/tests/src/test/java/org/jboss/windup/tests/bootstrap/migrate/IncludeMultipleTagsTest.java
+++ b/tests/src/test/java/org/jboss/windup/tests/bootstrap/migrate/IncludeMultipleTagsTest.java
@@ -1,0 +1,26 @@
+package org.jboss.windup.tests.bootstrap.migrate;
+
+import org.jboss.windup.tests.bootstrap.AbstractBootstrapTestWithRules;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertTrue;
+
+public class IncludeMultipleTagsTest extends AbstractBootstrapTestWithRules {
+    @Rule
+    public final TemporaryFolder tmp = new TemporaryFolder();
+
+    @Test
+    public void includeMultipleTags() throws IOException {
+        bootstrap("--input", "../test-files/Windup1x-javaee-example-tiny.war",
+                "--output", tmp.getRoot().getAbsolutePath(),
+                "--target", "eap7",
+                "--includeTags", "test-tag-eap", "another-test-tag-eap");
+
+        assertTrue(capturedOutput().contains("BootstrapTests_Eap6to7"));
+        assertTrue(capturedOutput().contains("BootstrapTests_More_Eap6to7"));
+    }
+}

--- a/tests/src/test/java/org/jboss/windup/tests/bootstrap/migrate/IncludeTagsTest.java
+++ b/tests/src/test/java/org/jboss/windup/tests/bootstrap/migrate/IncludeTagsTest.java
@@ -1,0 +1,27 @@
+package org.jboss.windup.tests.bootstrap.migrate;
+
+import org.jboss.windup.tests.bootstrap.AbstractBootstrapTestWithRules;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class IncludeTagsTest extends AbstractBootstrapTestWithRules {
+    @Rule
+    public final TemporaryFolder tmp = new TemporaryFolder();
+
+    @Test
+    public void includeTags() throws IOException {
+        bootstrap("--input", "../test-files/Windup1x-javaee-example-tiny.war",
+                "--output", tmp.getRoot().getAbsolutePath(),
+                "--target", "eap7",
+                "--includeTags", "test-tag-eap");
+
+        assertTrue(capturedOutput().contains("BootstrapTests_Eap6to7"));
+        assertFalse(capturedOutput().contains("BootstrapTests_More_Eap6to7"));
+    }
+}

--- a/tests/src/test/java/org/jboss/windup/tests/bootstrap/migrate/InputFileUnderOutputDirectoryTest.java
+++ b/tests/src/test/java/org/jboss/windup/tests/bootstrap/migrate/InputFileUnderOutputDirectoryTest.java
@@ -1,0 +1,22 @@
+package org.jboss.windup.tests.bootstrap.migrate;
+
+import org.jboss.windup.tests.bootstrap.AbstractBootstrapTestWithRules;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import static org.junit.Assert.assertTrue;
+
+public class InputFileUnderOutputDirectoryTest extends AbstractBootstrapTestWithRules {
+    @Rule
+    public final TemporaryFolder tmp = new TemporaryFolder();
+
+    @Test
+    public void inputFileUnderOutputDirectory() {
+        bootstrap("--input", "../test-files/Windup1x-javaee-example-tiny.war",
+                "--output", "../test-files/",
+                "--target", "eap7");
+
+        assertTrue(capturedOutput().contains("ERROR: Output path must not be a parent of input path."));
+    }
+}

--- a/tests/src/test/java/org/jboss/windup/tests/bootstrap/migrate/MissingValueOfExcludePackagesTest.java
+++ b/tests/src/test/java/org/jboss/windup/tests/bootstrap/migrate/MissingValueOfExcludePackagesTest.java
@@ -1,0 +1,29 @@
+package org.jboss.windup.tests.bootstrap.migrate;
+
+import org.jboss.windup.tests.bootstrap.AbstractBootstrapTestWithRules;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.IOException;
+import java.nio.file.Files;
+
+import static org.junit.Assert.assertTrue;
+
+public class MissingValueOfExcludePackagesTest extends AbstractBootstrapTestWithRules {
+    @Rule
+    public final TemporaryFolder tmp = new TemporaryFolder();
+
+    @Test
+    public void missingValueOfExcludePackages() throws IOException {
+        bootstrap("--input", "../test-files/Windup1x-javaee-example-tiny.war",
+                "--output", tmp.getRoot().getAbsolutePath(),
+                "--source", "eap6",
+                "--target", "eap7",
+                "--packages", "org.windup",
+                "--excludePackages");
+
+        String indexHtml = new String(Files.readAllBytes(tmp.getRoot().toPath().resolve("index.html")), "UTF-8");
+        assertTrue(indexHtml.contains("Decompiled Java File"));
+    }
+}

--- a/tests/src/test/java/org/jboss/windup/tests/bootstrap/migrate/MissingValueOfExcludeTagsTest.java
+++ b/tests/src/test/java/org/jboss/windup/tests/bootstrap/migrate/MissingValueOfExcludeTagsTest.java
@@ -1,0 +1,26 @@
+package org.jboss.windup.tests.bootstrap.migrate;
+
+import org.jboss.windup.tests.bootstrap.AbstractBootstrapTestWithRules;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertTrue;
+
+public class MissingValueOfExcludeTagsTest extends AbstractBootstrapTestWithRules {
+    @Rule
+    public final TemporaryFolder tmp = new TemporaryFolder();
+
+    @Test
+    public void missingValueOfExcludeTags() throws IOException {
+        bootstrap("--input", "../test-files/Windup1x-javaee-example-tiny.war",
+                "--output", tmp.getRoot().getAbsolutePath(),
+                "--target", "eap7",
+                "--excludeTags");
+
+        assertTrue(capturedOutput().contains("BootstrapTests_Eap6to7"));
+        assertTrue(capturedOutput().contains("BootstrapTests_More_Eap6to7"));
+    }
+}

--- a/tests/src/test/java/org/jboss/windup/tests/bootstrap/migrate/MissingValueOfIncludeTagsTest.java
+++ b/tests/src/test/java/org/jboss/windup/tests/bootstrap/migrate/MissingValueOfIncludeTagsTest.java
@@ -1,0 +1,26 @@
+package org.jboss.windup.tests.bootstrap.migrate;
+
+import org.jboss.windup.tests.bootstrap.AbstractBootstrapTestWithRules;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertTrue;
+
+public class MissingValueOfIncludeTagsTest extends AbstractBootstrapTestWithRules {
+    @Rule
+    public final TemporaryFolder tmp = new TemporaryFolder();
+
+    @Test
+    public void missingValueOfIncludeTags() throws IOException {
+        bootstrap("--input", "../test-files/Windup1x-javaee-example-tiny.war",
+                "--output", tmp.getRoot().getAbsolutePath(),
+                "--target", "eap7",
+                "--includeTags");
+
+        assertTrue(capturedOutput().contains("BootstrapTests_Eap6to7"));
+        assertTrue(capturedOutput().contains("BootstrapTests_More_Eap6to7"));
+    }
+}

--- a/tests/src/test/java/org/jboss/windup/tests/bootstrap/migrate/MissingValueOfPackagesParameterTest.java
+++ b/tests/src/test/java/org/jboss/windup/tests/bootstrap/migrate/MissingValueOfPackagesParameterTest.java
@@ -1,0 +1,24 @@
+package org.jboss.windup.tests.bootstrap.migrate;
+
+import org.jboss.windup.tests.bootstrap.AbstractBootstrapTestWithRules;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import static org.junit.Assert.assertTrue;
+
+public class MissingValueOfPackagesParameterTest extends AbstractBootstrapTestWithRules {
+    @Rule
+    public final TemporaryFolder tmp = new TemporaryFolder();
+
+    @Test
+    public void missingValueOfPackagesParameter() {
+        bootstrap("--input", "../test-files/Windup1x-javaee-example-tiny.war",
+                "--output", tmp.getRoot().getAbsolutePath(),
+                "--source", "eap6",
+                "--target", "eap7",
+                "--packages");
+
+        assertTrue(capturedOutput().contains("WARNING: No packages were set in --packages."));
+    }
+}

--- a/tests/src/test/java/org/jboss/windup/tests/bootstrap/migrate/NoOverwriteTest.java
+++ b/tests/src/test/java/org/jboss/windup/tests/bootstrap/migrate/NoOverwriteTest.java
@@ -1,0 +1,28 @@
+package org.jboss.windup.tests.bootstrap.migrate;
+
+import org.jboss.windup.tests.bootstrap.AbstractBootstrapTestWithRules;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertTrue;
+
+public class NoOverwriteTest extends AbstractBootstrapTestWithRules {
+    @Rule
+    public final TemporaryFolder tmp = new TemporaryFolder();
+
+    @Test
+    public void noOverwrite() throws IOException {
+        bootstrap("--input", "../test-files/Windup1x-javaee-example-tiny.war",
+                "--output", tmp.getRoot().getAbsolutePath(),
+                "--target", "eap7");
+
+        bootstrap("--input", "../test-files/Windup1x-javaee-example-tiny.war",
+                "--output", tmp.getRoot().getAbsolutePath(),
+                "--target", "eap7");
+
+        assertTrue(capturedOutput().contains("--overwrite not specified. Aborting"));
+    }
+}

--- a/tests/src/test/java/org/jboss/windup/tests/bootstrap/migrate/NoTargetParameterTest.java
+++ b/tests/src/test/java/org/jboss/windup/tests/bootstrap/migrate/NoTargetParameterTest.java
@@ -1,0 +1,21 @@
+package org.jboss.windup.tests.bootstrap.migrate;
+
+import org.jboss.windup.tests.bootstrap.AbstractBootstrapTestWithRules;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import static org.junit.Assert.assertTrue;
+
+public class NoTargetParameterTest extends AbstractBootstrapTestWithRules {
+    @Rule
+    public final TemporaryFolder tmp = new TemporaryFolder();
+
+    @Test
+    public void noTargetParameter() {
+        bootstrap("--input", "../test-files/Windup1x-javaee-example-tiny.war",
+                "--output", tmp.getRoot().getAbsolutePath());
+
+        assertTrue(capturedOutput().contains("ERROR: target parameter is required!"));
+    }
+}

--- a/tests/src/test/java/org/jboss/windup/tests/bootstrap/migrate/OverwriteTest.java
+++ b/tests/src/test/java/org/jboss/windup/tests/bootstrap/migrate/OverwriteTest.java
@@ -1,0 +1,29 @@
+package org.jboss.windup.tests.bootstrap.migrate;
+
+import org.jboss.windup.tests.bootstrap.AbstractBootstrapTestWithRules;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertFalse;
+
+public class OverwriteTest extends AbstractBootstrapTestWithRules {
+    @Rule
+    public final TemporaryFolder tmp = new TemporaryFolder();
+
+    @Test
+    public void overwrite() throws IOException {
+        bootstrap("--input", "../test-files/Windup1x-javaee-example-tiny.war",
+                "--output", tmp.getRoot().getAbsolutePath(),
+                "--target", "eap7");
+
+        bootstrap("--input", "../test-files/Windup1x-javaee-example-tiny.war",
+                "--output", tmp.getRoot().getAbsolutePath(),
+                "--target", "eap7",
+                "--overwrite");
+
+        assertFalse(capturedOutput().contains("--overwrite not specified. Aborting"));
+    }
+}

--- a/tests/src/test/java/org/jboss/windup/tests/bootstrap/migrate/SameInputAndOutputPathTest.java
+++ b/tests/src/test/java/org/jboss/windup/tests/bootstrap/migrate/SameInputAndOutputPathTest.java
@@ -1,0 +1,22 @@
+package org.jboss.windup.tests.bootstrap.migrate;
+
+import org.jboss.windup.tests.bootstrap.AbstractBootstrapTestWithRules;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import static org.junit.Assert.assertTrue;
+
+public class SameInputAndOutputPathTest extends AbstractBootstrapTestWithRules {
+    @Rule
+    public final TemporaryFolder tmp = new TemporaryFolder();
+
+    @Test
+    public void sameInputAndOutputPath() {
+        bootstrap("--input", "../test-files/Windup1x-javaee-example-tiny.war",
+                "--output", "../test-files/Windup1x-javaee-example-tiny.war",
+                "--target", "eap7");
+
+        assertTrue(capturedOutput().contains("ERROR: Output file cannot be the same as the input file."));
+    }
+}

--- a/tests/src/test/java/org/jboss/windup/tests/bootstrap/migrate/SourceModeExplodedAppTest.java
+++ b/tests/src/test/java/org/jboss/windup/tests/bootstrap/migrate/SourceModeExplodedAppTest.java
@@ -1,0 +1,30 @@
+package org.jboss.windup.tests.bootstrap.migrate;
+
+import org.jboss.windup.tests.bootstrap.AbstractBootstrapTestWithRules;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.IOException;
+import java.nio.file.Files;
+
+import static org.junit.Assert.assertTrue;
+
+public class SourceModeExplodedAppTest extends AbstractBootstrapTestWithRules {
+    @Rule
+    public final TemporaryFolder tmp = new TemporaryFolder();
+
+    @Test
+    public void sourceModeExplodedApp() throws IOException {
+        bootstrap("--input", "../test-files/src_example",
+                "--output", tmp.getRoot().getAbsolutePath(),
+                "--source", "eap6",
+                "--target", "eap7",
+                "--sourceMode",
+                "--explodedApp");
+
+        String indexHtml = new String(Files.readAllBytes(tmp.getRoot().toPath().resolve("index.html")), "UTF-8");
+        assertTrue(indexHtml.contains("Java Source"));
+        assertTrue(indexHtml.contains("Maven XML"));
+    }
+}

--- a/tests/src/test/java/org/jboss/windup/tests/bootstrap/migrate/SourceModeTest.java
+++ b/tests/src/test/java/org/jboss/windup/tests/bootstrap/migrate/SourceModeTest.java
@@ -1,0 +1,29 @@
+package org.jboss.windup.tests.bootstrap.migrate;
+
+import org.jboss.windup.tests.bootstrap.AbstractBootstrapTestWithRules;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.IOException;
+import java.nio.file.Files;
+
+import static org.junit.Assert.assertTrue;
+
+public class SourceModeTest extends AbstractBootstrapTestWithRules {
+    @Rule
+    public final TemporaryFolder tmp = new TemporaryFolder();
+
+    @Test
+    public void sourceMode() throws IOException {
+        bootstrap("--input", "../test-files/src_example",
+                "--output", tmp.getRoot().getAbsolutePath(),
+                "--source", "eap6",
+                "--target", "eap7",
+                "--sourceMode");
+
+        String indexHtml = new String(Files.readAllBytes(tmp.getRoot().toPath().resolve("index.html")), "UTF-8");
+        assertTrue(indexHtml.contains("Java Source"));
+        assertTrue(indexHtml.contains("Maven XML"));
+    }
+}

--- a/tests/src/test/java/org/jboss/windup/tests/bootstrap/migrate/TooGeneralValueOfPackagesParameterTest.java
+++ b/tests/src/test/java/org/jboss/windup/tests/bootstrap/migrate/TooGeneralValueOfPackagesParameterTest.java
@@ -1,0 +1,24 @@
+package org.jboss.windup.tests.bootstrap.migrate;
+
+import org.jboss.windup.tests.bootstrap.AbstractBootstrapTestWithRules;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import static org.junit.Assert.assertTrue;
+
+public class TooGeneralValueOfPackagesParameterTest extends AbstractBootstrapTestWithRules {
+    @Rule
+    public final TemporaryFolder tmp = new TemporaryFolder();
+
+    @Test
+    public void tooGeneralValueOfPackagesParameter() {
+        bootstrap("--input", "../test-files/Windup1x-javaee-example-tiny.war",
+                "--output", tmp.getRoot().getAbsolutePath(),
+                "--source", "eap6",
+                "--target", "eap7",
+                "--packages", "org");
+
+        assertTrue(capturedOutput().contains("WARNING: The packages specified to scan are very broad."));
+    }
+}

--- a/tests/src/test/java/org/jboss/windup/tests/bootstrap/migrate/UselessValueOfExcludePackagesTest.java
+++ b/tests/src/test/java/org/jboss/windup/tests/bootstrap/migrate/UselessValueOfExcludePackagesTest.java
@@ -1,0 +1,29 @@
+package org.jboss.windup.tests.bootstrap.migrate;
+
+import org.jboss.windup.tests.bootstrap.AbstractBootstrapTestWithRules;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.IOException;
+import java.nio.file.Files;
+
+import static org.junit.Assert.assertTrue;
+
+public class UselessValueOfExcludePackagesTest extends AbstractBootstrapTestWithRules {
+    @Rule
+    public final TemporaryFolder tmp = new TemporaryFolder();
+
+    @Test
+    public void uselessValueOfExcludePackages() throws IOException {
+        bootstrap("--input", "../test-files/Windup1x-javaee-example-tiny.war",
+                "--output", tmp.getRoot().getAbsolutePath(),
+                "--source", "eap6",
+                "--target", "eap7",
+                "--packages", "org.windup",
+                "--excludePackages", "com.example");
+
+        String indexHtml = new String(Files.readAllBytes(tmp.getRoot().toPath().resolve("index.html")), "UTF-8");
+        assertTrue(indexHtml.contains("Decompiled Java File"));
+    }
+}

--- a/tests/src/test/java/org/jboss/windup/tests/bootstrap/migrate/WrongSourceParameterTest.java
+++ b/tests/src/test/java/org/jboss/windup/tests/bootstrap/migrate/WrongSourceParameterTest.java
@@ -1,0 +1,23 @@
+package org.jboss.windup.tests.bootstrap.migrate;
+
+import org.jboss.windup.tests.bootstrap.AbstractBootstrapTestWithRules;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import static org.junit.Assert.assertTrue;
+
+public class WrongSourceParameterTest extends AbstractBootstrapTestWithRules {
+    @Rule
+    public final TemporaryFolder tmp = new TemporaryFolder();
+
+    @Test
+    public void wrongSourceParameter() {
+        bootstrap("--input", "../test-files/Windup1x-javaee-example-tiny.war",
+                "--output", tmp.getRoot().getAbsolutePath(),
+                "--source", "doesntExist",
+                "--target", "eap7");
+
+        assertTrue(capturedOutput().contains("ERROR: source value (doesntExist) not found,"));
+    }
+}

--- a/tests/src/test/java/org/jboss/windup/tests/bootstrap/migrate/WrongTargetParameterTest.java
+++ b/tests/src/test/java/org/jboss/windup/tests/bootstrap/migrate/WrongTargetParameterTest.java
@@ -1,0 +1,22 @@
+package org.jboss.windup.tests.bootstrap.migrate;
+
+import org.jboss.windup.tests.bootstrap.AbstractBootstrapTestWithRules;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import static org.junit.Assert.assertTrue;
+
+public class WrongTargetParameterTest extends AbstractBootstrapTestWithRules {
+    @Rule
+    public final TemporaryFolder tmp = new TemporaryFolder();
+
+    @Test
+    public void wrongTargetParameter() {
+        bootstrap("--input", "../test-files/Windup1x-javaee-example-tiny.war",
+                "--output", tmp.getRoot().getAbsolutePath(),
+                "--target", "doesntExist");
+
+        assertTrue(capturedOutput().contains("ERROR: target value (doesntExist) not found"));
+    }
+}


### PR DESCRIPTION
Adds a reasonable test coverage for the `bootstrap` module. According to JaCoCo:

Package | Line Coverage | Branch Coverage
------------- | ------------- | -------------
org.jboss.windup.bootstrap | 63% | 57%
org.jboss.windup.bootstrap.commands | 89% | 100%
org.jboss.windup.bootstrap.commands.addons | 66% | 43%
org.jboss.windup.bootstrap.commands.windup | 72% | 63%
org.jboss.windup.bootstrap.help | 80% | 50%
org.jboss.windup.bootstrap.listener | 100% | n/a

Couple of things to mention:

- I fixed the `META-INF/services/org.jboss.forge.furnace.spi.ContainerLifecycleListener` file, but this changes visible behavior (adds a nice Windup banner to the CLI), of which I'm not sure. I mean, the file was definitely wrong as it referenced a non-existing class, but maybe you'd like to remove the file and the banner completely, or something else.

- I originally had a lot of tests in a single class. However, Surefire keeps a single JVM for at least the entire test class. That test class ran the entire bootstrap (i.e., whole Windup) more than 20 times. And since Windup/Forge/Furnace is quite permgen-heavy, this led to `OOM: permgen` during test runs. That's why there's so many classes in the `org.jboss.windup.tests.bootstrap.migrate` package.

- Some tests are disabled using `@Ignore` or `assumeTrue` due to known bugs. There's only a few of them, though.