### PR TITLE
Extract generic Lucene querying code into LuceneIndexServiceBase.

### DIFF
--- a/rules-java-archives/addon/src/main/java/org/jboss/windup/rules/apps/java/archives/identify/LuceneArchiveIdentificationService.java
+++ b/rules-java-archives/addon/src/main/java/org/jboss/windup/rules/apps/java/archives/identify/LuceneArchiveIdentificationService.java
@@ -1,24 +1,17 @@
 package org.jboss.windup.rules.apps.java.archives.identify;
 
-import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
 import java.util.logging.Logger;
 
 import org.apache.lucene.document.Document;
-import org.apache.lucene.index.DirectoryReader;
-import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.Term;
-import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.search.TopDocs;
-import org.apache.lucene.store.Directory;
-import org.apache.lucene.store.SimpleFSDirectory;
 import org.jboss.forge.addon.dependencies.Coordinate;
 import org.jboss.forge.addon.dependencies.builder.CoordinateBuilder;
-import org.jboss.forge.furnace.util.Assert;
 import org.jboss.windup.util.Logging;
 import org.jboss.windup.util.exception.WindupException;
 
@@ -26,8 +19,11 @@ import org.jboss.windup.util.exception.WindupException;
  * Identifies archives by their hash, using pre-created Lucene index. See the nexus-repository-indexer project.
  *
  * @author <a href="mailto:jesse.sightler@gmail.com">Jesse Sightler</a>
+ * @author <a href="http://ondra.zizka.cz/">Ondrej Zizka, zizka@seznam.cz</a>
+ *
+ * TODO: This should be in Nexus Indexer - Data (client for Nexus Indexer - Core).
  */
-public class LuceneArchiveIdentificationService implements ArchiveIdentificationService, Closeable
+public class LuceneArchiveIdentificationService extends LuceneIndexServiceBase implements ArchiveIdentificationService
 {
     private static final Logger LOG = Logging.get(LuceneArchiveIdentificationService.class);
 
@@ -38,47 +34,17 @@ public class LuceneArchiveIdentificationService implements ArchiveIdentification
     private static final String CLASSIFIER = "classifier";
     private static final String VERSION = "version";
 
-    private File directory;
-    private Directory index;
-    private IndexReader reader;
-    private IndexSearcher searcher;
 
     public LuceneArchiveIdentificationService(File directory)
     {
-        Assert.isTrue(directory.exists(), "Hash to Lucene index directory does not exist: " + directory.toString());
-
-        this.directory = directory;
-        try
-        {
-            initialize();
-        }
-        catch (IOException e)
-        {
-            throw new WindupException("Failed to load Lucene index due to: " + e.getMessage(), e);
-        }
+        super(directory);
     }
 
-    private void initialize() throws IOException
-    {
-        this.index = new SimpleFSDirectory(this.directory);
-        this.reader = DirectoryReader.open(index);
-        this.searcher = new IndexSearcher(reader);
-    }
-
-    public void close() {
-        try {
-            this.reader.close();
-            this.index.close();
-        } catch (Exception e) {
-            LOG.warning("Failed to close lucene index at: " + this.directory + " due to: " + e.getMessage());
-        }
-    }
 
     @Override
     public Coordinate getCoordinate(String checksum)
     {
-
-        Query query = new TermQuery(new Term("sha1", checksum));
+        Query query = new TermQuery(new Term(SHA1, checksum));
         try
         {
             TopDocs results = searcher.search(query, 100);
@@ -91,15 +57,16 @@ public class LuceneArchiveIdentificationService implements ArchiveIdentification
                 String classifier = doc.get(CLASSIFIER);
                 String packaging = doc.get(PACKAGING);
 
-                Coordinate coordinate = CoordinateBuilder.create().setGroupId(groupId).setArtifactId(artifactId).setVersion(version)
-                            .setClassifier(classifier).setPackaging(packaging);
+                Coordinate coordinate = CoordinateBuilder.create()
+                    .setGroupId(groupId).setArtifactId(artifactId).setVersion(version)
+                    .setClassifier(classifier).setPackaging(packaging);
                 return coordinate;
             }
             return null;
         }
         catch (IOException e)
         {
-            throw new WindupException("Failed to find checksum: " + checksum + " due to: " + e.getMessage(), e);
+            throw new WindupException("Failed to find Maven coords for SHA1: " + checksum + " due to: " + e.getMessage(), e);
         }
     }
 }

--- a/rules-java-archives/addon/src/main/java/org/jboss/windup/rules/apps/java/archives/identify/LuceneIndexServiceBase.java
+++ b/rules-java-archives/addon/src/main/java/org/jboss/windup/rules/apps/java/archives/identify/LuceneIndexServiceBase.java
@@ -1,0 +1,79 @@
+package org.jboss.windup.rules.apps.java.archives.identify;
+
+import java.io.Closeable;
+import java.io.File;
+import java.io.IOException;
+import java.util.logging.Logger;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.SimpleFSDirectory;
+import org.jboss.windup.util.Checks;
+import org.jboss.windup.util.Logging;
+import org.jboss.windup.util.exception.WindupException;
+
+/**
+ *
+ *  @author <a href="http://ondra.zizka.cz/">Ondrej Zizka, zizka@seznam.cz</a>
+ */
+public abstract class LuceneIndexServiceBase implements Closeable
+{
+    private static final Logger LOG = Logging.get(LuceneIndexServiceBase.class);
+
+    protected File directory;
+    protected Directory index;
+    protected IndexReader reader;
+    protected IndexSearcher searcher;
+
+
+    public LuceneIndexServiceBase(File directory)
+    {
+        Checks.checkDirectoryToBeRead(directory, "Lucene index directory");
+
+        this.directory = directory;
+        try
+        {
+            initialize();
+        }
+        catch (IOException e)
+        {
+            throw new WindupException("Failed to load Lucene index due to: " + e.getMessage(), e);
+        }
+    }
+
+
+    private void initialize() throws IOException
+    {
+        this.index = new SimpleFSDirectory(this.directory);
+        this.reader = DirectoryReader.open(index);
+        this.searcher = new IndexSearcher(reader);
+    }
+
+
+    @Override
+    public final void close()
+    {
+        try
+        {
+            this.reader.close();
+            this.index.close();
+        }
+        catch (Exception e)
+        {
+            LOG.warning("Failed to close lucene index at: " + this.directory + " due to: " + e.getMessage());
+        }
+    }
+
+
+    public final IndexSearcher getSearcher()
+    {
+        return searcher;
+    }
+
+    public final File getDirectory()
+    {
+        return directory;
+    }
+
+}


### PR DESCRIPTION
The plan is to move that to nexus-indexer-data, see https://github.com/windup/nexus-repository-indexer/pull/5