### PR TITLE
Push the XML parse error stacktrace to FINE level.

### DIFF
--- a/rules-xml/api/src/main/java/org/jboss/windup/rules/apps/xml/DiscoverXmlFilesRuleProvider.java
+++ b/rules-xml/api/src/main/java/org/jboss/windup/rules/apps/xml/DiscoverXmlFilesRuleProvider.java
@@ -135,7 +135,8 @@ public class DiscoverXmlFilesRuleProvider extends AbstractRuleProvider
             else
             {
                 final String message = "Failed to parse XML entity: " + file.getFilePath() + ", due to: " + e.getMessage();
-                LOG.log(Level.INFO, message, e);
+                LOG.log(Level.INFO, message);
+                LOG.log(Level.FINE, message, e);
                 file.setParseError(message);
             }
             new ClassificationService(event.getGraphContext())


### PR DESCRIPTION
It clutters the output too much.