### PR TITLE
Remove effort from WebLogic EJB XML clsf that has a hint with effort.

### DIFF
--- a/rules-java-ee/addon/src/main/java/org/jboss/windup/rules/apps/javaee/rules/weblogic/ResolveWebLogicEjbXmlRuleProvider.java
+++ b/rules-java-ee/addon/src/main/java/org/jboss/windup/rules/apps/javaee/rules/weblogic/ResolveWebLogicEjbXmlRuleProvider.java
@@ -70,7 +70,11 @@ public class ResolveWebLogicEjbXmlRuleProvider extends IteratingRuleProvider<Xml
 
         ClassificationService classificationService = new ClassificationService(event.getGraphContext());
         ClassificationModel classif = classificationService.attachClassification(context, weblogicEjbXml, "WebLogic EJB XML", "WebLogic Enterprise Java Bean XML Descriptor.");
-        classif.setEffort(3);
+        // TODO -- this classification duplicates a hint/clsf in the
+        // weblogic-xml-descriptor-04000 XML rule. This should probably get a
+        // better fix, but for now the important thing is to avoid duplicating
+        // the effort added by that hint.
+        classif.setEffort(0);
         IssueCategoryRegistry issueCategoryRegistry = IssueCategoryRegistry.instance(event.getRewriteContext());
         classif.setIssueCategory(issueCategoryRegistry.loadFromGraph(event.getGraphContext(), IssueCategoryRegistry.MANDATORY));
 


### PR DESCRIPTION
Set effort to 0 in clsf generated by ResolveWebLogicEjbXmlRuleProvider to avoid duplicating effort from weblogic-xml-descriptors-04000 hint.

Hint with effort was added after 2.7 in this commit: https://github.com/windup/windup-rulesets/commit/baf299554f86d834c9e9188d9d06477cc3ed08b6