### PR TITLE
T379 Make it possible to stop running Windup core execution

### DIFF
--- a/config/api/src/main/java/org/jboss/windup/config/AbstractRuleLifecycleListener.java
+++ b/config/api/src/main/java/org/jboss/windup/config/AbstractRuleLifecycleListener.java
@@ -6,26 +6,29 @@ import org.ocpsoft.rewrite.context.EvaluationContext;
 /**
  * This provides a set of default (empty) methods that make it easy to implement {@link RuleLifecycleListener}s that only need to override a subset of
  * the available methods.
- * 
- * @author <a href="mailto:jesse.sightler@gmail.com">Jesse Sightler</a>
  *
+ * @author <a href="mailto:jesse.sightler@gmail.com">Jesse Sightler</a>
+ * @author <a href="mailto:zizka@seznam.cz">Ondrej Zizka</a>
  */
 public abstract class AbstractRuleLifecycleListener implements RuleLifecycleListener
 {
-
     @Override
     public void beforeExecution(GraphRewrite event)
     {
     }
 
     @Override
-    public void beforeRuleEvaluation(GraphRewrite event, Rule rule, EvaluationContext context)
+    public boolean beforeRuleEvaluation(GraphRewrite event, Rule rule, EvaluationContext context)
     {
+        // Execution was not cancelled.
+        return false;
     }
 
     @Override
-    public void ruleEvaluationProgress(GraphRewrite event, String name, int currentPosition, int total, int timeRemainingInSeconds)
+    public boolean ruleEvaluationProgress(GraphRewrite event, String name, int currentPosition, int total, int timeRemainingInSeconds)
     {
+        // Execution was not cancelled.
+        return false;
     }
 
     @Override
@@ -34,8 +37,10 @@ public abstract class AbstractRuleLifecycleListener implements RuleLifecycleList
     }
 
     @Override
-    public void beforeRuleOperationsPerformed(GraphRewrite event, EvaluationContext context, Rule rule)
+    public boolean beforeRuleOperationsPerformed(GraphRewrite event, EvaluationContext context, Rule rule)
     {
+        // Execution was not cancelled.
+        return false;
     }
 
     @Override

