### PR TITLE
Console progress output on the same line

### DIFF
--- a/bootstrap/src/main/java/org/jboss/windup/bootstrap/ConsoleProgressMonitor.java
+++ b/bootstrap/src/main/java/org/jboss/windup/bootstrap/ConsoleProgressMonitor.java
@@ -56,7 +56,14 @@ public class ConsoleProgressMonitor implements WindupProgressMonitor
     public void subTask(String subTask)
     {
         String message = String.format("[%d/%d] %s", currentWork, totalWork, subTask);
-        System.out.println(message);
+        if (subTask.endsWith("\r"))
+        {
+            System.out.print(message);
+        } 
+        else 
+        {
+            System.out.println("\r" + message);
+        }
         LOG.info(message);
     }
 

--- a/exec/impl/src/main/java/org/jboss/windup/exec/DefaultRuleLifecycleListener.java
+++ b/exec/impl/src/main/java/org/jboss/windup/exec/DefaultRuleLifecycleListener.java
@@ -67,8 +67,12 @@ class DefaultRuleLifecycleListener implements RuleLifecycleListener
         // don't redisplay it if nothing has changed
         if (!newProgressMessage.equals(lastRuleProgressMessage))
         {
+            if (lastRuleProgressMessage != null && lastRuleProgressMessage.length() > newProgressMessage.length())
+            {
+                newProgressMessage = String.format("%1$-" + lastRuleProgressMessage.length() + "s", newProgressMessage);
+            }
             lastRuleProgressMessage = newProgressMessage;
-            progressMonitor.subTask(newProgressMessage);
+            progressMonitor.subTask(newProgressMessage + "\r");
         }
         return progressMonitor.isCancelled();
     }


### PR DESCRIPTION
1. pad the n-th message to be long as the (n-1)-th message to have every message clearly written without the final part of the previous one
2. print the n-th message with the "\r" carriage return to stay on the same line
3. println the next rule execution message with "\r" prefix to have the log clear with just all the rules executed