### PR TITLE
    WINDUP-978 Convenience: ...Model m = GraphContext#create(Class<..Model> type);

### DIFF
--- a/graph/api/src/main/java/org/jboss/windup/graph/GraphContext.java
+++ b/graph/api/src/main/java/org/jboss/windup/graph/GraphContext.java
@@ -9,11 +9,14 @@ import org.jboss.windup.graph.frames.TypeAwareFramedGraphQuery;
 import com.thinkaurelius.titan.core.TitanGraph;
 import com.tinkerpop.blueprints.util.wrappers.event.EventGraph;
 import com.tinkerpop.frames.FramedGraph;
+import org.jboss.windup.graph.model.WindupVertexFrame;
+import org.jboss.windup.graph.service.GraphService;
 
 /**
  * Context for interacting with the underlying graph database API.
  * 
  * @author <a href="mailto:lincolnbaxter@gmail.com">Lincoln Baxter, III</a>
+ * @author <a href="mailto:zizka@seznam.cz">Ondrej Zizka, I</a>
  */
 public interface GraphContext extends Closeable
 {
@@ -68,4 +71,26 @@ public interface GraphContext extends Closeable
      * Returns the globally configured options as an immutable {@link Map}
      */
     Map<String, Object> getOptionMap();
+
+
+
+    /**
+     * Create a GraphService of given class.
+     */
+    public <T extends WindupVertexFrame> GraphService<T> service(Class<T> clazz);
+
+    /**
+     * Convenience delegation to new GraphService(this)
+     */
+    public <T extends WindupVertexFrame> T getUnique(Class<T> clazz);
+
+    /**
+     * Convenience delegation to new GraphService(this)
+     */
+    public <T extends WindupVertexFrame> Iterable<T> findAll(Class<T> clazz);
+
+    /**
+     * Convenience delegation to new GraphService(this)
+     */
+    public <T extends WindupVertexFrame> T create(Class<T> clazz);
 }

--- a/graph/impl/src/main/java/org/jboss/windup/graph/GraphContextImpl.java
+++ b/graph/impl/src/main/java/org/jboss/windup/graph/GraphContextImpl.java
@@ -45,6 +45,7 @@ import com.tinkerpop.frames.modules.FrameClassLoaderResolver;
 import com.tinkerpop.frames.modules.Module;
 import com.tinkerpop.frames.modules.gremlingroovy.GremlinGroovyModule;
 import com.tinkerpop.frames.modules.javahandler.JavaHandlerModule;
+import org.jboss.windup.graph.service.GraphService;
 
 public class GraphContextImpl implements GraphContext
 {
@@ -413,6 +414,33 @@ public class GraphContextImpl implements GraphContext
         {
             throw new RuntimeException("Failed writing Titan config to " + file.getAbsolutePath() + ": " + ex.getMessage(), ex);
         }
+    }
+
+
+    @Override
+    public <T extends WindupVertexFrame> GraphService<T> service(Class<T> clazz)
+    {
+        return new GraphService<>(this, clazz);
+    }
+
+    // --- Convenience delegations to new GraphService(this) --
+
+    @Override
+    public <T extends WindupVertexFrame> T getUnique(Class<T> clazz)
+    {
+        return service(clazz).getUnique();
+    }
+
+    @Override
+    public <T extends WindupVertexFrame> Iterable<T> findAll(Class<T> clazz)
+    {
+        return service(clazz).findAll();
+    }
+
+    @Override
+    public <T extends WindupVertexFrame> T create(Class<T> clazz)
+    {
+        return service(clazz).getUnique();
     }
 
 }


### PR DESCRIPTION
and few others. Reduces boilerplate a bit in the Java-based rules.