--- a/config/api/src/main/java/org/jboss/windup/config/GraphRewrite.java
+++ b/config/api/src/main/java/org/jboss/windup/config/GraphRewrite.java
@@ -50,6 +50,7 @@ public class GraphRewrite extends AbstractRewrite implements Rewrite
 
     /**
      * Stores the exception which holds information if, and where, the Windup stopped (typically on an external request).
+     * If windup was stopped, this must be called.
      */
     public void setWindupStopException(WindupStopException windupStopException)
     {

--- a/config/api/src/main/java/org/jboss/windup/config/RuleLifecycleListener.java
+++ b/config/api/src/main/java/org/jboss/windup/config/RuleLifecycleListener.java
@@ -5,8 +5,9 @@ import org.ocpsoft.rewrite.context.EvaluationContext;
 
 /**
  * Receives events from {@link RuleSubset} during execution.
- * 
+ *
  * @author <a href="mailto:lincolnbaxter@gmail.com">Lincoln Baxter, III</a>
+ * @author <a href="mailto:zizka@seznam.cz">Ondrej Zizka</a>
  */
 public interface RuleLifecycleListener
 {
@@ -17,13 +18,17 @@ public interface RuleLifecycleListener
 
     /**
      * Called immediately before the given {@link Rule} is executed.
+     *
+     * @return true if the execution should be stopped, which is typically indicated by an underlying {@link WindupProgressMonitor}.
      */
-    void beforeRuleEvaluation(GraphRewrite event, Rule rule, EvaluationContext context);
+    boolean beforeRuleEvaluation(GraphRewrite event, Rule rule, EvaluationContext context);
 
     /**
      * This is optionally called by long-running rules to indicate their current progress and estimated time-remaining.
+     *
+     * @return true if the execution should be stopped, which is typically indicated by an underlying {@link WindupProgressMonitor}.
      */
-    void ruleEvaluationProgress(GraphRewrite event, String name, int currentPosition, int total, int timeRemainingInSeconds);
+    boolean ruleEvaluationProgress(GraphRewrite event, String name, int currentPosition, int total, int timeRemainingInSeconds);
 
     /**
      * Called immediately after execution of the each {@link Rule}.
@@ -33,8 +38,10 @@ public interface RuleLifecycleListener
     /**
      * Called immediately before {@link Rule} operations are performed (Only called if
      * {@link Rule#evaluate(org.ocpsoft.rewrite.event.Rewrite, EvaluationContext)} returned <code>true</code>).
+     *
+     * @return true if the execution should be stopped, which is typically indicated by an underlying {@link WindupProgressMonitor}.
      */
-    void beforeRuleOperationsPerformed(GraphRewrite event, EvaluationContext context, Rule rule);
+    boolean beforeRuleOperationsPerformed(GraphRewrite event, EvaluationContext context, Rule rule);
 
     /**
      * Called immediately after {@link Rule} operations are performed (Only called if

--- a/config/api/src/main/java/org/jboss/windup/config/RuleSubset.java
+++ b/config/api/src/main/java/org/jboss/windup/config/RuleSubset.java
@@ -32,11 +32,13 @@ import org.jboss.forge.furnace.spi.ListenerRegistration;
 import org.jboss.windup.config.metadata.RuleMetadataType;
 import org.jboss.windup.config.phase.RulePhase;
 import org.jboss.windup.graph.GraphContext;
+import org.jboss.windup.graph.model.WindupExecutionModel;
 import org.jboss.windup.graph.model.performance.RulePhaseExecutionStatisticsModel;
 import org.jboss.windup.graph.model.performance.RuleProviderExecutionStatisticsModel;
 import org.jboss.windup.graph.service.GraphService;
 import org.jboss.windup.graph.service.RuleProviderExecutionStatisticsService;
 import org.jboss.windup.util.exception.WindupException;
+import org.jboss.windup.util.exception.WindupStopException;
 import org.ocpsoft.common.util.Assert;
 import org.ocpsoft.rewrite.bind.Binding;
 import org.ocpsoft.rewrite.bind.Evaluation;
@@ -201,6 +203,7 @@ public class RuleSubset extends DefaultOperationBuilder implements CompositeOper
         }
 
         EvaluationContextImpl subContext = new EvaluationContextImpl();
+        rulesLoop:
         for (int i = 0; i < rules.size(); i++)
         {
             Rule rule = rules.get(i);
@@ -238,7 +241,14 @@ public class RuleSubset extends DefaultOperationBuilder implements CompositeOper
                 {
                     for (RuleLifecycleListener listener : listeners)
                     {
-                        listener.beforeRuleEvaluation(event, rule, subContext);
+                        boolean windupStopRequested = listener.beforeRuleEvaluation(event, rule, subContext);
+                        if (windupStopRequested)
+                        {
+                            String msg = "Windup was requested to stop before beforeRuleEvaluation() of " + rule.getId() + ", skipping further rules.";
+                            log.warning(msg);
+                            event.setWindupStopException(new WindupStopException(msg));
+                            break rulesLoop;
+                        }
                     }
 
                     if (rule.evaluate(event, subContext))
@@ -257,7 +267,14 @@ public class RuleSubset extends DefaultOperationBuilder implements CompositeOper
 
                         for (RuleLifecycleListener listener : listeners)
                         {
-                            listener.beforeRuleOperationsPerformed(event, subContext, rule);
+                            boolean windupStopRequested = listener.beforeRuleOperationsPerformed(event, subContext, rule);
+                            if (windupStopRequested)
+                            {
+                                String msg = "Windup was requested to stop before beforeRuleOperationsPerformed() of " + rule.getId() + ", skipping further rules.";
+                                log.warning(msg);
+                                event.setWindupStopException(new WindupStopException(msg));
+                                break rulesLoop;
+                            }
                         }
 
                         List<Operation> preOperations = subContext.getPreOperations();
@@ -295,6 +312,14 @@ public class RuleSubset extends DefaultOperationBuilder implements CompositeOper
                             listener.afterRuleConditionEvaluation(event, subContext, rule, false);
                         }
                     }
+                }
+                catch (WindupStopException ex)
+                {
+                    final String msg = "Windup was requested to stop during execution of " + rule.getId() + ", skipping further rules.";
+                    log.warning(msg);
+                    event.setWindupStopException(new WindupStopException(msg, ex));
+                    event.getGraphContext().service(WindupExecutionModel.class).create().setStopMessage(msg);
+                    break rulesLoop;
                 }
                 finally
                 {

--- a/config/api/src/main/java/org/jboss/windup/config/RuleSubset.java
+++ b/config/api/src/main/java/org/jboss/windup/config/RuleSubset.java
@@ -372,10 +372,9 @@ public class RuleSubset extends DefaultOperationBuilder implements CompositeOper
             }
         }
 
-        for (RuleLifecycleListener listener : listeners)
-        {
-            listener.afterExecution(event);
-        }
+        if (event.getWindupStopException() == null)
+            for (RuleLifecycleListener listener : listeners)
+                listener.afterExecution(event);
     }
 
     private boolean handleBindings(final Rewrite event, final EvaluationContextImpl context,

--- a/config/api/src/main/java/org/jboss/windup/config/operation/Iteration.java
+++ b/config/api/src/main/java/org/jboss/windup/config/operation/Iteration.java
@@ -45,6 +45,7 @@ import org.ocpsoft.rewrite.context.EvaluationContext;
 import org.ocpsoft.rewrite.event.Rewrite;
 
 import com.google.common.collect.Iterables;
+import org.jboss.windup.util.exception.WindupStopException;
 import org.ocpsoft.rewrite.config.CompositeCondition;
 
 /**
@@ -284,9 +285,13 @@ public class Iteration extends DefaultOperationBuilder
                     variables.pop();
                 }
             }
+            catch (WindupStopException ex)
+            {
+                throw new WindupStopException("Windup stop requested in " + this.toString(), ex);
+            }
             catch (Exception e)
             {
-                    throw new WindupException("Failed when iterating " + frame.toPrettyString() + ", due to: " + e.getMessage(), e);
+                throw new WindupException("Failed when iterating " + frame.toPrettyString() + ", due to: " + e.getMessage(), e);
             }
         }
         finally
@@ -495,6 +500,9 @@ public class Iteration extends DefaultOperationBuilder
 
     }
 
+    /**
+     * @return Description of this iteration, e.g. "Iteration.over(?).as(...).when(...).perform(...)".
+     */
     @Override
     public String toString()
     {

--- a/exec/api/src/main/java/org/jboss/windup/exec/CombinedWindupProgressMonitor.java
+++ b/exec/api/src/main/java/org/jboss/windup/exec/CombinedWindupProgressMonitor.java
@@ -1,0 +1,65 @@
+package org.jboss.windup.exec;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Passes the calls to all nested monitors.
+ *
+ * @author <a href="mailto:zizka@seznam.cz">Ondrej Zizka</a>
+ */
+public class CombinedWindupProgressMonitor implements WindupProgressMonitor
+{
+
+    private List<WindupProgressMonitor> monitors = new ArrayList<>();
+
+    public CombinedWindupProgressMonitor addMonitor(WindupProgressMonitor monitor)
+    {
+        this.monitors.add(monitor);
+        return this;
+    }
+
+
+    @Override
+    public void beginTask(String name, int totalWork)
+    {
+        monitors.forEach(m -> m.beginTask(name, totalWork));
+    }
+
+    @Override
+    public void done()
+    {
+        monitors.forEach(m -> m.done());
+    }
+
+    @Override
+    public boolean isCancelled()
+    {
+        return monitors.stream().anyMatch(m -> m.isCancelled());
+    }
+
+    @Override
+    public void setCancelled(boolean value)
+    {
+        monitors.forEach(m -> m.setCancelled(value));
+    }
+
+    @Override
+    public void setTaskName(String name)
+    {
+        monitors.forEach(m -> m.setTaskName(name));
+    }
+
+    @Override
+    public void subTask(String name)
+    {
+        monitors.forEach(m -> m.subTask(name));
+    }
+
+    @Override
+    public void worked(int work)
+    {
+        monitors.forEach(m -> m.worked(work));
+    }
+
+}

--- a/exec/api/src/main/java/org/jboss/windup/exec/WindupProgressMonitor.java
+++ b/exec/api/src/main/java/org/jboss/windup/exec/WindupProgressMonitor.java
@@ -2,8 +2,9 @@ package org.jboss.windup.exec;
 
 /**
  * A progress monitor API to allow monitoring of system while analyzing an application and/or generating reports.
- * 
+ *
  * @author <a href="mailto:lincolnbaxter@gmail.com">Lincoln Baxter, III</a>
+ * @author <a href="mailto:zizka@seznam.cz">Ondrej Zizka</a>
  */
 public interface WindupProgressMonitor
 {
@@ -14,7 +15,7 @@ public interface WindupProgressMonitor
 
     /**
      * Notifies that the main task is beginning. This must only be called once on a given progress monitor instance.
-     * 
+     *
      * @param name the name (or description) of the main task
      * @param totalWork the total number of work units into which the main task is been subdivided. If the value is
      *            <code>UNKNOWN</code> the implementation is free to indicate progress in a way which doesn't require
@@ -30,8 +31,8 @@ public interface WindupProgressMonitor
 
     /**
      * Returns whether cancellation of current operation has been requested. Long-running operations should poll to see
-     * if cancelation has been requested.
-     * 
+     * if cancellation has been requested.
+     *
      * @return <code>true</code> if cancellation has been requested, and <code>false</code> otherwise
      * @see #setCancelled(boolean)
      */
@@ -39,9 +40,9 @@ public interface WindupProgressMonitor
 
     /**
      * Sets the cancel state to the given value.
-     * 
+     *
      * @param value <code>true</code> indicates that cancellation has been requested (but not necessarily acknowledged);
-     *            <code>false</code> clears this flag
+     *        value <code>false</code> clears this flag
      * @see #isCancelled()
      */
     void setCancelled(boolean value);
@@ -49,7 +50,7 @@ public interface WindupProgressMonitor
     /**
      * Sets the task name to the given value. This method is used to restore the task label after a nested operation was
      * executed. Normally there is no need for clients to call this method.
-     * 
+     *
      * @param name the name (or description) of the main task
      * @see #beginTask(java.lang.String, int)
      */
@@ -58,7 +59,7 @@ public interface WindupProgressMonitor
     /**
      * Notifies that a subtask of the main task is beginning. Subtasks are optional; the main task might not have
      * subtasks.
-     * 
+     *
      * @param name the name (or description) of the subtask
      */
     void subTask(String name);
@@ -66,7 +67,7 @@ public interface WindupProgressMonitor
     /**
      * Notifies that a given number of work unit of the main task has been completed. Note that this amount represents
      * an installment, as opposed to a cumulative amount of work done to date.
-     * 
+     *
      * @param work a non-negative number of work units just completed
      */
     void worked(int work);

--- a/exec/impl/src/main/java/org/jboss/windup/exec/DefaultRuleLifecycleListener.java
+++ b/exec/impl/src/main/java/org/jboss/windup/exec/DefaultRuleLifecycleListener.java
@@ -52,13 +52,14 @@ class DefaultRuleLifecycleListener implements RuleLifecycleListener
     }
 
     @Override
-    public void beforeRuleEvaluation(GraphRewrite event, Rule rule, EvaluationContext context)
+    public boolean beforeRuleEvaluation(GraphRewrite event, Rule rule, EvaluationContext context)
     {
         progressMonitor.subTask(RuleUtils.prettyPrintRule(rule));
+        return progressMonitor.isCancelled();
     }
 
     @Override
-    public void ruleEvaluationProgress(GraphRewrite event, String name, int currentPosition, int total, int timeRemainingInSeconds)
+    public boolean ruleEvaluationProgress(GraphRewrite event, String name, int currentPosition, int total, int timeRemainingInSeconds)
     {
         String timeRemaining = formatTimeRemaining(timeRemainingInSeconds);
         int percentage = (int) (100 * ((double) currentPosition / (double) total));
@@ -69,6 +70,7 @@ class DefaultRuleLifecycleListener implements RuleLifecycleListener
             lastRuleProgressMessage = newProgressMessage;
             progressMonitor.subTask(newProgressMessage);
         }
+        return progressMonitor.isCancelled();
     }
 
     private String formatTimeRemaining(int timeRemainingInSeconds)
@@ -96,8 +98,9 @@ class DefaultRuleLifecycleListener implements RuleLifecycleListener
     }
 
     @Override
-    public void beforeRuleOperationsPerformed(GraphRewrite event, EvaluationContext context, Rule rule)
+    public boolean beforeRuleOperationsPerformed(GraphRewrite event, EvaluationContext context, Rule rule)
     {
+        return progressMonitor.isCancelled();
     }
 
     @Override

--- a/exec/tests/src/test/java/org/jboss/windup/exec/test/SkippingReportsRenderingTest.java
+++ b/exec/tests/src/test/java/org/jboss/windup/exec/test/SkippingReportsRenderingTest.java
@@ -97,16 +97,18 @@ public class SkippingReportsRenderingTest
         }
 
         @Override
