### PR TITLE
WINDUPRULE-109: Long Xpaths suffered from not executed parts

### DIFF
--- a/rules-xml/api/src/main/java/org/jboss/windup/rules/apps/xml/condition/XmlFile.java
+++ b/rules-xml/api/src/main/java/org/jboss/windup/rules/apps/xml/condition/XmlFile.java
@@ -574,7 +574,7 @@ public class XmlFile extends ParameterizedGraphCondition implements XmlFileDTD, 
                     }
                 }
 
-                for (Map.Entry<String, String> entry : paramMatchCache.getVariables(frameIdx).entrySet())
+                for (Map.Entry<String, String> entry : paramMatchCache.getVariables().entrySet())
                 {
                     Parameter<?> param = store.get(entry.getKey());
                     String value = entry.getValue();

--- a/rules-xml/api/src/main/java/org/jboss/windup/rules/apps/xml/condition/XmlFileNamespace.java
+++ b/rules-xml/api/src/main/java/org/jboss/windup/rules/apps/xml/condition/XmlFileNamespace.java
@@ -16,4 +16,12 @@ public interface XmlFileNamespace extends ConditionBuilder
      * @return
      */
     ConditionBuilder as(String variable);
+
+    /**
+     * Specify the namespace used in the xpath that was provided sooner. Use this now only if you don't want to specify any of these: xpath result regex, DTD regex, file naem regex.
+     * @param prefix the namespace prefix
+     * @param url the namespace url
+     * @return the last step in XmlFile definition to provide the variable name
+     */
+    XmlFileNamespace namespace(String prefix, String url);
 }

