### PR TITLE
WINDUP-933  Create a test resources artifact containing the test jee-app

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,6 +91,7 @@
         <module>ui</module>
 
         <module>utils</module>
+        <module>test-files</module>
         <module>tests</module>
         <module>test-util</module>
         <module>bootstrap</module>

--- a/rules-tattletale/tests/pom.xml
+++ b/rules-tattletale/tests/pom.xml
@@ -8,7 +8,7 @@
         <version>2.5.0-SNAPSHOT</version>
     </parent>
     <artifactId>windup-rules-tattletale-tests</artifactId>
-    <name>Windup Rules - Tattletale</name>
+    <name>Windup Rules - Tattletale Tests</name>
 
     <dependencies>
         <!-- Addon Dependencies -->
@@ -58,7 +58,7 @@
                 <artifactId>windup-test-harness</artifactId>
                 <version>${project.version}</version>
 		<scope>test</scope>
-        </dependency>  
+        </dependency>
         <dependency>
             <groupId>org.jboss.windup.exec</groupId>
             <artifactId>windup-exec</artifactId>

--- a/test-files/pom.xml
+++ b/test-files/pom.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.jboss.windup</groupId>
+        <artifactId>windup-parent</artifactId>
+        <version>2.5.0-SNAPSHOT</version>
+    </parent>
+
+    <groupId>org.jboss.windup.tests</groupId>
+    <artifactId>windup-test-files</artifactId>
+
+    <name>Windup Engine - Test files</name>
+
+    <dependencies>
+
+        <!-- Local Dependencies -->
+
+        <!-- Addon Dependencies -->
+
+        <!-- Test Dependencies -->
+
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-jar</id>
+                        <phase>none</phase>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-artifacts</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>attach-artifact</goal>
+                        </goals>
+                        <configuration>
+                            <artifacts>
+                                <artifact>
+                                    <file>${basedir}/jee-example-app-1.0.0.ear</file>
+                                    <type>ear</type>
+                                    <classifier>jeeapp</classifier>
+                                </artifact>
+                            </artifacts>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <!--
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>2.6</version>
+                <executions>
+                    <execution>
+                        <id>create-jee-app-artifact</id>
+                        <goals>
+                            <goal>test-jar</goal>
+                        </goals>
+                        <configuration>
+                            <includes>
+                                <include>jee-example-app-1.0.0.ear</include>
+                            </includes>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            -->
+        </plugins>
+    </build>
+
+</project>

--- a/test-files/pom.xml
+++ b/test-files/pom.xml
@@ -56,26 +56,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <!--
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <version>2.6</version>
-                <executions>
-                    <execution>
-                        <id>create-jee-app-artifact</id>
-                        <goals>
-                            <goal>test-jar</goal>
-                        </goals>
-                        <configuration>
-                            <includes>
-                                <include>jee-example-app-1.0.0.ear</include>
-                            </includes>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            -->
         </plugins>
     </build>
 


### PR DESCRIPTION
This will serve for tests outside of the windup/windup repo (e.g. windup-maven-plugin).
Result:

--- maven-install-plugin:2.5.2:install (default-install) @ windup-test-files ---
No primary artifact to install, installing attached artifacts instead.
Installing /home/ondra/work/Migration/Windup/test-files/pom.xml to /home/ondra/.m2/repository/org/jboss/windup/tests/windup-test-files/2.5.0-SNAPSHOT/windup-test-files-2.5.0-SNAPSHOT.pom
Installing /home/ondra/work/Migration/Windup/test-files/jee-example-app-1.0.0.ear to /home/ondra/.m2/repository/org/jboss/windup/tests/windup-test-files/2.5.0-SNAPSHOT/windup-test-files-2.5.0-SNAPSHOT-jeeapp.ear