-        public void beforeRuleEvaluation(GraphRewrite event, Rule rule, EvaluationContext context)
+        public boolean beforeRuleEvaluation(GraphRewrite event, Rule rule, EvaluationContext context)
         {
             RuleProvider provider = (RuleProvider) ((Context) rule).get(RuleMetadataType.RULE_PROVIDER);
             String realName = Proxies.unwrapProxyClassName(provider.getClass());
             executedRules.put(realName, Boolean.FALSE);
+            return false;
         }
 
         @Override
-        public void ruleEvaluationProgress(GraphRewrite event, String name, int currentPosition, int total, int timeRemainingInSeconds)
+        public boolean ruleEvaluationProgress(GraphRewrite event, String name, int currentPosition, int total, int timeRemainingInSeconds)
         {
+            return false;
         }
 
         @Override
@@ -119,7 +121,7 @@ public class SkippingReportsRenderingTest
 
         @Override
         public void afterExecution(GraphRewrite event)
-        {            
+        {
             verifyExecutionOfRule(TestRuleinMigrationRulesPhase.class, Boolean.TRUE);
             verifyExecutionOfRule(TestRuleinPreReportGenerationPhase.class, Boolean.FALSE);
             verifyExecutionOfRule(TestRuleinReportGenerationPhase.class, Boolean.FALSE);

--- a/exec/tests/src/test/java/org/jboss/windup/exec/test/TagsIncludeExcludeTest.java
+++ b/exec/tests/src/test/java/org/jboss/windup/exec/test/TagsIncludeExcludeTest.java
@@ -92,16 +92,18 @@ public class TagsIncludeExcludeTest
         }
 
         @Override
-        public void beforeRuleEvaluation(GraphRewrite event, Rule rule, EvaluationContext context)
+        public boolean beforeRuleEvaluation(GraphRewrite event, Rule rule, EvaluationContext context)
         {
             RuleProvider provider = (RuleProvider) ((Context) rule).get(RuleMetadataType.RULE_PROVIDER);
             String realName = Proxies.unwrapProxyClassName(provider.getClass());
             executedRules.put(realName, Boolean.FALSE);
+            return false;
         }
 
         @Override
-        public void ruleEvaluationProgress(GraphRewrite event, String name, int currentPosition, int total, int timeRemainingInSeconds)
+        public boolean ruleEvaluationProgress(GraphRewrite event, String name, int currentPosition, int total, int timeRemainingInSeconds)
         {
+            return false;
         }
 
         @Override

--- a/graph/api/src/main/java/org/jboss/windup/graph/model/WindupExecutionModel.java
+++ b/graph/api/src/main/java/org/jboss/windup/graph/model/WindupExecutionModel.java
@@ -1,0 +1,28 @@
+package org.jboss.windup.graph.model;
+
+import com.tinkerpop.frames.Property;
+import com.tinkerpop.frames.modules.typedgraph.TypeValue;
+
+/**
+ * Information about the Windup execution.
+ * Some of the information are stored in memory, see e.g. {@link RuleExecutionResultsListener}.
+ */
+@TypeValue(WindupExecutionModel.TYPE)
+public interface WindupExecutionModel extends WindupVertexFrame
+{
+    String TYPE = "WindupExecution";
+
+    String STOP_MESSAGE   = "stopMessage";
+
+    /**
+     * A message about where Windup stopped on request.
+     */
+    @Property(STOP_MESSAGE)
+    String getStopMessage();
+
+    /**
+     * A message about where Windup stopped on request.
+     */
+    @Property(STOP_MESSAGE)
+    void setStopMessage(String message);
+}

--- a/reporting/impl/src/main/java/org/jboss/windup/reporting/ruleexecution/RuleExecutionResultsListener.java
+++ b/reporting/impl/src/main/java/org/jboss/windup/reporting/ruleexecution/RuleExecutionResultsListener.java
@@ -18,9 +18,9 @@ import com.tinkerpop.blueprints.util.wrappers.event.listener.GraphChangedListene
 
 /**
  * Manages recording the history of {@link Rule}s executed by Windup.
- * 
- * @author <a href="mailto:jesse.sightler@gmail.com">Jesse Sightler</a>
  *
+ * @author <a href="mailto:jesse.sightler@gmail.com">Jesse Sightler</a>
+ * @author <a href="mailto:zizka@seznam.cz">Ondrej Zizka</a>
  */
 public class RuleExecutionResultsListener implements RuleLifecycleListener
 {
@@ -37,7 +37,7 @@ public class RuleExecutionResultsListener implements RuleLifecycleListener
     }
 
     /**
-     * 
+     *
      */
     public List<RuleExecutionInformation> getRuleExecutionInformation(AbstractRuleProvider provider)
     {
@@ -62,15 +62,17 @@ public class RuleExecutionResultsListener implements RuleLifecycleListener
     }
 
     @Override
-    public void beforeRuleEvaluation(GraphRewrite event, Rule rule, EvaluationContext context)
+    public boolean beforeRuleEvaluation(GraphRewrite event, Rule rule, EvaluationContext context)
     {
         ruleExecutionInformation.put(rule, new RuleExecutionInformation(rule));
         RuleExecutionResultsListener.this.currentRule = rule;
+        return false; // Don't request a stop.
     }
 
     @Override
-    public void ruleEvaluationProgress(GraphRewrite event, String name, int currentPosition, int total, int timeRemainingInSeconds)
+    public boolean ruleEvaluationProgress(GraphRewrite event, String name, int currentPosition, int total, int timeRemainingInSeconds)
     {
+        return false; // Don't request a stop.
     }
 
     @Override
@@ -85,8 +87,9 @@ public class RuleExecutionResultsListener implements RuleLifecycleListener
     }
 
     @Override
