### PR TITLE
    WINDUP-904 On the report index, the text inside the boxes does no…

### DIFF
--- a/rules-java/api/src/main/resources/reports/templates/report_index.ftl
+++ b/rules-java/api/src/main/resources/reports/templates/report_index.ftl
@@ -18,7 +18,7 @@
     <link rel='stylesheet' type='text/css' href='resources/libraries/flot/plot.css' />
     <style>
 .report-index-row {
-  margin-top: 10px;
+    margin: 10px -32px 0;
 }
     </style>
 </head>


### PR DESCRIPTION
…t line up perfectly with the page heading