--- a/rules-xml/api/src/main/java/org/jboss/windup/rules/apps/xml/condition/XmlFileParameterMatchCache.java
+++ b/rules-xml/api/src/main/java/org/jboss/windup/rules/apps/xml/condition/XmlFileParameterMatchCache.java
@@ -23,7 +23,11 @@ public class XmlFileParameterMatchCache
     {
         for (int i = frameID; i >= 0; i--)
         {
-            String existingValue = vars.get(i).get(key);
+            Map<String, String> frameVariables = vars.get(i);
+            if(frameVariables == null) {
+                continue;
+            }
+            String existingValue = frameVariables.get(key);
             if (existingValue != null && !existingValue.equals(value))
             {
                 return false;
@@ -37,10 +41,10 @@ public class XmlFileParameterMatchCache
         vars.get(frameID).put(key, value);
     }
 
-    public Map<String, String> getVariables(int frameID)
+    public Map<String, String> getVariables()
     {
         Map<String, String> result = new HashMap<>();
-        for (int i = 0; i < vars.size(); i++)
+        for (int i  : vars.keySet())
         {
             Map<String, String> existingVars = vars.get(i);
             for (Map.Entry<String, String> existingVar : existingVars.entrySet())

--- a/rules-xml/tests/src/test/java/org/jboss/windup/rules/xml/XmlFileLongXpathTest.java
+++ b/rules-xml/tests/src/test/java/org/jboss/windup/rules/xml/XmlFileLongXpathTest.java
@@ -1,0 +1,131 @@
+package org.jboss.windup.rules.xml;
+
+import org.apache.commons.io.FileUtils;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.forge.arquillian.AddonDependencies;
+import org.jboss.forge.arquillian.AddonDependency;
+import org.jboss.forge.arquillian.archive.AddonArchive;
+import org.jboss.forge.furnace.util.Iterators;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.windup.config.AbstractRuleProvider;
+import org.jboss.windup.config.metadata.MetadataBuilder;
+import org.jboss.windup.config.operation.Iteration;
+import org.jboss.windup.config.phase.MigrationRulesPhase;
+import org.jboss.windup.config.phase.PostMigrationRulesPhase;
+import org.jboss.windup.config.phase.ReportGenerationPhase;
+import org.jboss.windup.exec.WindupProcessor;
+import org.jboss.windup.exec.configuration.WindupConfiguration;
+import org.jboss.windup.exec.rulefilters.NotPredicate;
+import org.jboss.windup.exec.rulefilters.RuleProviderPhasePredicate;
+import org.jboss.windup.graph.GraphContext;
+import org.jboss.windup.graph.GraphContextFactory;
+import org.jboss.windup.graph.model.ProjectModel;
+import org.jboss.windup.graph.model.resource.FileModel;
+import org.jboss.windup.graph.service.GraphService;
+import org.jboss.windup.reporting.config.Hint;
+import org.jboss.windup.reporting.config.classification.Classification;
+import org.jboss.windup.reporting.model.ClassificationModel;
+import org.jboss.windup.reporting.model.InlineHintModel;
+import org.jboss.windup.rules.apps.xml.condition.XmlFile;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.ocpsoft.rewrite.config.Configuration;
+import org.ocpsoft.rewrite.config.ConfigurationBuilder;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Testing {@link XmlFile} condition with a long xpath that registers multiple startFrame()/persist functions in the complicated fashion.
+ */
+@RunWith(Arquillian.class)
+public class XmlFileLongXpathTest
+{
+
+    public static final String LONG_XPATHS_WORK_FINE_CLASSIFICATION = "Long xpaths work fine!";
+
+    @Deployment
+    @AddonDependencies({
+                @AddonDependency(name = "org.jboss.windup.config:windup-config"),
+                @AddonDependency(name = "org.jboss.windup.exec:windup-exec"),
+                @AddonDependency(name = "org.jboss.windup.rules.apps:windup-rules-java"),
+                @AddonDependency(name = "org.jboss.windup.rules.apps:windup-rules-base"),
+                @AddonDependency(name = "org.jboss.windup.rules.apps:windup-rules-xml"),
+                @AddonDependency(name = "org.jboss.windup.reporting:windup-reporting"),
+                @AddonDependency(name = "org.jboss.forge.furnace.container:cdi")
+    })
+    public static AddonArchive getDeployment()
+    {
+        return ShrinkWrap.create(AddonArchive.class).addBeansXML();
+    }
+
+    @Inject
+    private WindupProcessor processor;
+
+    @Inject
+    private GraphContextFactory factory;
+
+    @Test
+    public void test() throws IOException
+    {
+        try (GraphContext context = factory.create())
+        {
+            ProjectModel pm = context.getFramed().addVertex(null, ProjectModel.class);
+            pm.setName("Main Project");
+            FileModel inputPath = context.getFramed().addVertex(null, FileModel.class);
+            inputPath.setFilePath("src/test/resources/");
+
+            Path outputPath = Paths.get(FileUtils.getTempDirectory().toString(), "windup_"
+                        + UUID.randomUUID().toString());
+            FileUtils.deleteDirectory(outputPath.toFile());
+            Files.createDirectories(outputPath);
+
+            inputPath.setProjectModel(pm);
+            pm.setRootFileModel(inputPath);
+
+            WindupConfiguration windupConfiguration = new WindupConfiguration()
+                        .setRuleProviderFilter(new NotPredicate(
+                                    new RuleProviderPhasePredicate(MigrationRulesPhase.class, ReportGenerationPhase.class)
+                        ))
+                        .setGraphContext(context);
+            windupConfiguration.addInputPath(Paths.get(inputPath.getFilePath()));
+            windupConfiguration.setOutputDirectory(outputPath);
+            processor.execute(windupConfiguration);
+
+            GraphService<ClassificationModel> classificationService = new GraphService<>(context,
+                        ClassificationModel.class);
+            List<ClassificationModel> classifications = Iterators.asList(classificationService.findAll());
+            Assert.assertEquals(1, classifications.size());
+            Assert.assertEquals(LONG_XPATHS_WORK_FINE_CLASSIFICATION, classifications.get(0).getClassification());
+        }
+    }
+
+    @Singleton
+    public static class TestXMLNestedXmlFileRuleProvider extends AbstractRuleProvider
+    {
+        public TestXMLNestedXmlFileRuleProvider()
+        {
+            super(MetadataBuilder.forProvider(TestXMLNestedXmlFileRuleProvider.class).setPhase(PostMigrationRulesPhase.class));
+        }
+
+        // @formatter:off
+        @Override
+        public Configuration getConfiguration(GraphContext context)
+        {
+            return ConfigurationBuilder
+                        .begin()
+                        .addRule()
+                        .when(XmlFile.matchesXpath("//1:randomElement[contains(text(),'first')] | //2:randomElement[contains(text(),'first')] | //randomElement[contains(text(),'first')]").namespace("1","fake-namespace-1").namespace("2", "fake-namespace-2"))
+                        .perform(Classification.as(LONG_XPATHS_WORK_FINE_CLASSIFICATION));
+        }
+    }
+
+}


### PR DESCRIPTION
This may be a rather complicated issue.
In the xpath, we generate multiple startFrame(index...) methods that register Maps in the cache. However, if the xpath is long, not all of the startFrame() are executed that means not all of the numbers are registered.