-    public void beforeRuleOperationsPerformed(GraphRewrite event, EvaluationContext context, Rule rule)
+    public boolean beforeRuleOperationsPerformed(GraphRewrite event, EvaluationContext context, Rule rule)
     {
+        return false; // Don't request a stop.
     }
 
     @Override
@@ -109,9 +112,11 @@ public class RuleExecutionResultsListener implements RuleLifecycleListener
     {
     }
 
+    /**
+     * Stores or counts the information about graph changes, especially which rules created which elements.
+     */
     private class GraphChangeListener implements GraphChangedListener
     {
-
         @Override
         public synchronized void vertexAdded(Vertex vertex)
         {
@@ -167,6 +172,5 @@ public class RuleExecutionResultsListener implements RuleLifecycleListener
         public void edgePropertyChanged(Edge edge, String key, Object oldValue, Object setValue)
         {
         }
-
     }
 }

--- a/tests/src/test/java/org/jboss/windup/tests/application/WindupArchitectureStopTest.java
+++ b/tests/src/test/java/org/jboss/windup/tests/application/WindupArchitectureStopTest.java
@@ -1,0 +1,165 @@
+package org.jboss.windup.tests.application;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.jboss.windup.graph.GraphContext;
+
+import java.io.FileOutputStream;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import org.apache.commons.io.IOUtils;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.forge.arquillian.AddonDependencies;
+import org.jboss.forge.arquillian.AddonDependency;
+import org.jboss.forge.arquillian.archive.AddonArchive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.windup.exec.WindupProgressMonitor;
+import org.jboss.windup.tests.application.rules.TestServletAnnotationRuleProvider;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Test for stopping Windup. Stops before ArchiveExtractionPhase.
+ *
+ * @author <a href="mailto:zizka@seznam.cz">Ondrej Zizka</a>
+ */
+@RunWith(Arquillian.class)
+public class WindupArchitectureStopTest extends WindupArchitectureTest
+{
+    private static final String EXAMPLE_USERSCRIPT_INPUT = "/exampleuserscript.xml";
+    private static final String EXAMPLE_USERSCRIPT_OUTPUT = "exampleuserscript_output.windup.xml";
+    private static final String XSLT_OUTPUT_NAME = "exampleconversion_userdir.xslt";
+
+    @Deployment
+    @AddonDependencies({
+        @AddonDependency(name = "org.jboss.windup.config:windup-config-xml"),
+        @AddonDependency(name = "org.jboss.windup.graph:windup-graph"),
+        @AddonDependency(name = "org.jboss.windup.exec:windup-exec"),
+        @AddonDependency(name = "org.jboss.windup.rules.apps:windup-rules-java"),
+        @AddonDependency(name = "org.jboss.windup.rules.apps:windup-rules-java-ee"),
+        @AddonDependency(name = "org.jboss.windup.utils:windup-utils"),
+        @AddonDependency(name = "org.jboss.windup.tests:test-util"),
+        @AddonDependency(name = "org.jboss.windup.reporting:windup-reporting"),
+        @AddonDependency(name = "org.jboss.windup.config:windup-config-groovy"),
+        @AddonDependency(name = "org.jboss.forge.furnace.container:cdi"),
+    })
+    public static AddonArchive getDeployment()
+    {
+        return ShrinkWrap.create(AddonArchive.class)
+            .addBeansXML()
+            .addClass(WindupArchitectureTest.class)
+            .addClass(TestServletAnnotationRuleProvider.class)
+            .addAsResource(new File("src/test/xml/XmlExample.windup.xml"))
+            .addAsResource(new File("src/test/xml/exampleuserscript.xml"), EXAMPLE_USERSCRIPT_INPUT)
+            .addAsResource(new File("src/test/xml/exampleconversion.xsl"));
+    }
+
+
+
+
+    @Test
+    public void testRunWindupSourceMode() throws Exception
+    {
+        Path userPath = FileUtils.getTempDirectory().toPath().resolve("Windup")
+                    .resolve("windupuserscriptsdir_" + RandomStringUtils.randomAlphanumeric(6));
+        try
+        {
+            Files.createDirectories(userPath);
+            try (InputStream is = getClass().getResourceAsStream(EXAMPLE_USERSCRIPT_INPUT);
+                OutputStream os = new FileOutputStream(userPath.resolve(EXAMPLE_USERSCRIPT_OUTPUT).toFile()))
+            {
+                IOUtils.copy(is, os);
+            }
+            try (InputStream is = getClass().getResourceAsStream("/exampleconversion.xsl");
+                OutputStream os = new FileOutputStream(userPath.resolve(XSLT_OUTPUT_NAME).toFile()))
+            {
+                IOUtils.copy(is, os);
+            }
+
+            try (GraphContext context = createGraphContext())
+            {
+                // The test-files folder in the project root dir.
+                List<String> includeList = Collections.emptyList();
+                List<String> excludeList = Collections.emptyList();
+                super.runTest(context, "../test-files/src_example", userPath.toFile(), true, includeList, excludeList);
+
+            }
+        }
+        finally
+        {
+            FileUtils.deleteDirectory(userPath.toFile());
+        }
+    }
+
+    @Override
+    protected void assertRecordedData(RecordingWindupProgressMonitor recordingMonitor)
+    {
+        Assert.assertFalse(recordingMonitor.isCancelled()); // It's not this monitor which is used to cancel.
+        Assert.assertFalse(recordingMonitor.isDone());
+        Assert.assertFalse(recordingMonitor.getSubTaskNames().isEmpty());
+        Assert.assertTrue(recordingMonitor.getTotalWork() > 0);
+        Assert.assertTrue(recordingMonitor.getCompletedWork() > 0);
+        Assert.assertTrue(recordingMonitor.getTotalWork() > recordingMonitor.getCompletedWork());
+    }
+
+
+
+    /**
+     * Overriding isCancelled()...
+     */
+    @Override
+    public WindupProgressMonitor overrideWindupProgressMonitor(WindupProgressMonitor recordingMonitor)
+    {
+        return new WindupProgressMonitor()
+        {
+            private boolean stop = false;
+
+            @Override
+            public boolean isCancelled()
+            {
+                return this.stop;
+            }
+
+            public void beginTask(String name, int totalWork)
+            {
+                recordingMonitor.beginTask(name, totalWork);
+            }
+
+            public void done()
+            {
+                recordingMonitor.done();
+            }
+
+            public void setCancelled(boolean value)
+            {
+                recordingMonitor.setCancelled(value);
+            }
+
+            public void setTaskName(String name)
+            {
+                recordingMonitor.setTaskName(name);
+            }
+
+            public void subTask(String name)
+            {
+                recordingMonitor.subTask(name);
+                if (name.contains("ArchiveExtractionPhase"))
+                    this.stop = true;
+                System.out.println("BBB STOP TEST " + name);
+            }
+
+            public void worked(int work)
+            {
+                recordingMonitor.worked(work);
+            }
+        };
+    }
+}

