### PR TITLE
MIGRFEED-17 fix link to JMS configuration

### DIFF
--- a/rules-java-ee/addon/src/main/java/org/jboss/windup/rules/apps/javaee/rules/ResolveServerResourceLinksRuleProvider.java
+++ b/rules-java-ee/addon/src/main/java/org/jboss/windup/rules/apps/javaee/rules/ResolveServerResourceLinksRuleProvider.java
@@ -89,7 +89,7 @@ public class ResolveServerResourceLinksRuleProvider extends AbstractRuleProvider
         LinkModel jmsDestinationLink = linkService
                     .getOrCreate(
                                 "Destination Setup",
-                                "https://access.redhat.com/documentation/en-US/JBoss_Enterprise_Application_Platform/6.4/html/Administration_and_Configuration_Guide/sect-Configuration.html");
+                                "https://access.redhat.com/documentation/en-US/JBoss_Enterprise_Application_Platform/6.4/html/Administration_and_Configuration_Guide/sect-Configuration1.html");
         linkable.addLink(jmsDestinationLink);
     }
 


### PR DESCRIPTION
AFAICT link originally pointed to 18.8. Configuration (for Messaging) -- at some point 23.2 Configuration (for Hibernate Search) was added, and whatever generates the documentation html effectively changed sect-Configuration.html from pointing at 18.8 to pointing at 23.2. (Not a friendly behavior...)