### PR TITLE
    WINDUP-987 Trim the text of titles, hints and classifications

### DIFF
--- a/reporting/api/src/main/java/org/jboss/windup/reporting/config/Hint.java
+++ b/reporting/api/src/main/java/org/jboss/windup/reporting/config/Hint.java
@@ -8,8 +8,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.jboss.forge.furnace.util.Assert;
 import org.jboss.windup.config.GraphRewrite;
 import org.jboss.windup.config.parameters.ParameterizedIterationOperation;
@@ -116,12 +115,12 @@ public class Hint extends ParameterizedIterationOperation<FileLocationModel> imp
             {
                 try
                 {
-                    hintModel.setTitle(hintTitlePattern.getBuilder().build(event, context));
+                    hintModel.setTitle(StringUtils.trim(hintTitlePattern.getBuilder().build(event, context)));
                 }
                 catch (Throwable t)
                 {
                     LOG.log(Level.WARNING, "Failed to generate parameterized Hint title due to: " + t.getMessage(), t);
-                    hintModel.setTitle(hintTitlePattern.toString());
+                    hintModel.setTitle(hintTitlePattern.toString().trim());
                 }
             }
             else
@@ -141,14 +140,14 @@ public class Hint extends ParameterizedIterationOperation<FileLocationModel> imp
                 LOG.log(Level.WARNING, "Failed to generate parameterized Hint body due to: " + t.getMessage(), t);
                 hintText = hintTextPattern.toString();
             }
-            hintModel.setHint(hintText);
+            hintModel.setHint(StringUtils.trim(hintText));
 
             GraphService<LinkModel> linkService = new GraphService<>(event.getGraphContext(), LinkModel.class);
             for (Link link : links)
             {
                 LinkModel linkModel = linkService.create();
-                linkModel.setDescription(link.getTitle());
-                linkModel.setLink(link.getLink());
+                linkModel.setDescription(StringUtils.trim(link.getTitle()));
+                linkModel.setLink(StringUtils.trim(link.getLink()));
                 hintModel.addLink(linkModel);
             }
 

--- a/reporting/api/src/main/java/org/jboss/windup/reporting/config/classification/Classification.java
+++ b/reporting/api/src/main/java/org/jboss/windup/reporting/config/classification/Classification.java
@@ -7,7 +7,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-
+import org.apache.commons.lang.StringUtils;
 import org.jboss.forge.furnace.util.Assert;
 import org.jboss.windup.config.GraphRewrite;
 import org.jboss.windup.config.operation.Iteration;
@@ -201,8 +201,8 @@ public class Classification extends ParameterizedIterationOperation<FileModel> i
                 classification = classificationService.create();
                 classification.setEffort(effort);
                 classification.setSeverity(severity);
-                classification.setDescription(description);
-                classification.setClassification(text);
+                classification.setDescription(StringUtils.trim(description));
+                classification.setClassification(StringUtils.trim(text));
 
                 Set<String> tags = new HashSet<>(this.getTags());
                 TagSetService tagSetService = new TagSetService(event.getGraphContext());
@@ -213,7 +213,9 @@ public class Classification extends ParameterizedIterationOperation<FileModel> i
                 LinkService linkService = new LinkService(graphContext);
                 for (Link link : links)
                 {
-                    LinkModel linkModel = linkService.getOrCreate(link.getTitle(), link.getLink());
+                    LinkModel linkModel = linkService.getOrCreate(
+                            StringUtils.trim(link.getTitle()),
+                            StringUtils.trim(link.getLink()));
                     classification.addLink(linkModel);
                 }
             }

--- a/reporting/api/src/main/java/org/jboss/windup/reporting/model/ClassificationModel.java
+++ b/reporting/api/src/main/java/org/jboss/windup/reporting/model/ClassificationModel.java
@@ -1,20 +1,17 @@
 package org.jboss.windup.reporting.model;
 
-import java.util.Set;
-
+import com.tinkerpop.blueprints.Direction;
 import com.tinkerpop.blueprints.Vertex;
+import com.tinkerpop.frames.Adjacency;
+import com.tinkerpop.frames.Property;
 import com.tinkerpop.frames.modules.javahandler.JavaHandler;
 import com.tinkerpop.frames.modules.javahandler.JavaHandlerContext;
+import com.tinkerpop.frames.modules.typedgraph.TypeValue;
 import org.jboss.windup.graph.Indexed;
 import org.jboss.windup.graph.model.resource.FileModel;
 import org.jboss.windup.reporting.model.association.LinkableModel;
 import org.jboss.windup.rules.files.condition.ToFileModelTransformable;
 import org.ocpsoft.rewrite.config.Rule;
-
-import com.tinkerpop.blueprints.Direction;
-import com.tinkerpop.frames.Adjacency;
-import com.tinkerpop.frames.Property;
-import com.tinkerpop.frames.modules.typedgraph.TypeValue;
 
 /**
  * This classifies files and provides general background information about a specific {@link FileModel}. (For instance,
@@ -61,7 +58,7 @@ public interface ClassificationModel extends EffortReportModel, LinkableModel, T
      * Set the description text of this {@link ClassificationModel}.
      */
     @Property(DESCRIPTION)
-    void setDescription(String ruleID);
+    void setDescription(String description);
 
     /**
      * Get the description text of this {@link ClassificationModel}.


### PR DESCRIPTION
This may sound trivial, but it will reduce the size of the reports .html and .js by few megabytes.
The values need to be trimmed right when created, not in the reports, because somewhere they are printed through things like ObjectWrapper.