--- a/tooling/api/src/main/java/org/jboss/windup/tooling/ExecutionResults.java
+++ b/tooling/api/src/main/java/org/jboss/windup/tooling/ExecutionResults.java
@@ -12,9 +12,15 @@ import java.util.List;
  * that were produced.
  *
  * @author <a href="mailto:jesse.sightler@gmail.com">Jesse Sightler</a>
+ * @author <a href="mailto:zizka@seznam.cz">Ondrej Zizka</a>
  */
 public interface ExecutionResults
 {
+    /**
+     * A message about Windup stopping on request before finishing, if that happened; null otherwise.
+     */
+    String getWindupStopOnRequestMessage();
+
     /**
      * Contains all {@link Classification}s produced by this run of Windup.
      */

--- a/tooling/impl/src/main/java/org/jboss/windup/tooling/ExecutionBuilderImpl.java
+++ b/tooling/impl/src/main/java/org/jboss/windup/tooling/ExecutionBuilderImpl.java
@@ -58,7 +58,7 @@ public class ExecutionBuilderImpl implements ExecutionBuilder, ExecutionBuilderS
 
     /**
      * Is the option to skip Report preparing and generation set?
-     * 
+     *
      * @return the skipReportsRendering
      */
     public boolean isSkipReportsRendering()
@@ -68,7 +68,7 @@ public class ExecutionBuilderImpl implements ExecutionBuilder, ExecutionBuilderS
 
     /**
      * Sets the option to skip Report preparing and generation
-     * 
+     *
      * @param skipReportsRendering the skipReportsRendering to set
      */
     public void setSkipReportsRendering(boolean skipReportsRendering)
@@ -235,11 +235,11 @@ public class ExecutionBuilderImpl implements ExecutionBuilder, ExecutionBuilderS
             {
                 windupConfiguration.setOptionValue(option.getKey(), option.getValue());
             }
-            
+
             windupConfiguration
                         .setProgressMonitor(progressMonitor)
                         .setGraphContext(graphContext);
-            
+
             processor.execute(windupConfiguration);
 
             return new ExecutionResultsImpl(graphContext, toolingXMLService);
@@ -247,13 +247,15 @@ public class ExecutionBuilderImpl implements ExecutionBuilder, ExecutionBuilderS
         catch (IOException e)
         {
             throw new WindupException("Failed to instantiate graph due to: " + e.getMessage(), e);
-        } finally
+        }
+        finally
         {
             if (loggingHandler != null)
                 globalLogger.removeHandler(loggingHandler);
         }
     }
 
