### PR TITLE
App list design3 feedback2

### DIFF
--- a/reporting/api/src/main/java/org/jboss/windup/reporting/rules/CreateApplicationListReportRuleProvider.java
+++ b/reporting/api/src/main/java/org/jboss/windup/reporting/rules/CreateApplicationListReportRuleProvider.java
@@ -78,7 +78,7 @@ public class CreateApplicationListReportRuleProvider extends AbstractRuleProvide
             {
                 applications.addItem(applicationReportModel);
                 if (ProjectService.SHARED_LIBS_UNIQUE_ID.equals(applicationReportModel.getProjectModel().getUniqueID()))
-                    relatedData.put("sharedLibsExists", applicationReportModel); // Instead of a boolean.
+                    relatedData.put("sharedLibsApplicationReport", applicationReportModel); // Used as kind of boolean in the template.
             }
         }
         relatedData.put("applications", applications);

--- a/reporting/api/src/main/java/org/jboss/windup/reporting/rules/CreateApplicationListReportRuleProvider.java
+++ b/reporting/api/src/main/java/org/jboss/windup/reporting/rules/CreateApplicationListReportRuleProvider.java
@@ -14,6 +14,7 @@ import org.jboss.windup.config.phase.PostReportGenerationPhase;
 import org.jboss.windup.graph.GraphContext;
 import org.jboss.windup.graph.model.WindupVertexFrame;
 import org.jboss.windup.graph.service.GraphService;
+import org.jboss.windup.graph.service.ProjectService;
 import org.jboss.windup.reporting.model.ApplicationReportModel;
 import org.jboss.windup.reporting.model.TemplateType;
 import org.jboss.windup.reporting.model.WindupVertexListModel;
@@ -70,12 +71,16 @@ public class CreateApplicationListReportRuleProvider extends AbstractRuleProvide
 
         GraphService<WindupVertexListModel> listService = new GraphService<>(context, WindupVertexListModel.class);
         WindupVertexListModel<ApplicationReportModel> applications = listService.create();
+        Map<String, WindupVertexFrame> relatedData = new HashMap<>();
         for (ApplicationReportModel applicationReportModel : applicationReportService.findAll())
         {
             if (applicationReportModel.isMainApplicationReport() != null && applicationReportModel.isMainApplicationReport())
+            {
                 applications.addItem(applicationReportModel);
+                if (ProjectService.SHARED_LIBS_UNIQUE_ID.equals(applicationReportModel.getProjectModel().getUniqueID()))
+                    relatedData.put("sharedLibsExists", applicationReportModel); // Instead of a boolean.
+            }
         }
-        Map<String, WindupVertexFrame> relatedData = new HashMap<>();
         relatedData.put("applications", applications);
 
         report.setRelatedResource(relatedData);

--- a/reporting/impl/src/main/resources/reports/templates/application_list.ftl
+++ b/reporting/impl/src/main/resources/reports/templates/application_list.ftl
@@ -46,6 +46,9 @@
             </div>
             <div class="incidentsCount">
                 <table>
+                    <tr>
+                        <td colspan="2">Number of incidents</td>
+                    </tr>
                     <#assign totalIncidents = 0 >
                     <#list incidentCountBySeverity?keys as severity>
                         <#assign totalIncidents = totalIncidents + incidentCountBySeverity?api.get(severity) >
@@ -111,7 +114,7 @@
         body.viewAppList .apps .appInfo .stats .incidentsCount { float: left; margin:  0 2ex;}
         body.viewAppList .apps .appInfo .stats .incidentsCount table tr.total td { border-top: 1px solid silver; }
         body.viewAppList .apps .appInfo .stats .incidentsCount .count { text-align: right; padding-right: 1ex; }
-        body.viewAppList .apps .appInfo .traits { margin-left: px; }
+        body.viewAppList .apps .appInfo .traits { margin-left: 0px; }
         body.viewAppList .apps .appInfo .traits .fileName { padding: 0.0ex 0em 0.2ex; font-size: 18pt; /* color: #008cba; (Default BS link color) */ }
         body.viewAppList .apps .appInfo .traits .techs { }
 

