### PR TITLE
Fix div close

### DIFF
--- a/rules-java/api/src/main/resources/reports/templates/report_index.ftl
+++ b/rules-java/api/src/main/resources/reports/templates/report_index.ftl
@@ -146,7 +146,7 @@
                     <div style="margin-bottom: 10px; margin-left: 190px;">
                         <b>Java Incidents by Package</b>
                     </div>
-                    <div id='application_pie' class='windupPieGraph'/>
+                    <div id='application_pie' class='windupPieGraph'></div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
HTML 5 != XHTML. Throws warnings in strict mode.