+    
     private class WindupProgressLoggingHandler extends Handler
     {
         private final WindupToolingProgressMonitor monitor;

--- a/tooling/impl/src/main/java/org/jboss/windup/tooling/ExecutionResultsImpl.java
+++ b/tooling/impl/src/main/java/org/jboss/windup/tooling/ExecutionResultsImpl.java
@@ -34,12 +34,14 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import javax.xml.bind.annotation.XmlAttribute;
 
 /**
  * Contains an implementation of {@link ExecutionResults} that loads its results from a {@link GraphContext}.
  *
  * @author <a href="mailto:jesse.sightler@gmail.com">Jesse Sightler</a>
  * @author <a href="mailto:hotmana76@gmail.com">Marek Novotny</a>
+ * @author <a href="mailto:zizka@seznam.cz">Ondrej Zizka</a>
  */
 @XmlRootElement(name = "execution-results")
 public class ExecutionResultsImpl implements ExecutionResults
@@ -49,10 +51,12 @@ public class ExecutionResultsImpl implements ExecutionResults
     private final List<Classification> classifications;
     private final List<Hint> hints;
     private final List<ReportLink> reportLinks;
+    private String windupStopOnRequestMessage;
 
     public ExecutionResultsImpl()
     {
         this.toolingXMLService = null;
+        this.windupStopOnRequestMessage = null;
         this.classifications = Collections.emptyList();
         this.hints = Collections.emptyList();
         this.reportLinks = Collections.emptyList();
@@ -64,6 +68,13 @@ public class ExecutionResultsImpl implements ExecutionResults
         this.classifications = getClassifications(graphContext);
         this.hints = getHints(graphContext);
         this.reportLinks = getReportLinks(graphContext);
+    }
+
+    @Override
+    @XmlAttribute(name = "stopMessage")
+    public String getWindupStopOnRequestMessage()
+    {
+        return this.windupStopOnRequestMessage;
     }
 
     @Override
@@ -102,7 +113,7 @@ public class ExecutionResultsImpl implements ExecutionResults
         }
     }
 
