### PR TITLE
T874 Add black brand bar at the top - T875Remove main logo

### DIFF
--- a/reporting/impl/src/main/resources/reports/resources/css/windup.css
+++ b/reporting/impl/src/main/resources/reports/resources/css/windup.css
@@ -6,7 +6,7 @@
 
 
 body {
-  padding-top: 45px;
+  padding-top: 105px;
   padding-bottom: 30px;
 }
 
@@ -338,4 +338,23 @@ strong {
 
 div.indent{
     padding-left: 20px;
+}
+
+div.wu-navbar-header {
+    width:100%;
+    background-color: #030303;
+}
+
+span.wu-navbar-header {
+    font-size: 18px;
+    line-height: 60px;
+    color: #d1d1d1;
+    height: 60px;
+    padding-left: 30px;
+    font-weight: normal;
+}
+
+strong.wu-navbar-header {
+    text-transform: uppercase;
+    font-size: 18px;
 }

--- a/reporting/impl/src/main/resources/reports/templates/application_list.ftl
+++ b/reporting/impl/src/main/resources/reports/templates/application_list.ftl
@@ -147,12 +147,8 @@
 
     <!-- Navbar -->
     <div id="main-navbar" class="navbar navbar-default navbar-fixed-top">
-        <div class="navbar-header">
-            <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-responsive-collapse">
-                <span class="icon-bar"></span>
-                <span class="icon-bar"></span>
-                <span class="icon-bar"></span>
-            </button>
+        <div class="wu-navbar-header navbar-header">
+            <#include "include/navheader.ftl">
         </div>
 
         <#if applicationReportIndexModel??>
@@ -165,13 +161,6 @@
 
 
     <div class="container-fluid" role="main">
-        <div class="row">
-            <div class="windup-bar" role="navigation" style="text-align: left;">
-                <div class="container theme-showcase" style="margin-left: 0px;" role="main">
-                    <img src="reports/resources/img/rhamt-logo-gray.svg" class="logo" height="100" width="420"/>
-                </div>
-            </div>
-        </div>
 
         <div class="row">
             <div class="page-header">

--- a/reporting/impl/src/main/resources/reports/templates/classloader.ftl
+++ b/reporting/impl/src/main/resources/reports/templates/classloader.ftl
@@ -27,12 +27,8 @@
                 </div>
 
                 <div class="navbar navbar-default">
-                <div class="navbar-header">
-                    <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-responsive-collapse">
-                        <span class="icon-bar"></span>
-                        <span class="icon-bar"></span>
-                        <span class="icon-bar"></span>
-                    </button>
+                <div class="wu-navbar-header navbar-header">
+                    <#include "include/navheader.ftl">
                 </div>
                 <div class="navbar-collapse collapse navbar-responsive-collapse">
                     <ul class="nav navbar-nav">
@@ -75,7 +71,7 @@
                         <tr>${reference.referenceType}<td></td><td>${reference.clzName}</td></tr>
                     </#items>
                 </table>
-                </#if>
+                </#list>
               </td>
             </tr>
             </#items>

--- a/reporting/impl/src/main/resources/reports/templates/embedded.ftl
+++ b/reporting/impl/src/main/resources/reports/templates/embedded.ftl
@@ -15,12 +15,8 @@
 
     <!-- Navbar -->
     <div id="main-navbar" class="navbar navbar-default navbar-fixed-top">
-        <div class="navbar-header">
-            <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-responsive-collapse">
-                <span class="icon-bar"></span>
-                <span class="icon-bar"></span>
-                <span class="icon-bar"></span>
-            </button>
+        <div class="wu-navbar-header navbar-header">
+            <#include "include/navheader.ftl">
         </div>
         <div class="navbar-collapse collapse navbar-responsive-collapse">
             <#include "include/navbar.ftl">

--- a/reporting/impl/src/main/resources/reports/templates/include/navheader.ftl
+++ b/reporting/impl/src/main/resources/reports/templates/include/navheader.ftl
@@ -1,0 +1,9 @@
+            <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-responsive-collapse">
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+            </button>
+            <span class="wu-navbar-header">
+              <strong class="wu-navbar-header">Red Hat Application Migration Toolkit</strong>
+               - Web Console 
+            </span>

--- a/reporting/impl/src/main/resources/reports/templates/include/navheader.ftl
+++ b/reporting/impl/src/main/resources/reports/templates/include/navheader.ftl
@@ -5,5 +5,4 @@
             </button>
             <span class="wu-navbar-header">
               <strong class="wu-navbar-header">Red Hat Application Migration Toolkit</strong>
-               - Web Console 
             </span>

--- a/reporting/impl/src/main/resources/reports/templates/migration-issues.ftl
+++ b/reporting/impl/src/main/resources/reports/templates/migration-issues.ftl
@@ -89,13 +89,9 @@
     <body role="document">
         <!-- Navbar -->
         <div id="main-navbar" class="navbar navbar-default navbar-fixed-top">
-            <div class="navbar-header">
-                <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-responsive-collapse">
-                    <span class="icon-bar"></span>
-                    <span class="icon-bar"></span>
-                    <span class="icon-bar"></span>
-                </button>
-            </div>
+        <div class="wu-navbar-header navbar-header">
+            <#include "include/navheader.ftl">
+        </div>
 
             <#if applicationReportIndexModel??>
                 <div class="navbar-collapse collapse navbar-responsive-collapse">

--- a/reporting/impl/src/main/resources/reports/templates/ruleprovidersummary.ftl
+++ b/reporting/impl/src/main/resources/reports/templates/ruleprovidersummary.ftl
@@ -13,12 +13,8 @@
 <body role="document">
 
     <div id="main-navbar" class="navbar navbar-default navbar-fixed-top">
-        <div class="navbar-header">
-            <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-responsive-collapse">
-                <span class="icon-bar"></span>
-                <span class="icon-bar"></span>
-                <span class="icon-bar"></span>
-            </button>
+        <div class="wu-navbar-header navbar-header">
+            <#include "include/navheader.ftl">
         </div>
         <div class="navbar-collapse collapse navbar-responsive-collapse">
             <ul class="nav navbar-nav">
@@ -119,5 +115,6 @@
     <script src="resources/libraries/flot/jquery.flot.pie.min.js"></script>
 
     <script src="resources/js/bootstrap.min.js"></script>
+    <script type="text/javascript" src="resources/js/navbar.js"></script>
 </body>
 </html>

--- a/reporting/impl/src/main/resources/reports/templates/source.ftl
+++ b/reporting/impl/src/main/resources/reports/templates/source.ftl
@@ -15,12 +15,8 @@
 <body role="document" class="source-report">
 
     <div class="navbar navbar-default navbar-fixed-top" id="main-navbar" style="display: none">
-        <div class="navbar-header">
-            <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-responsive-collapse">
-                <span class="icon-bar"></span>
-                <span class="icon-bar"></span>
-                <span class="icon-bar"></span>
-            </button>
+        <div class="wu-navbar-header navbar-header">
+            <#include "include/navheader.ftl">
         </div>
 
         <#include "include/navbar_macro.ftl">

--- a/reporting/impl/src/main/resources/reports/templates/windupfreemarkerfunctions.ftl
+++ b/reporting/impl/src/main/resources/reports/templates/windupfreemarkerfunctions.ftl
@@ -13,12 +13,8 @@
 <body role="document">
 
     <div id="main-navbar" class="navbar navbar-default navbar-fixed-top">
-        <div class="navbar-header">
-            <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-responsive-collapse">
-                <span class="icon-bar"></span>
-                <span class="icon-bar"></span>
-                <span class="icon-bar"></span>
-            </button>
+        <div class="wu-navbar-header navbar-header">
+            <#include "include/navheader.ftl">
         </div>
         <div class="navbar-collapse collapse navbar-responsive-collapse">
             <ul class="nav navbar-nav">
@@ -89,5 +85,6 @@
     <script src="resources/libraries/flot/jquery.flot.pie.min.js"></script>
 
     <script src="resources/js/bootstrap.min.js"></script>
+    <script type="text/javascript" src="resources/js/navbar.js"></script>
 </body>
 </html>

--- a/rules-java-ee/addon/src/main/resources/reports/templates/ejb.ftl
+++ b/rules-java-ee/addon/src/main/resources/reports/templates/ejb.ftl
@@ -66,12 +66,8 @@
 
 
     <div id="main-navbar" class="navbar navbar-default navbar-fixed-top">
-        <div class="navbar-header">
-            <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-responsive-collapse">
-                <span class="icon-bar"></span>
-                <span class="icon-bar"></span>
-                <span class="icon-bar"></span>
-            </button>
+        <div class="wu-navbar-header navbar-header">
+            <#include "include/navheader.ftl">
         </div>
         <div class="navbar-collapse collapse navbar-responsive-collapse">
             <#include "include/navbar.ftl">

--- a/rules-java-ee/addon/src/main/resources/reports/templates/hibernate.ftl
+++ b/rules-java-ee/addon/src/main/resources/reports/templates/hibernate.ftl
@@ -15,12 +15,8 @@
 
     <!-- Navbar -->
     <div id="main-navbar" class="navbar navbar-default navbar-fixed-top">
-        <div class="navbar-header">
-            <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-responsive-collapse">
-                <span class="icon-bar"></span>
-                <span class="icon-bar"></span>
-                <span class="icon-bar"></span>
-            </button>
+        <div class="wu-navbar-header navbar-header">
+            <#include "include/navheader.ftl">
         </div>
         <div class="navbar-collapse collapse navbar-responsive-collapse">
             <#include "include/navbar.ftl">

--- a/rules-java-ee/addon/src/main/resources/reports/templates/jbpm.ftl
+++ b/rules-java-ee/addon/src/main/resources/reports/templates/jbpm.ftl
@@ -17,12 +17,8 @@
 
     <!-- Navbar -->
     <div id="main-navbar" class="navbar navbar-default navbar-fixed-top">
-        <div class="navbar-header">
-            <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-responsive-collapse">
-                <span class="icon-bar"></span>
-                <span class="icon-bar"></span>
-                <span class="icon-bar"></span>
-            </button>
+        <div class="wu-navbar-header navbar-header">
+            <#include "include/navheader.ftl">
         </div>
         <div class="navbar-collapse collapse navbar-responsive-collapse">
             <#include "include/navbar.ftl">

--- a/rules-java-ee/addon/src/main/resources/reports/templates/jpa.ftl
+++ b/rules-java-ee/addon/src/main/resources/reports/templates/jpa.ftl
@@ -15,12 +15,8 @@
 
     <!-- Navbar -->
     <div id="main-navbar" class="navbar navbar-default navbar-fixed-top">
-        <div class="navbar-header">
-            <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-responsive-collapse">
-                <span class="icon-bar"></span>
-                <span class="icon-bar"></span>
-                <span class="icon-bar"></span>
-            </button>
+        <div class="wu-navbar-header navbar-header">
+            <#include "include/navheader.ftl">
         </div>
         <div class="navbar-collapse collapse navbar-responsive-collapse">
             <#include "include/navbar.ftl">

--- a/rules-java-ee/addon/src/main/resources/reports/templates/remote.ftl
+++ b/rules-java-ee/addon/src/main/resources/reports/templates/remote.ftl
@@ -15,12 +15,8 @@
 
     <!-- Navbar -->
     <div id="main-navbar" class="navbar navbar-default navbar-fixed-top">
-        <div class="navbar-header">
-            <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-responsive-collapse">
-                <span class="icon-bar"></span>
-                <span class="icon-bar"></span>
-                <span class="icon-bar"></span>
-            </button>
+        <div class="wu-navbar-header navbar-header">
+            <#include "include/navheader.ftl">
         </div>
         <div class="navbar-collapse collapse navbar-responsive-collapse">
             <#include "include/navbar.ftl">

--- a/rules-java-ee/addon/src/main/resources/reports/templates/server.ftl
+++ b/rules-java-ee/addon/src/main/resources/reports/templates/server.ftl
@@ -15,12 +15,8 @@
 
     <!-- Navbar -->
     <div id="main-navbar" class="navbar navbar-default navbar-fixed-top">
-        <div class="navbar-header">
-            <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-responsive-collapse">
-                <span class="icon-bar"></span>
-                <span class="icon-bar"></span>
-                <span class="icon-bar"></span>
-            </button>
+        <div class="wu-navbar-header navbar-header">
+            <#include "include/navheader.ftl">
         </div>
         <div class="navbar-collapse collapse navbar-responsive-collapse">
             <#include "include/navbar.ftl">

--- a/rules-java-ee/addon/src/main/resources/reports/templates/spring.ftl
+++ b/rules-java-ee/addon/src/main/resources/reports/templates/spring.ftl
@@ -15,12 +15,8 @@
 
     <!-- Navbar -->
     <div id="main-navbar" class="navbar navbar-default navbar-fixed-top">
-        <div class="navbar-header">
-            <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-responsive-collapse">
-                <span class="icon-bar"></span>
-                <span class="icon-bar"></span>
-                <span class="icon-bar"></span>
-            </button>
+        <div class="wu-navbar-header navbar-header">
+            <#include "include/navheader.ftl">
         </div>
         <div class="navbar-collapse collapse navbar-responsive-collapse">
             <#include "include/navbar.ftl">

--- a/rules-java/api/src/main/resources/reports/templates/about_windup.ftl
+++ b/rules-java/api/src/main/resources/reports/templates/about_windup.ftl
@@ -21,13 +21,9 @@
 <body role="document">
 
     <!-- Navbar -->
-    <div class="navbar navbar-default navbar-fixed-top">
-        <div class="navbar-header">
-            <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-responsive-collapse">
-                <span class="icon-bar"></span>
-                <span class="icon-bar"></span>
-                <span class="icon-bar"></span>
-            </button>
+    <div id="main-navbar" class="navbar navbar-default navbar-fixed-top">
+        <div class="wu-navbar-header navbar-header">
+            <#include "include/navheader.ftl">
         </div>
         <div class="navbar-collapse collapse navbar-responsive-collapse">
             <#include "include/navbar.ftl">

--- a/rules-java/api/src/main/resources/reports/templates/compatible_files.ftl
+++ b/rules-java/api/src/main/resources/reports/templates/compatible_files.ftl
@@ -82,12 +82,8 @@
 
     <!-- Navbar -->
     <div id="main-navbar" class="navbar navbar-default navbar-fixed-top">
-        <div class="navbar-header">
-            <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-responsive-collapse">
-                <span class="icon-bar"></span>
-                <span class="icon-bar"></span>
-                <span class="icon-bar"></span>
-            </button>
+        <div class="wu-navbar-header navbar-header">
+            <#include "include/navheader.ftl">
         </div>
 
         <div class="navbar-collapse collapse navbar-responsive-collapse">

--- a/rules-java/api/src/main/resources/reports/templates/dependency_report.ftl
+++ b/rules-java/api/src/main/resources/reports/templates/dependency_report.ftl
@@ -26,12 +26,8 @@
 
     <!-- Navbar -->
     <div id="main-navbar" class="navbar navbar-default navbar-fixed-top">
-        <div class="navbar-header">
-            <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-responsive-collapse">
-                <span class="icon-bar"></span>
-                <span class="icon-bar"></span>
-                <span class="icon-bar"></span>
-            </button>
+        <div class="wu-navbar-header navbar-header">
+            <#include "include/navheader.ftl">
         </div>
         <div class="navbar-collapse collapse navbar-responsive-collapse">
             <#include "include/navbar.ftl">

--- a/rules-java/api/src/main/resources/reports/templates/hardcoded_ip_addresses.ftl
+++ b/rules-java/api/src/main/resources/reports/templates/hardcoded_ip_addresses.ftl
@@ -48,12 +48,8 @@
 
     <!-- Navbar -->
     <div id="main-navbar" class="navbar navbar-default navbar-fixed-top">
-        <div class="navbar-header">
-            <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-responsive-collapse">
-                <span class="icon-bar"></span>
-                <span class="icon-bar"></span>
-                <span class="icon-bar"></span>
-            </button>
+        <div class="wu-navbar-header navbar-header">
+            <#include "include/navheader.ftl">
         </div>
         <div class="navbar-collapse collapse navbar-responsive-collapse">
             <#include "include/navbar.ftl">

--- a/rules-java/api/src/main/resources/reports/templates/ignored_files.ftl
+++ b/rules-java/api/src/main/resources/reports/templates/ignored_files.ftl
@@ -67,12 +67,8 @@
 
     <!-- Navbar -->
     <div id="main-navbar" class="navbar navbar-default navbar-fixed-top">
-        <div class="navbar-header">
-            <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-responsive-collapse">
-                <span class="icon-bar"></span>
-                <span class="icon-bar"></span>
-                <span class="icon-bar"></span>
-            </button>
+        <div class="wu-navbar-header navbar-header">
+            <#include "include/navheader.ftl">
         </div>
         <div class="navbar-collapse collapse navbar-responsive-collapse">
             <#include "include/navbar.ftl">

--- a/rules-java/api/src/main/resources/reports/templates/java_application.ftl
+++ b/rules-java/api/src/main/resources/reports/templates/java_application.ftl
@@ -302,12 +302,8 @@
 
     <!-- Navbar -->
     <div id="main-navbar" class="navbar navbar-default navbar-fixed-top">
-        <div class="navbar-header">
-            <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-responsive-collapse">
-                <span class="icon-bar"></span>
-                <span class="icon-bar"></span>
-                <span class="icon-bar"></span>
-            </button>
+        <div class="wu-navbar-header navbar-header">
+            <#include "include/navheader.ftl">
         </div>
 
         <div class="navbar-collapse collapse navbar-responsive-collapse">

--- a/rules-java/api/src/main/resources/reports/templates/report_index.ftl
+++ b/rules-java/api/src/main/resources/reports/templates/report_index.ftl
@@ -28,12 +28,8 @@
 
     <!-- Navbar -->
     <div id="main-navbar" class="navbar navbar-default navbar-fixed-top">
-        <div class="navbar-header">
-            <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-responsive-collapse">
-                <span class="icon-bar"></span>
-                <span class="icon-bar"></span>
-                <span class="icon-bar"></span>
-            </button>
+        <div class="wu-navbar-header navbar-header">
+            <#include "include/navheader.ftl">
         </div>
 
         <div class="navbar-collapse collapse navbar-responsive-collapse">

--- a/rules-java/api/src/main/resources/reports/templates/unparsable_files.ftl
+++ b/rules-java/api/src/main/resources/reports/templates/unparsable_files.ftl
@@ -57,12 +57,8 @@
 
 	<!-- Navbar -->
 	<div id="main-navbar" class="navbar navbar-default navbar-fixed-top">
-        <div class="navbar-header">
-            <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-responsive-collapse">
-                <span class="icon-bar"></span>
-                <span class="icon-bar"></span>
-                <span class="icon-bar"></span>
-            </button>
+        <div class="wu-navbar-header navbar-header">
+            <#include "include/navheader.ftl">
         </div>
         <div class="navbar-collapse collapse navbar-responsive-collapse">
             <#include "include/navbar.ftl">


### PR DESCRIPTION
- create new component `navheader.ftl` 
- add style for components of the brand bar (`class="wu-navbar-header"`)
- change all the pages to included the `navheader.ftl` component with the brand bar
- add link to `navbar.js` in pages where it was missing to be sure that `div id="main-navbar"` is rightly positioned (`about_windup.ftl, ruleprovidersummary.ftl, windupfreemarkerfunctions.ftl`)
- remove main logo (task#875)
- fixed a closing tag in https://github.com/windup/windup/blob/master/reporting/impl/src/main/resources/reports/templates/classloader.ftl#L78