### PR TITLE
WINDUP-1049  Running with JDK 7 fails due nexus-index built and deplo…

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -5,7 +5,7 @@
     <properties>
         <version.forge>2.20.2.Final</version.forge>
         <version.furnace>2.22.10.Final</version.furnace>
-        <version.nexus.index>5</version.nexus.index>
+        <version.nexus.index>6.1</version.nexus.index>
     </properties>
 
     <!-- Does NOT use windup-parent - this is a BOM. -->
@@ -253,6 +253,12 @@
                 <version>${project.version}</version>
             </dependency>
             <!-- Windup Rules - Java - Archives - Data bundle. -->
+            <dependency>
+                <groupId>org.jboss.windup.maven</groupId>
+                <artifactId>nexus-indexer-data</artifactId>
+                <type>jar</type>
+                <version>${version.nexus.index}</version>
+            </dependency>
             <dependency>
                 <groupId>org.jboss.windup.maven</groupId>
                 <artifactId>nexus-indexer-data</artifactId>

--- a/rules-java-archives/addon/pom.xml
+++ b/rules-java-archives/addon/pom.xml
@@ -17,7 +17,6 @@
         <dependency>
             <groupId>org.jboss.windup.maven</groupId>
             <artifactId>nexus-indexer-data</artifactId>
-            <version>6.0</version>
             <scope>compile</scope>
             <optional>true</optional>
             <exclusions>

--- a/rules-java/api/pom.xml
+++ b/rules-java/api/pom.xml
@@ -39,7 +39,6 @@
         <dependency>
             <groupId>org.jboss.windup.maven</groupId>
             <artifactId>nexus-indexer-data</artifactId>
-            <version>6.0</version>
             <scope>compile</scope>
             <optional>true</optional>
         </dependency>


### PR DESCRIPTION
This upgrades nexus-indexer-data 6.1.

I have released nexus-indexer 6.1. Waiting for it to appear in the repositories.
http://repository.jboss.org/nexus/content/groups/public/org/jboss/windup/maven/nexus-indexer-data/
http://search.maven.org/#search|gav|1|g%3A%22org.jboss.windup.maven%22%20AND%20a%3A%22nexus-indexer-data%22