### PR TITLE
WINDUP-1274 - Removed port number. Turns out to be redundant since yo…

### DIFF
--- a/tooling/api/src/main/java/org/jboss/windup/tooling/ExecutionBuilder.java
+++ b/tooling/api/src/main/java/org/jboss/windup/tooling/ExecutionBuilder.java
@@ -108,14 +108,4 @@ public interface ExecutionBuilder extends Remote
      * Sets the version of Windup.
      */
     void setVersion(String version) throws RemoteException;
-    
-    /**
-     * Returns the port the Windup server is running on.
-     */
-    int getPort() throws RemoteException;
-    
-    /**
-     * Sets the port the Windup server is running on.
-     */
-    void setPort(int port) throws RemoteException;
 }

--- a/tooling/api/src/main/java/org/jboss/windup/tooling/ToolingRMIServer.java
+++ b/tooling/api/src/main/java/org/jboss/windup/tooling/ToolingRMIServer.java
@@ -25,7 +25,6 @@ public class ToolingRMIServer
         try
         {
         	executionBuilder.setVersion(version);
-        	executionBuilder.setPort(port);
             Registry registry = LocateRegistry.getRegistry(port);
             try
             {

--- a/tooling/impl/src/main/java/org/jboss/windup/tooling/ExecutionBuilderImpl.java
+++ b/tooling/impl/src/main/java/org/jboss/windup/tooling/ExecutionBuilderImpl.java
@@ -61,7 +61,6 @@ public class ExecutionBuilderImpl implements ExecutionBuilder
     private boolean skipReportsRendering;
     
     private String version;
-    private int port;
 
     @Override
     public void clear() throws RemoteException
@@ -220,18 +219,6 @@ public class ExecutionBuilderImpl implements ExecutionBuilder
     {
     	this.version = version;
     }
-    
-    @Override
-    public int getPort() throws RemoteException 
-    {
-    	return port;
-    }
-    
-    @Override
-    public void setPort(int port) throws RemoteException
-    {
-		this.port = port;
-	}
 
     @Override
     public ExecutionResults execute() throws RemoteException


### PR DESCRIPTION
…u need the port number in order to get the Windup ExecutionBuilder in the first place.