-    private List<ReportLink> getReportLinks(GraphContext graphContext)
+    private static List<ReportLink> getReportLinks(GraphContext graphContext)
     {
         final List<ReportLink> reportLinks = new ArrayList<>();
         SourceReportService sourceReportService = new SourceReportService(graphContext);
@@ -118,7 +129,7 @@ public class ExecutionResultsImpl implements ExecutionResults
         return reportLinks;
     }
 
-    private List<Hint> getHints(GraphContext graphContext)
+    private static List<Hint> getHints(GraphContext graphContext)
     {
         final List<Hint> hints = new ArrayList<>();
         InlineHintService hintService = new InlineHintService(graphContext);
@@ -143,7 +154,7 @@ public class ExecutionResultsImpl implements ExecutionResults
         return hints;
     }
 
-    private List<Classification> getClassifications(GraphContext graphContext)
+    private static List<Classification> getClassifications(GraphContext graphContext)
     {
         final List<Classification> classifications = new ArrayList<>();
         ClassificationService classificationService = new ClassificationService(graphContext);
@@ -161,14 +172,14 @@ public class ExecutionResultsImpl implements ExecutionResults
 
                 classification.setLinks(asLinks(classificationModel.getLinks()));
                 classifications.add(classification);
-                
+
                 classification.setQuickfixes(asQuickfixes(classificationModel.getQuickfixes()));
             }
         }
         return classifications;
     }
 