--- a/reporting/impl/src/main/resources/reports/templates/application_list.ftl
+++ b/reporting/impl/src/main/resources/reports/templates/application_list.ftl
@@ -169,21 +169,17 @@
 
         <!-- Apps -->
         <section class="apps">
+            <#assign virtualAppExists = false>
             <div class="real">
                 <#list reportModel.relatedResources.applications.list.iterator() as applicationReport>
                     <#if applicationReport.projectModel.projectType! != "VIRTUAL" >
                         <@applicationReportRenderer applicationReport/>
+                    <#else>
+                        <#assign virtualAppExists = true>
                     </#if>
                 </#list>
             </div>
-
-            <#assign virtualAppExists = false>
-            <#list reportModel.relatedResources.applications.list.iterator() as applicationReport>
-                <#if applicationReport.projectModel.projectType! = "VIRTUAL">
-                    <#assign virtualAppExists = true>
-                </#if>
-            </#list>
-        <section>
+        </section>
 
         <#if virtualAppExists>
         <div class="row">

--- a/reporting/impl/src/main/resources/reports/templates/application_list.ftl
+++ b/reporting/impl/src/main/resources/reports/templates/application_list.ftl
@@ -117,9 +117,13 @@
         body.viewAppList .apps .appInfo .stats .effortPoints        .points { line-height: 1; color: #294593; }
         body.viewAppList .apps .appInfo .stats .effortPoints        .legend { font-size: 7pt; }
         body.viewAppList .apps .appInfo .stats .effortPoints.shared,
-        body.viewAppList .apps .appInfo .stats .effortPoints.unique { width: 100px; font-size: 24pt; margin-top: 13px; }
+        body.viewAppList .apps .appInfo .stats .effortPoints.unique { width: 90px; font-size: 18pt; margin-top: 23px; }
+        /* Hide the "cell" if the app has 0 shared points". */
         body.viewAppList .apps .appInfo.pointsShared0 .stats .effortPoints.shared,
         body.viewAppList .apps .appInfo.pointsShared0 .stats .effortPoints.unique { display: hidden; }
+        /* Hide the whole "column" if there's no virtual app (i.e. no shared-libs app). */
+        body.viewAppList.noVirtualApp .apps .appInfo  .stats .effortPoints.shared,
+        body.viewAppList.noVirtualApp .apps .appInfo  .stats .effortPoints.unique { display: none; }
         body.viewAppList .apps .appInfo .stats .effortPoints.shared .points,
         body.viewAppList .apps .appInfo .stats .effortPoints.unique .points { color: #8491a8; /* Like normal, but grayed. */ }
 
@@ -213,7 +217,9 @@
                     </#if>
                 </#list>
             </div>
-        <section>
+        </section>
+        <#else>
+            <script>$("body").addClass("noVirtualApp");</script>
         </#if>
 
 

--- a/reporting/impl/src/main/resources/reports/templates/application_list.ftl
+++ b/reporting/impl/src/main/resources/reports/templates/application_list.ftl
@@ -32,9 +32,9 @@
     <#assign pointsFromSharedTraversal = getMigrationEffortPointsForProject(sharedTraversal, true) >
 
     <#-- Total Effort Points, Name, Technologies, Incident Count per Severity-->
-    <div class="appInfo">
+    <div class="appInfo pointsShared${pointsFromSharedTraversal}">
         <div class="stats">
-            <div class="effortPoints unique">
+            <div class="effortPoints total">
                 <span class="points">${pointsFromAllTraversal}</span>
                 <span class="legend">story points</span>
             </div>
@@ -42,6 +42,12 @@
                 <#if appReport.projectModel.projectType! != "VIRTUAL">
                     <span class="points">${pointsFromSharedTraversal}</span>
                     <span class="legend">in shared libs <#--<br/>once: ${pointsFromOnceTraversal}--></span>
+                </#if>
+            </div>
+            <div class="effortPoints unique">
+                <#if appReport.projectModel.projectType! != "VIRTUAL">
+                    <span class="points">${pointsFromAllTraversal - pointsFromSharedTraversal}</span>
+                    <span class="legend">only in this app</span>
                 </#if>
             </div>
             <div class="incidentsCount">
@@ -105,15 +111,21 @@
             margin: 1ex 0;
             padding: 1ex 0 2ex;
         }
-        body.viewAppList .apps .appInfo .stats { float: right; width: 496px; padding: 0.4ex 0; }
+        body.viewAppList .apps .appInfo .stats { float: right; width: 610px; padding: 0.4ex 0; }
         body.viewAppList .apps .appInfo .stats .effortPoints { float: left; width: 160px; padding: 0.3ex 0.2em 0; font-size: 33pt; }
         body.viewAppList .apps .appInfo .stats .effortPoints        span { display: block; margin: auto; text-align: center; }
-        body.viewAppList .apps .appInfo .stats .effortPoints        .points { line-height: 1; color: rgb(41, 69, 147); }
+        body.viewAppList .apps .appInfo .stats .effortPoints        .points { line-height: 1; color: #294593; }
         body.viewAppList .apps .appInfo .stats .effortPoints        .legend { font-size: 7pt; }
-        body.viewAppList .apps .appInfo .stats .effortPoints.shared .points { color: #8491a8; /* Like normal, but grayed. */ }
+        body.viewAppList .apps .appInfo .stats .effortPoints.shared,
+        body.viewAppList .apps .appInfo .stats .effortPoints.unique { width: 100px; font-size: 24pt; margin-top: 13px; }
+        body.viewAppList .apps .appInfo.pointsShared0 .stats .effortPoints.shared,
+        body.viewAppList .apps .appInfo.pointsShared0 .stats .effortPoints.unique { display: hidden; }
+        body.viewAppList .apps .appInfo .stats .effortPoints.shared .points,
+        body.viewAppList .apps .appInfo .stats .effortPoints.unique .points { color: #8491a8; /* Like normal, but grayed. */ }
+
         body.viewAppList .apps .appInfo .stats .incidentsCount { float: left; margin:  0 2ex;}
         body.viewAppList .apps .appInfo .stats .incidentsCount table tr.total td { border-top: 1px solid silver; }
-        body.viewAppList .apps .appInfo .stats .incidentsCount .count { text-align: right; padding-right: 1ex; min-width: 6ex; }
+        body.viewAppList .apps .appInfo .stats .incidentsCount .count { text-align: right; padding-right: 1ex; min-width: 7.4ex; }
         body.viewAppList .apps .appInfo .traits { margin-left: 0px; }
         body.viewAppList .apps .appInfo .traits .fileName { padding: 0.0ex 0em 0.2ex; font-size: 18pt; /* color: #008cba; (Default BS link color) */ }
         body.viewAppList .apps .appInfo .traits .techs { }
@@ -123,7 +135,7 @@
 
     </style>
 </head>
-<body role="document" class="viewAppList">
+<body role="document" class="viewAppList" style="max-width: 1480px; margin: auto;">
 
     <!-- Navbar -->
     <div id="main-navbar" class="navbar navbar-default navbar-fixed-top">

--- a/reporting/impl/src/main/resources/reports/templates/application_list.ftl
+++ b/reporting/impl/src/main/resources/reports/templates/application_list.ftl
@@ -113,7 +113,7 @@
         body.viewAppList .apps .appInfo .stats .effortPoints.shared .points { color: #8491a8; /* Like normal, but grayed. */ }
         body.viewAppList .apps .appInfo .stats .incidentsCount { float: left; margin:  0 2ex;}
         body.viewAppList .apps .appInfo .stats .incidentsCount table tr.total td { border-top: 1px solid silver; }
-        body.viewAppList .apps .appInfo .stats .incidentsCount .count { text-align: right; padding-right: 1ex; }
+        body.viewAppList .apps .appInfo .stats .incidentsCount .count { text-align: right; padding-right: 1ex; min-width: 6ex; }
         body.viewAppList .apps .appInfo .traits { margin-left: 0px; }
         body.viewAppList .apps .appInfo .traits .fileName { padding: 0.0ex 0em 0.2ex; font-size: 18pt; /* color: #008cba; (Default BS link color) */ }
         body.viewAppList .apps .appInfo .traits .techs { }

--- a/reporting/impl/src/main/resources/reports/templates/application_list.ftl
+++ b/reporting/impl/src/main/resources/reports/templates/application_list.ftl
@@ -190,7 +190,7 @@
 
         <!-- Apps -->
 
-        <#assign sharedLibsExists = reportModel.relatedResources["sharedLibsExists"]!?has_content >
+        <#assign sharedLibsExists = reportModel.relatedResources["sharedLibsApplicationReport"]!?has_content >
 
         <section class="apps">
             <#assign virtualAppExists = false>

--- a/reporting/impl/src/main/resources/reports/templates/application_list.ftl
+++ b/reporting/impl/src/main/resources/reports/templates/application_list.ftl
@@ -50,13 +50,13 @@
                     <#list incidentCountBySeverity?keys as severity>
                         <#assign totalIncidents = totalIncidents + incidentCountBySeverity?api.get(severity) >
                         <tr>
-                            <td class="label_"> ${severity} </td>
-                            <td class="count"> ${incidentCountBySeverity?api.get(severity)}&times; </td>
+                            <td class="count">${incidentCountBySeverity?api.get(severity)}</td>
+                            <td class="label_">${severity}</td>
                         </tr>
                     </#list>
                     <tr class="total">
+                        <td class="count"> <span>${totalIncidents}</span> </td>
                         <td class="label_"> <span>Total</span> </td>
-                        <td class="count"> <span>${totalIncidents}&times;</span> </td>
                     </tr>
                 </table>
             </div>
@@ -110,7 +110,7 @@
         body.viewAppList .apps .appInfo .stats .effortPoints.shared .points { color: #8491a8; /* Like normal, but grayed. */ }
         body.viewAppList .apps .appInfo .stats .incidentsCount { float: left; margin:  0 2ex;}
         body.viewAppList .apps .appInfo .stats .incidentsCount table tr.total td { border-top: 1px solid silver; }
-        body.viewAppList .apps .appInfo .stats .incidentsCount .count { text-align: right; padding-left: 10px; }
+        body.viewAppList .apps .appInfo .stats .incidentsCount .count { text-align: right; padding-right: 1ex; }
         body.viewAppList .apps .appInfo .traits { margin-left: px; }
         body.viewAppList .apps .appInfo .traits .fileName { padding: 0.0ex 0em 0.2ex; font-size: 18pt; /* color: #008cba; (Default BS link color) */ }
         body.viewAppList .apps .appInfo .traits .techs { }

--- a/reporting/impl/src/main/resources/reports/templates/application_list.ftl
+++ b/reporting/impl/src/main/resources/reports/templates/application_list.ftl
@@ -102,7 +102,7 @@
             margin: 1ex 0;
             padding: 1ex 0 2ex;
         }
-        body.viewAppList .apps .appInfo .stats { float: left; width: 496px; padding: 0.4ex 0; }
+        body.viewAppList .apps .appInfo .stats { float: right; width: 496px; padding: 0.4ex 0; }
         body.viewAppList .apps .appInfo .stats .effortPoints { float: left; width: 160px; padding: 0.3ex 0.2em 0; font-size: 33pt; }
         body.viewAppList .apps .appInfo .stats .effortPoints        span { display: block; margin: auto; text-align: center; }
         body.viewAppList .apps .appInfo .stats .effortPoints        .points { line-height: 1; color: rgb(41, 69, 147); }
@@ -111,7 +111,7 @@
         body.viewAppList .apps .appInfo .stats .incidentsCount { float: left; margin:  0 2ex;}
         body.viewAppList .apps .appInfo .stats .incidentsCount table tr.total td { border-top: 1px solid silver; }
         body.viewAppList .apps .appInfo .stats .incidentsCount .count { text-align: right; padding-left: 10px; }
-        body.viewAppList .apps .appInfo .traits { margin-left: 340px; }
+        body.viewAppList .apps .appInfo .traits { margin-left: px; }
         body.viewAppList .apps .appInfo .traits .fileName { padding: 0.0ex 0em 0.2ex; font-size: 18pt; /* color: #008cba; (Default BS link color) */ }
         body.viewAppList .apps .appInfo .traits .techs { }
 

--- a/reporting/impl/src/main/resources/reports/templates/application_list.ftl
+++ b/reporting/impl/src/main/resources/reports/templates/application_list.ftl
@@ -28,8 +28,14 @@
     <#--assign onceTraversal  = getProjectTraversal(appReport.projectModel, 'only_once')>
     <#assign pointsFromOnceTraversal = getMigrationEffortPointsForProject(onceTraversal, true) -->
 
-    <#assign sharedTraversal = getProjectTraversal(appReport.projectModel, 'shared')>
-    <#assign pointsFromSharedTraversal = getMigrationEffortPointsForProject(sharedTraversal, true) >
+    <#-- For VIRTUAL apps, or if there is no VIRTUAL app, skip computing of the shared points. -->
+    <#assign showSharedPoints = appReport.projectModel.projectType! != "VIRTUAL" && sharedLibsExists>
+    <#if showSharedPoints>
+        <#assign sharedTraversal = getProjectTraversal(appReport.projectModel, 'shared')>
+        <#assign pointsFromSharedTraversal = getMigrationEffortPointsForProject(sharedTraversal, true) >
+    <#else>
+        <#assign pointsFromSharedTraversal = 0 >
+    </#if>
 
     <#-- Total Effort Points, Name, Technologies, Incident Count per Severity-->
     <div class="appInfo pointsShared${pointsFromSharedTraversal}">
@@ -38,18 +44,17 @@
                 <span class="points">${pointsFromAllTraversal}</span>
                 <span class="legend">story points</span>
             </div>
-            <div class="effortPoints shared">
-                <#if appReport.projectModel.projectType! != "VIRTUAL">
+            <#-- If there is no Shared Libraries virtual app, don't show the "column". -->
+            <#if sharedLibsExists>
+                <div class="effortPoints shared">
                     <span class="points">${pointsFromSharedTraversal}</span>
-                    <span class="legend">in shared libs <#--<br/>once: ${pointsFromOnceTraversal}--></span>
-                </#if>
-            </div>
-            <div class="effortPoints unique">
-                <#if appReport.projectModel.projectType! != "VIRTUAL">
+                    <span class="legend">in shared libs</span>
+                </div>
+                <div class="effortPoints unique">
                     <span class="points">${pointsFromAllTraversal - pointsFromSharedTraversal}</span>
                     <span class="legend">only in this app</span>
-                </#if>
-            </div>
+                </div>
+            </#if>
             <div class="incidentsCount">
                 <table>
                     <tr>
@@ -184,6 +189,9 @@
 
 
         <!-- Apps -->
+
+        <#assign sharedLibsExists = reportModel.relatedResources["sharedLibsExists"]!?has_content >
+
         <section class="apps">
             <#assign virtualAppExists = false>
             <div class="real">


### PR DESCRIPTION
(I see no ID to refer to)
https://docs.google.com/document/d/1nnsmOu8INH_jxcyAYyry1TTtf47AMYE8BR9OjrGi3jI/edit?ts=575842d0

This is based on the #5 version from the other app list design PR #975 (== has shared commits)

2.6 App list tweaks based on discussion on 20160616:
Start with the latest version without the bubble (version #5 of the 6 Ondra shared)
Shared libs story point number feels a little too prominent
We need to communicate this number but it doesn't need to be so huge
Possible options:
 ✔ Replace the large shared-libs number with two smaller shared + unique numbers
Remove the extra column, and display the shared+unique numbers directly underneath the total story points number (possibly using the stacked-progress-bar style of visualization we talked about)
 ✔ There is quite a lot of horizontal whitespace if you are full-size on a large screen -- maybe the width of the row could be capped (say at ~1200px wide? or whatever looks good) (~1470 still looks good IMO)
 ✔ Incident count table: alignment is still a little bit different between app list rows if the largest number of digits is different (more obvious if you put in a 6 digit number) 
Minor issue, it looks perfect up to 4 digits
