### PR TITLE
WINDUP-1083: Remove dead doc link in Ignored Files report

### DIFF
--- a/rules-java/api/src/main/java/org/jboss/windup/rules/apps/java/reporting/rules/CreateJavaIgnoredFilesReportRuleProvider.java
+++ b/rules-java/api/src/main/java/org/jboss/windup/rules/apps/java/reporting/rules/CreateJavaIgnoredFilesReportRuleProvider.java
@@ -38,9 +38,7 @@ public class CreateJavaIgnoredFilesReportRuleProvider extends AbstractRuleProvid
     public static final String DESCRIPTION = "This report lists the files which were found in the application,\n" +
             "                    but based on certain rules and the Windup configuration, both built-in and local,\n" +
             "                    they were not processed.\n" +
-            "                    See the <code>--userIgnorePath</code> Windup option in\n" +
-            "                    <a href=\"http://windup.github.io/windup/docs/latest/html/WindupUserGuide.html#command-line-arguments\"\n" +
-            "                       >Windup User Guide</a>.";
+            "                    See the <code>--userIgnorePath</code> Windup option in the Windup User Guide.";
 
     // @formatter:off
     @Override


### PR DESCRIPTION
Removing the link entirely here rather than pointing it to somewhere else. Doesn't seem like our GH wiki is a stable enough place to point links at, and probably not worth the maintenance burden of keeping links from Windup output to RH Windup documentation in-sync unless we're going to do it in enough places to get significant value out of it.