### PR TITLE
Added different method for tag comparison.

### DIFF
--- a/reporting/api/src/main/java/org/jboss/windup/reporting/TagUtil.java
+++ b/reporting/api/src/main/java/org/jboss/windup/reporting/TagUtil.java
@@ -24,6 +24,33 @@ public class TagUtil
     }
 
     /**
+     * Returns true if
+     *  - includeTags is not empty and tag is in includeTags
+     *  - includeTags is empty and tag is not in excludeTags
+     * @param tags Hint tags
+     * @param includeTags Include tags
+     * @param excludeTags Exclude tags
+     * @return has tag match
+     */
+    public static boolean strictCheckMatchingTags(Collection<String> tags, Set<String> includeTags, Set<String> excludeTags)
+    {
+        boolean includeTagsEnabled = !includeTags.isEmpty();
+
+        for (String tag : tags)
+        {
+            boolean isIncluded = includeTags.contains(tag);
+            boolean isExcluded = excludeTags.contains(tag);
+
+            if ((includeTagsEnabled && isIncluded) || (!includeTagsEnabled && !isExcluded))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
      * <p>
      * If any tag is in the exclude list and strictExclude is true, this will return false.
      *

--- a/reporting/api/src/main/java/org/jboss/windup/reporting/freemarker/problemsummary/ProblemSummaryService.java
+++ b/reporting/api/src/main/java/org/jboss/windup/reporting/freemarker/problemsummary/ProblemSummaryService.java
@@ -31,8 +31,22 @@ public class ProblemSummaryService
     /**
      * Gets lists of {@link ProblemSummary} objects organized by {@link IssueCategoryModel}.
      */
+    public static Map<IssueCategoryModel, List<ProblemSummary>> getProblemSummaries(
+            GraphContext graphContext,
+            Set<ProjectModel> projectModels,
+            Set<String> includeTags,
+            Set<String> excludeTags)
+    {
+        return getProblemSummaries(graphContext, projectModels, includeTags, excludeTags, false, false);
+    }
+
+    /**
+     * Gets lists of {@link ProblemSummary} objects organized by {@link IssueCategoryModel}.
+     */
     public static Map<IssueCategoryModel, List<ProblemSummary>> getProblemSummaries(GraphContext graphContext, Set<ProjectModel> projectModels, Set<String> includeTags,
-                                                                                    Set<String> excludeTags)
+                                                                                    Set<String> excludeTags,
+                                                                                    boolean strictComparison,
+                                                                                    boolean strictExclude)
     {
         // The key is the severity as a String
         Map<IssueCategoryModel, List<ProblemSummary>> results = new TreeMap<>(new IssueCategoryModel.IssueSummaryPriorityComparator());
@@ -43,8 +57,22 @@ public class ProblemSummaryService
         for (InlineHintModel hint : hints)
         {
             Set<String> tags = hint.getTags();
-            if (!TagUtil.checkMatchingTags(tags, includeTags, excludeTags, false))
+
+            boolean hasTagMatch;
+
+            if (strictComparison)
+            {
+                hasTagMatch = TagUtil.strictCheckMatchingTags(tags, includeTags, excludeTags);
+            }
+            else
+            {
+                hasTagMatch = TagUtil.checkMatchingTags(tags, includeTags, excludeTags, strictExclude);
+            }
+
+            if (!hasTagMatch)
+            {
                 continue;
+            }
 
             RuleSummaryKey key = new RuleSummaryKey(hint.getEffort(), hint.getRuleID(), hint.getTitle());
 


### PR DESCRIPTION
I had issue with very non intuitive tag include/exclude in windup-web.

I added method which returns true if:
- tag is included or tag is not excluded

It checks if includeTags is not empty, if it is not, tag is included ONLY when it is in includeTags.
If includeTags is empty, tag is by default included, but is excluded, when it is in excludeTags.