-    private List<Link> asLinks(Iterable<LinkModel> linkModels)
+    private static List<Link> asLinks(Iterable<LinkModel> linkModels)
     {
         List<Link> links = new ArrayList<>();
         for (LinkModel linkModel : linkModels)
@@ -180,8 +191,8 @@ public class ExecutionResultsImpl implements ExecutionResults
         }
         return links;
     }
-    
-    private List<Quickfix> asQuickfixes(Iterable<QuickfixModel> quickfixModels)
+
+    private static List<Quickfix> asQuickfixes(Iterable<QuickfixModel> quickfixModels)
     {
         List<Quickfix> fixes = new ArrayList<>();
         for (QuickfixModel quickfixModel : quickfixModels)

--- a/utils/src/main/java/org/jboss/windup/util/exception/WindupStopException.java
+++ b/utils/src/main/java/org/jboss/windup/util/exception/WindupStopException.java
@@ -1,0 +1,19 @@
+package org.jboss.windup.util.exception;
+
+/**
+ * Thrown in certain situations when we need to stop Windup execution, typically based on external request.
+ *
+ * @author <a href="mailto:zizka@seznam.cz">Ondrej Zizka</a>
+ */
+public final class WindupStopException extends WindupException
+{
+    public WindupStopException(String message)
+    {
+        super(message);
+    }
+
+    public WindupStopException(String message, Throwable cause)
+    {
+        super(message, cause);
+    }
+}


### PR DESCRIPTION
This makes use of WindupProgressMonitor#isCancelled().
That is queried in DefaultRuleLifecycleListener
which is queried by RuleSubset. 
RuleSubset, on spoting stop request, stops the rules cycle and creates a WindupExecutionModel vertex.