### PR TITLE
WINDUP-1200: rolled back excluded rewrite dependency in bootstrap

### DIFF
--- a/bootstrap/pom.xml
+++ b/bootstrap/pom.xml
@@ -19,23 +19,14 @@
         <dependency>
             <groupId>org.jboss.windup.config</groupId>
             <artifactId>windup-config-api</artifactId>
-            <scope>compile</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.ocpsoft.rewrite</groupId>
-                    <artifactId>rewrite-api</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.jboss.windup.exec</groupId>
             <artifactId>windup-exec-api</artifactId>
-            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.windup.graph</groupId>
             <artifactId>windup-graph-api</artifactId>
-            <scope>compile</scope>
             <exclusions>
                 <exclusion>
                     <groupId>com.tinkerpop.gremlin</groupId>
@@ -54,7 +45,6 @@
         <dependency>
             <groupId>org.jboss.windup.rules.apps</groupId>
             <artifactId>windup-rules-java-api</artifactId>
-            <scope>compile</scope>
             <exclusions>
                 <exclusion>
                     <groupId>org.jboss.forge.roaster</groupId>
@@ -86,7 +76,6 @@
             <groupId>org.jboss.windup.utils</groupId>
             <artifactId>windup-utils</artifactId>
             <classifier>forge-addon</classifier>
-            <scope>compile</scope>
             <exclusions>
                 <exclusion>
                     <groupId>commons-io</groupId>


### PR DESCRIPTION
https://issues.jboss.org/browse/WINDUP-1200
and cleaned a bit compile scopes which are by default COMPILE so not required to be specified there.