### PR TITLE
Make GraphTypeManager and GraphModelScanner use WindupFrame instead o…

### DIFF
--- a/graph/api/src/main/java/org/jboss/windup/graph/GraphModelScanner.java
+++ b/graph/api/src/main/java/org/jboss/windup/graph/GraphModelScanner.java
@@ -10,21 +10,20 @@ import java.util.logging.Logger;
 
 import org.jboss.forge.furnace.util.OperatingSystemUtils;
 import org.jboss.forge.furnace.util.Predicate;
-import org.jboss.windup.graph.model.WindupVertexFrame;
+import org.jboss.windup.graph.model.WindupFrame;
 import org.jboss.windup.util.PathUtil;
 import org.jboss.windup.util.furnace.FurnaceClasspathScanner;
 
 /**
- * This is used to provide a registry of {@link WindupVertexFrame} subclasses for integration with Tinkerpop Frames.
- *
+ * This is used to provide a registry of {@link WindupFrame} subclasses for integration with Tinkerpop Frames.
  */
 class GraphModelScanner
 {
     private static final Logger LOG = Logger.getLogger(GraphModelScanner.class.getName());
 
-    public static List<Class<? extends WindupVertexFrame>> loadFrames(FurnaceClasspathScanner scanner)
+    public static List<Class<? extends WindupFrame<?>>> loadFrames(FurnaceClasspathScanner scanner)
     {
-        List<Class<? extends WindupVertexFrame>> results = new ArrayList<>();
+        List<Class<? extends WindupFrame<?>>> results = new ArrayList<>();
 
         // Scan for all classes form *Model.class.
         Predicate<String> modelClassFilter = new Predicate<String>()
@@ -65,11 +64,11 @@ class GraphModelScanner
 
         for (Class<?> clazz : classes)
         {
-            if (WindupVertexFrame.class.isAssignableFrom(clazz))
+            if (WindupFrame.class.isAssignableFrom(clazz))
             {
                 LOG.fine("    Found: " + clazz);
                 @SuppressWarnings("unchecked")
-                Class<? extends WindupVertexFrame> windupVertexFrame = (Class<? extends WindupVertexFrame>) clazz;
+                Class<? extends WindupFrame<?>> windupVertexFrame = (Class<? extends WindupFrame<?>>) clazz;
                 results.add(windupVertexFrame);
             }
             else
@@ -82,13 +81,13 @@ class GraphModelScanner
         return results;
     }
 
-    private static void logLoadedModelTypes(List<Class<? extends WindupVertexFrame>> types)
+    private static void logLoadedModelTypes(List<Class<? extends WindupFrame<?>>> types)
     {
-        List<Class<? extends WindupVertexFrame>> list = new ArrayList<>(types);
-        Collections.sort(list, new Comparator<Class<? extends WindupVertexFrame>>()
+        List<Class<? extends WindupFrame<?>>> list = new ArrayList<>(types);
+        Collections.sort(list, new Comparator<Class<? extends WindupFrame<?>>>()
         {
             @Override
-            public int compare(Class<? extends WindupVertexFrame> left, Class<? extends WindupVertexFrame> right)
+            public int compare(Class<? extends WindupFrame<?>> left, Class<? extends WindupFrame<?>> right)
             {
                 if (left == right)
                     return 0;
@@ -100,12 +99,12 @@ class GraphModelScanner
             }
         });
         StringBuilder result = new StringBuilder();
-        for (Class<? extends WindupVertexFrame> frameType : list)
+        for (Class<? extends WindupFrame<?>> frameType : list)
         {
             result.append("\t").append(frameType.getName()).append(NEWLINE);
         }
 
-        LOG.info("Loaded [" + list.size() + "] WindupVertexFrame sub-types [" + NEWLINE + result.toString() + "]");
+        LOG.info("Loaded [" + list.size() + "] WindupFrame sub-types [" + NEWLINE + result.toString() + "]");
     }
 
     private static final String NEWLINE = OperatingSystemUtils.getLineSeparator();

--- a/graph/api/src/main/java/org/jboss/windup/graph/GraphTypeManager.java
+++ b/graph/api/src/main/java/org/jboss/windup/graph/GraphTypeManager.java
@@ -31,6 +31,7 @@ import com.tinkerpop.frames.modules.TypeResolver;
 import com.tinkerpop.frames.modules.typedgraph.TypeField;
 import com.tinkerpop.frames.modules.typedgraph.TypeRegistry;
 import com.tinkerpop.frames.modules.typedgraph.TypeValue;
+import java.util.logging.Logger;
 
 /**
  * Windup's implementation of extended type handling for TinkerPop Frames. This allows storing multiple types based on the @TypeValue.value(), also in
@@ -38,6 +39,8 @@ import com.tinkerpop.frames.modules.typedgraph.TypeValue;
  */
 public class GraphTypeManager implements TypeResolver, FrameInitializer
 {
+    private static final Logger LOG = Logger.getLogger(GraphTypeManager.class.getName());
+
     private Map<String, Class<? extends WindupFrame<?>>> registeredTypes;
     private TypeRegistry typeRegistry;
 
@@ -74,8 +77,10 @@ public class GraphTypeManager implements TypeResolver, FrameInitializer
         return typeRegistry;
     }
 
-    private void addTypeToRegistry(Class<? extends WindupVertexFrame> frameType)
+    private void addTypeToRegistry(Class<? extends WindupFrame<?>> frameType)
     {
+        LOG.info(" Adding type to registry: " + frameType.getName());
+
         TypeValue typeValueAnnotation = frameType.getAnnotation(TypeValue.class);
 
         // Do not attempt to add items where this is null... we use
@@ -97,7 +102,7 @@ public class GraphTypeManager implements TypeResolver, FrameInitializer
     /**
      * Remove the given type from the provided {@link Element}.
      */
-    public void removeTypeFromElement(Class<? extends WindupFrame> kind, Element element)
+    public void removeTypeFromElement(Class<? extends WindupFrame<?>> kind, Element element)
     {
         StandardVertex v = GraphTypeManager.asTitanVertex(element);
         Class<?> typeHoldingTypeField = getTypeRegistry().getTypeHoldingTypeField(kind);
@@ -154,7 +159,7 @@ public class GraphTypeManager implements TypeResolver, FrameInitializer
     /**
      * Adds the type value to the field denoting which type the element represents.
      */
-    public void addTypeToElement(Class<? extends WindupFrame> kind, Element element)
+    public void addTypeToElement(Class<? extends WindupFrame<?>> kind, Element element)
     {
         StandardVertex v = GraphTypeManager.asTitanVertex(element);
         Class<?> typeHoldingTypeField = getTypeRegistry().getTypeHoldingTypeField(kind);
@@ -182,13 +187,13 @@ public class GraphTypeManager implements TypeResolver, FrameInitializer
     }
 
     @SuppressWarnings("unchecked")
-    private void addSuperclassType(Class<? extends WindupFrame> kind, Element element)
+    private void addSuperclassType(Class<? extends WindupFrame<?>> kind, Element element)
     {
         for (Class<?> superInterface : kind.getInterfaces())
         {
-            if (WindupVertexFrame.class.isAssignableFrom(superInterface))
+            if (WindupFrame.class.isAssignableFrom(superInterface))
             {
-                addTypeToElement((Class<? extends WindupFrame>) superInterface, element);
+                addTypeToElement((Class<? extends WindupFrame<?>>) superInterface, element);
             }
         }
 
@@ -318,7 +323,7 @@ public class GraphTypeManager implements TypeResolver, FrameInitializer
     {
         if (VertexFrame.class.isAssignableFrom(kind))
         {
-            addTypeToElement((Class<? extends WindupFrame>) kind, element);
+            addTypeToElement((Class<? extends WindupFrame<?>>) kind, element);
         }
     }
 


### PR DESCRIPTION
…f WindupVertexFrame, where appropriate.

Otherwise, GraphTypeManager discarded WindupEdgeFrame's and those were then unknown to TsModelGen.