### PR TITLE
T877 Links to articles should open in a new tab

### DIFF
--- a/reporting/impl/src/main/java/org/jboss/windup/reporting/freemarker/MarkdownToHtmlMethod.java
+++ b/reporting/impl/src/main/java/org/jboss/windup/reporting/freemarker/MarkdownToHtmlMethod.java
@@ -64,7 +64,7 @@ public class MarkdownToHtmlMethod implements WindupFreeMarkerMethod
             // Our plugin is also a serializer, so build a plugins list for serialization as well
             List<ToHtmlSerializerPlugin> serializerPlugins = new ArrayList<>(1);
 
-            ToHtmlSerializer serializer = new ToHtmlSerializer(new LinkRenderer(), Collections.<String, VerbatimSerializer> emptyMap(),
+            ToHtmlSerializer serializer = new ToHtmlSerializerExtended(new LinkRenderer(), Collections.<String, VerbatimSerializer> emptyMap(),
                         serializerPlugins);
             String result = serializer.toHtml(outputNode);
             cache.put(markdownSource, new SoftReference<>(result));

--- a/reporting/impl/src/main/java/org/jboss/windup/reporting/freemarker/ToHtmlSerializerExtended.java
+++ b/reporting/impl/src/main/java/org/jboss/windup/reporting/freemarker/ToHtmlSerializerExtended.java
@@ -1,0 +1,51 @@
+package org.jboss.windup.reporting.freemarker;
+
+import java.util.List;
+import java.util.Map;
+
+import org.pegdown.LinkRenderer;
+import org.pegdown.ToHtmlSerializer;
+import org.pegdown.VerbatimSerializer;
+import org.pegdown.plugins.ToHtmlSerializerPlugin;
+
+public class ToHtmlSerializerExtended extends ToHtmlSerializer
+{
+    public ToHtmlSerializerExtended(LinkRenderer linkRenderer)
+    {
+        super(linkRenderer);
+    }
+
+    public ToHtmlSerializerExtended(LinkRenderer linkRenderer, List<ToHtmlSerializerPlugin> plugins)
+    {
+        super(linkRenderer, plugins);
+    }
+
+    public ToHtmlSerializerExtended(LinkRenderer linkRenderer, Map<String, VerbatimSerializer> verbatimSerializers,
+                List<ToHtmlSerializerPlugin> plugins)
+    {
+        super(linkRenderer, verbatimSerializers, plugins);
+    }
+
+    public ToHtmlSerializerExtended(LinkRenderer linkRenderer, Map<String, VerbatimSerializer> verbatimSerializers)
+    {
+        super(linkRenderer, verbatimSerializers);
+    }
+
+    @Override
+    protected void printLink(LinkRenderer.Rendering rendering)
+    {
+        printer.print('<').print('a');
+        printAttribute("href", rendering.href);
+        for (LinkRenderer.Attribute attr : rendering.attributes) {
+            printAttribute(attr.name, attr.value);
+        }
+        printAttribute("target", "_blank");
+        printer.print('>').print(rendering.text).print("</a>");        
+    }
+    
+    private void printAttribute(String name, String value)
+    {
+        printer.print(' ').print(name).print('=').print('"').print(value).print('"');
+    }
+
+}

--- a/reporting/impl/src/main/resources/reports/resources/css/windup.css
+++ b/reporting/impl/src/main/resources/reports/resources/css/windup.css
@@ -339,3 +339,14 @@ strong {
 div.indent{
     padding-left: 20px;
 }
+
+@font-face {
+    font-family: FontAwesome;
+    src: url('../fonts/fontawesome-webfont.woff');
+}
+
+a[target="_blank"]:after {
+    content: "\f08e";
+    font-family: FontAwesome;
+    padding-left: 5px;
+}

--- a/reporting/impl/src/main/resources/reports/templates/migration-issues.ftl
+++ b/reporting/impl/src/main/resources/reports/templates/migration-issues.ftl
@@ -332,7 +332,7 @@
                                         <div class="panel-body">
                                             <ul>
                                                 {{#each ../resourceLinks}}
-                                                    <li><a href="{{h}}">{{t}}</a></li>
+                                                    <li><a href="{{h}}" target="_blank">{{t}}</a></li>
                                                 {{/each}}
                                             </ul>
                                         </div>

--- a/reporting/impl/src/main/resources/reports/templates/source.ftl
+++ b/reporting/impl/src/main/resources/reports/templates/source.ftl
@@ -180,7 +180,7 @@
                                         <ul><#t>
                                             <#list hintLine.links.iterator() as link>
                                                 <li><#t>
-                                                    <a href='${link.link}'>${link.description}</a><#t>
+                                                    <a href='${link.link}' target='_blank'>${link.description}</a><#t>
                                                 </li><#t>
                                             </#list>
                                         </ul><#t>

--- a/rules-java/api/src/main/java/org/jboss/windup/rules/apps/java/reporting/freemarker/RenderLinkDirective.java
+++ b/rules-java/api/src/main/java/org/jboss/windup/rules/apps/java/reporting/freemarker/RenderLinkDirective.java
@@ -300,7 +300,7 @@ public class RenderLinkDirective implements WindupFreeMarkerTemplateDirective
     {
         writer.append("<a href='").append(link.getLink());
         appendProject(writer, project);
-        writer.append("'>");
+        writer.append("' target='_blank'>");
         writer.append(link.getDescription());
         writer.append("</a>");
     }


### PR DESCRIPTION
- created `ToHtmlSerializerExtended` class to override `org.pegdown.ToHtmlSerializer.printLink(LinkRenderer.Rendering rendering)` method to always add the `target='_blank'` attribute to markdown defined links
- add `target='_blank'` attribute to links in hints in Migration Issues Report and Source Report (both in code snippet and in categories header) 
- add CSS directive to use Font Awesome (font file already in project)
- add external-link icon from Font Awesome after every link with `target='_blank'` attribute defined

You can see the result in next screenshots:
- Migration Issues Report
![20170505migrationissuesreport](https://cloud.githubusercontent.com/assets/7288588/25741381/d50485ba-318a-11e7-8cf8-f3fc6e9b1365.png)
- Source Report (code snippet) 
![20170505sourcereport_codesnippet](https://cloud.githubusercontent.com/assets/7288588/25741391/e57c72b8-318a-11e7-9ef1-85db7a937b71.png)
- Source Report (categories header)
![20170505sourcereport_categoriesheader](https://cloud.githubusercontent.com/assets/7288588/25741395/e9266bf8-318a-11e7-9a99-1e8f388c8a31.png)


PS: source.ftl is highlighted all in red all around the line changes but `git diff` locally doesn't show all that changes. Maybe some wrong formatting between spaces and tabs?