### PR TITLE
WINDUP-1320 and tasks 608,607 - Report index charts and tables relayout

### DIFF
--- a/reporting/impl/src/main/resources/reports/resources/css/windup.css
+++ b/reporting/impl/src/main/resources/reports/resources/css/windup.css
@@ -369,3 +369,8 @@ strong.wu-navbar-header {
     text-transform: uppercase;
     font-size: 18px;
 }
+
+.chartBoundary h4 {
+    border-bottom: 1px solid #008cba;
+    margin-right: 10%;
+}

--- a/rules-java/api/src/main/java/org/jboss/windup/rules/apps/java/reporting/rules/CreateIssueSummaryDataRuleProvider.java
+++ b/rules-java/api/src/main/java/org/jboss/windup/rules/apps/java/reporting/rules/CreateIssueSummaryDataRuleProvider.java
@@ -114,7 +114,7 @@ public class CreateIssueSummaryDataRuleProvider extends AbstractRuleProvider
                 }
                 issueSummaryWriter.write("];" + NEWLINE);
 
-                issueSummaryWriter.write("var severityOrder = [");
+                issueSummaryWriter.write("var categoryOrder = [");
                 IssueCategoryRegistry issueCategoryRegistry = IssueCategoryRegistry.instance(event.getRewriteContext());
                 for (IssueCategory issueCategory : issueCategoryRegistry.getIssueCategories())
                 {

--- a/rules-java/api/src/main/resources/reports/templates/report_index.ftl
+++ b/rules-java/api/src/main/resources/reports/templates/report_index.ftl
@@ -18,10 +18,12 @@
     <link rel="stylesheet" type="text/css" href="resources/libraries/flot/plot.css" />
     <link href="resources/img/rhamt-icon-128.png" rel="shortcut icon" type="image/x-icon"/>
     <style>
-.report-index-row {
-    margin: 10px -32px 0px 5px;
-    margin-bottom: 25px;
-}
+        .report-index-row {
+            margin: 10px -32px 0px 5px;
+            margin-bottom: 25px;
+        }
+        .dataTable { max-width: 500px; margin-top: 2ex; }
+        div.panel-collapsed { display: none; }
     </style>
 </head>
 <body role="document" class="java-report-index">
@@ -54,99 +56,84 @@
             </div>
         </div>
 
-        <div class="row container-fluid col-md-12 summaryInfo">
-            <div class="panel panel-primary col-md-12">
-                <div class="row col-md-12 report-index-row">
-                    <div class="col-md-3">
-                        <table class="table table-condensed table-striped" id="incidentsByTypeTable">
-                            <thead>
-                                <tr>
-                                    <td>
-                                        <b>Incidents by Category</b>
-                                    </td>
-                                    <td class='numeric-column'>
-                                        <b>Incidents</b>
-                                    </td>
-                                    <td class='numeric-column'>
-                                        <b>Total Story Points</b>
-                                    </td>
-                                </tr>
-                            </thead>
-                            <tbody id="incidentsByTypeTBody">
-                            </tbody>
-                        </table>
-                    </div>
+        <div class="row container-fluid summaryInfo col-md-12">            
+            <div class="row report-index-row col-md-12">
+                <!-- Java incidents by package chart -->
+                <div class="chartBoundary col-md-4">
+                  <h4>Java Incidents by Package</h4>
+                  <div id='application_pie' class='windupPieGraph'></div>
+                </div>
+                <!-- end of Java Package usage -->
 
-                    <div class="col-md-8">
-                        <div class="col-md-6">
-                            <div style="text-align: center"><strong>Incidents by Category</strong></div>
-                            <div id="incidentsBySeverityChart" style="float: left;"></div>
-                        </div>
-                        <div class="col-md-6">
-                            <div style="text-align: center"><strong>Incidents and Story Points</strong></div>
-                            <div id="effortAndSeverityChart" style="float: right;"></div>
-                        </div>
-                    </div>
+                <!-- Incidents and story points chart -->
+                <div class="chartBoundary col-md-4">
+                    <h4>Incidents and Story Points</h4>
+                    <div id="effortAndCategoryChart"></div>
+               </div>
+                <!-- end of Incidents and story Points chart -->
+
+                <!-- Mandatory incidents by Effort -->
+                <div class="chartBoundary col-md-4">
+                    <h4>Mandatory Incidents and Story Points</h4>
+                    <div id="mandatoryIncidentsByEffortChart"></div>
+                </div>
+            </div>
+
+            <!-- second row with tables -->
+             <div class="row report-index-row col-md-12">
+                <div class="panel panel-heading clickable" style="cursor: pointer;">
+                    <span id="hide" style="display: none;"><i class="glyphicon glyphicon-expand"></i> Hide Details</span>
+                    <span id="show"><i class="glyphicon glyphicon-collapse-down"></i> Show Details</span>
+               </div>
+
+                <!-- Java package usage table DETAILS -->
+                <div class="panel-body details panel-collapsed col-md-4" id="javaIncidentsByPackageRow">
+                    <table class="table table-condensed table-striped  dataTable">
+                        <#--caption>Java Packages Usage</caption-->
+                         <thead>
+                             <tr>
+                             <th>Java Package</th>
+                                <th class='numeric-column'>Incidents</th>
+                             </tr>
+                         </thead>
+                          <tbody id="javaIncidentsByPackageTBody">
+                         </tbody>
+                     </table>
+                    <span class="note">Note: this does not include XML files and "possible" issues.</span>
+                </div>
+                <!-- end of Java package usage table DETAILS -->
+                
+                <div class="panel-body details panel-collapsed col-md-4">
+                    <table class="table table-condensed table-striped dataTable" id="incidentsByTypeTable">
+                        <#--caption>Incidents by Category</caption-->
+                        <thead>
+                            <tr>
+                                <th>Category</th>
+                                <th class='numeric-column'>Incidents</th>
+                                <th class='numeric-column'>Total Story Points</th>
+                            </tr>
+                        </thead>
+                        <tbody id="incidentsByTypeTBody">
+                        </tbody>
+                    </table>
                 </div>
 
-                <div class="row col-md-12 report-index-row">
-                    <div class="col-md-3">
-                        <table class="table table-condensed table-striped">
-                            <thead>
-                                <tr>
-                                    <td>
-                                        <b>Mandatory Incidents by Type</b>
-                                    </td>
-                                    <td class='numeric-column'>
-                                        <b>Incidents</b>
-                                    </td>
-                                    <td class='numeric-column'>
-                                        <b>Total Story Points</b>
-                                    </td>
-                                </tr>
-                            </thead>
-                            <tbody id="mandatoryIncidentsByEffortTBody">
-                            </tbody>
-                        </table>
-                    </div>
-                    <div class="col-md-8">
-                        <div class="col-md-6">
-                            <div style="text-align: center"><strong>Mandatory Incidents by category</strong></div>
-                            <div id="mandatoryIncidentsByEffort" style="float: left;"></div>
-                        </div>
-                        <div class="col-md-6">
-                            <div style="text-align: center"><strong>Mandatory Incidents and Story Points</strong></div>
-                            <div id="mandatoryIncidentsByEffortAndStoryPoints" style="float: right;"></div>
-                        </div>
-                    </div>
-                </div><#-- .row -->
-
-                <div class="row col-md-12 report-index-row" id="javaIncidentsByPackageRow">
-                    <div class="col-md-3">
-                        <table class="table table-condensed table-striped">
-                            <thead>
-                                <tr>
-                                    <td>
-                                        <b>Java Incidents by Package</b>
-                                    </td>
-                                    <td class='numeric-column'>
-                                        <b>Incidents</b>
-                                    </td>
-                                </tr>
-                            </thead>
-                            <tbody id="javaIncidentsByPackageTBody">
-                            </tbody>
-                        </table>
-                        <span class="note">Note: this does not include XML files and "possible" issues.</span>
-                    </div>
-                    <div class="panel col-md-6">
-                        <div style="margin-bottom: 10px; margin-left: 190px;">
-                            <b>Java Incidents by Package</b>
-                        </div>
-                        <div id='application_pie' class='windupPieGraph'></div>
-                    </div>
-                </div><#-- .row -->
-            </div><#-- .panel -->
+                <!-- Mandatory incidents table DETAILS -->
+                <div class="panel-body details panel-collapsed col-md-4">
+                    <table class="table table-condensed table-striped dataTable">
+                        <#-- caption>Mandatory Incidents by Type</caption-->
+                        <thead>
+                            <tr>
+                                <th>Effort Level</th>
+                                <th class='numeric-column'>Incidents</th>
+                                <th class='numeric-column'>Total Story Points</th>
+                            </tr>
+                        </thead>
+                        <tbody id="mandatoryIncidentsByEffortTBody">
+                        </tbody>
+                    </table>
+                </div>
+            </div><#-- .row -->
         </div><#-- .row.summaryInfo -->
 
         <div class="row col-md-12">
@@ -166,6 +153,22 @@
     <script type="text/javascript" src="data/issue_summaries.js"></script>
 
     <script type="text/javascript">
+        // function for collapsing/expanding of summary table details
+        $(document).ready(function(){
+            $('#hide').click(function(){
+                $('.details').addClass('.panel-collapsed');
+                $('.details').hide();
+                $('#show').show();
+                $('#hide').hide();
+            });
+            $("#show").click(function(){
+                $('.details').removeClass('.panel-collapsed');
+                $('.details').show();
+                $('#show').hide();
+                $('#hide').show();
+            });
+        });
+
         function getWindupIssueSummaries() {
             return WINDUP_ISSUE_SUMMARIES['${reportModel.projectModel.asVertex().id?c}'];
         }

--- a/test-util/src/main/java/org/jboss/windup/testutil/html/TestReportIndexReportUtil.java
+++ b/test-util/src/main/java/org/jboss/windup/testutil/html/TestReportIndexReportUtil.java
@@ -6,15 +6,19 @@ import java.nio.file.Path;
 
 import org.apache.commons.io.FileUtils;
 import org.openqa.selenium.By;
+import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.WebElement;
+
 
 /**
  * @author <a href="mailto:jesse.sightler@gmail.com">Jesse Sightler</a>
  */
 public class TestReportIndexReportUtil extends TestReportUtil
 {
+
     public boolean checkIncidentByCategoryRow(String category, int incidents, int totalStoryPoints)
     {
+        ((JavascriptExecutor) getDriver()).executeScript("document.getElementById('show').click();");
         WebElement element = getDriver().findElement(By.id("incidentsByTypeTable"));
         if (element == null)
         {
@@ -46,7 +50,7 @@ public class TestReportIndexReportUtil extends TestReportUtil
 
             contents = contents.replaceAll("jQuery.Color\\((.|[\n])*?\\);", "");
 
-            contents = contents.replace("createTagCharts();", "");
+            contents = contents.replace("createCharts();", "");
 
             try (FileWriter writer = new FileWriter(modifiedPath.toFile()))
             {


### PR DESCRIPTION
* I changed generation of issues summaries to have categoryID instead of name of category
* i change layout to be more like dynamic report index with hiding/showing tables 

I need to fix mandatory chart as it is somehow crippled with incidents and if it could be done x axis labels to be rotated and possibly fit longer categoryIds - that is one option.
