### PR TITLE
T921 Support *.rhamt.xml files

### DIFF
--- a/config-groovy/addon/src/main/java/org/jboss/windup/ext/groovy/GroovyWindupRuleProviderLoader.java
+++ b/config-groovy/addon/src/main/java/org/jboss/windup/ext/groovy/GroovyWindupRuleProviderLoader.java
@@ -41,8 +41,9 @@ import org.jboss.windup.util.exception.WindupException;
 import org.jboss.windup.util.furnace.FurnaceClasspathScanner;
 
 /**
- * Loads files with the specified extension (specified in {@link GroovyWindupRuleProviderLoader#GROOVY_RULES_EXTENSION}
- * ), interprets them as Groovy scripts, and returns the resulting {@link AbstractRuleProvider}s.
+ * Loads files with the specified extension (specified in {@link GroovyWindupRuleProviderLoader#GROOVY_RULES_WINDUP_EXTENSION} and in
+ * {@link GroovyWindupRuleProviderLoader#GROOVY_RULES_RHAMT_EXTENSION}), interprets them as Groovy scripts, and returns the resulting
+ * {@link AbstractRuleProvider}s.
  * 
  * @author <a href="mailto:jesse.sightler@gmail.com">Jesse Sightler</a>
  *
@@ -53,7 +54,8 @@ public class GroovyWindupRuleProviderLoader implements RuleProviderLoader
 
     public static final String CURRENT_WINDUP_SCRIPT = "CURRENT_WINDUP_SCRIPT";
 
-    private static final String GROOVY_RULES_EXTENSION = "windup.groovy";
+    private static final String GROOVY_RULES_WINDUP_EXTENSION = "windup.groovy";
+    private static final String GROOVY_RULES_RHAMT_EXTENSION = "rhamt.groovy";
 
     @Inject
     private FurnaceClasspathScanner scanner;
@@ -175,8 +177,10 @@ public class GroovyWindupRuleProviderLoader implements RuleProviderLoader
     private Iterable<URL> getScripts(RuleLoaderContext ruleLoaderContext)
     {
         List<URL> results = new ArrayList<>();
-        List<URL> scripts = scanner.scan(GROOVY_RULES_EXTENSION);
-        results.addAll(scripts);
+        List<URL> windupScripts = scanner.scan(GROOVY_RULES_WINDUP_EXTENSION);
+        results.addAll(windupScripts);
+        List<URL> rhamtScripts = scanner.scan(GROOVY_RULES_RHAMT_EXTENSION);
+        results.addAll(rhamtScripts);
 
         for (Path userRulesPath : ruleLoaderContext.getRulePaths())
         {
@@ -221,7 +225,9 @@ public class GroovyWindupRuleProviderLoader implements RuleProviderLoader
         }
     }
 
-    private boolean pathMatchesNamePattern(Path file) {
-        return file.getFileName().toString().toLowerCase().endsWith("." + GROOVY_RULES_EXTENSION);
+    private boolean pathMatchesNamePattern(Path file)
+    {
+        return file.getFileName().toString().toLowerCase().endsWith("." + GROOVY_RULES_WINDUP_EXTENSION)
+                    || file.getFileName().toString().toLowerCase().endsWith("." + GROOVY_RULES_RHAMT_EXTENSION);
     }
 }

--- a/config-groovy/tests/src/test/resources/groovy/GroovyExampleRule.rhamt.groovy
+++ b/config-groovy/tests/src/test/resources/groovy/GroovyExampleRule.rhamt.groovy
@@ -1,0 +1,25 @@
+import org.jboss.windup.config.operation.GraphOperation;
+import org.jboss.windup.config.GraphRewrite;
+import org.jboss.windup.config.phase.MigrationRulesPhase;
+import org.jboss.windup.config.metadata.RuleMetadataType;
+import org.jboss.windup.config.phase.RulePhase;
+import org.jboss.windup.util.Logging;
+import org.ocpsoft.rewrite.config.True;
+import org.ocpsoft.rewrite.context.EvaluationContext;
+
+
+ruleSet("ExampleRhamtGroovyRule").setPhase(MigrationRulesPhase.class)
+
+    .addRule()
+    .when(
+        new True()
+    )
+    .perform(
+        new GraphOperation  () {
+            public void perform(GraphRewrite event, EvaluationContext context) {
+                Logging.get(this.getClass()).info("Performing rewrite operation in ExampleRhamtGroovyRule");
+            }
+        }
+    )
+    .withMetadata(RuleMetadataType.TAGS, "Basic")
+    

--- a/config-xml/addon/src/main/java/org/jboss/windup/config/parser/ParserContext.java
+++ b/config-xml/addon/src/main/java/org/jboss/windup/config/parser/ParserContext.java
@@ -213,7 +213,7 @@ public class ParserContext
     }
 
     /**
-     * The path to the rule xml file itself (eg, /path/to/rule.windup.xml).
+     * The path to the rule xml file itself (eg, /path/to/rule.windup.xml or /path/to/rule.rhamt.xml).
      */
     public void setXmlInputPath(Path xmlInputPath)
     {
@@ -221,7 +221,7 @@ public class ParserContext
     }
 
     /**
-     * The path to the rule xml file itself (eg, /path/to/rule.windup.xml).
+     * The path to the rule xml file itself (eg, /path/to/rule.windup.xml or /path/to/rule.rhamt.xml).
      */
     public Path getXmlInputPath()
     {

--- a/config-xml/addon/src/main/java/org/jboss/windup/config/parser/XMLRuleProviderLoader.java
+++ b/config-xml/addon/src/main/java/org/jboss/windup/config/parser/XMLRuleProviderLoader.java
@@ -203,7 +203,9 @@ public class XMLRuleProviderLoader implements RuleProviderLoader
         }
     }
 
-    private boolean pathMatchesNamePattern(Path file) {
-        return file.getFileName().toString().toLowerCase().endsWith("." + XML_RULES_WINDUP_EXTENSION) || file.getFileName().toString().toLowerCase().endsWith("." + XML_RULES_RHAMT_EXTENSION);
+    private boolean pathMatchesNamePattern(Path file)
+    {
+        return file.getFileName().toString().toLowerCase().endsWith("." + XML_RULES_WINDUP_EXTENSION)
+                    || file.getFileName().toString().toLowerCase().endsWith("." + XML_RULES_RHAMT_EXTENSION);
     }
 }

--- a/config-xml/addon/src/main/java/org/jboss/windup/config/parser/XMLRuleProviderLoader.java
+++ b/config-xml/addon/src/main/java/org/jboss/windup/config/parser/XMLRuleProviderLoader.java
@@ -40,7 +40,7 @@ import org.w3c.dom.Document;
 
 /**
  * This {@link RuleProviderLoader} searches for and loads {@link AbstractRuleProvider}s from XML files that within all
- * addons, with filenames that end in ".windup.xml".
+ * addons, with filenames that end in ".windup.xml" or ".rhamt.xml".
  *
  * @author <a href="mailto:lincolnbaxter@gmail.com">Lincoln Baxter, III</a>
  *
@@ -49,7 +49,8 @@ public class XMLRuleProviderLoader implements RuleProviderLoader
 {
     private static final Logger LOG = Logging.get(XMLRuleProviderLoader.class);
 
-    private static final String XML_RULES_EXTENSION = "windup.xml";
+    private static final String XML_RULES_WINDUP_EXTENSION = "windup.xml";
+    private static final String XML_RULES_RHAMT_EXTENSION = "rhamt.xml";
 
     @Inject
     private Furnace furnace;
@@ -154,7 +155,9 @@ public class XMLRuleProviderLoader implements RuleProviderLoader
 
     private Map<Addon, List<URL>> getAddonWindupXmlFiles()
     {
-        return scanner.scanForAddonMap(new FileExtensionFilter(XML_RULES_EXTENSION));
+        Map<Addon, List<URL>> addon = scanner.scanForAddonMap(new FileExtensionFilter(XML_RULES_WINDUP_EXTENSION));
+        addon.putAll(scanner.scanForAddonMap(new FileExtensionFilter(XML_RULES_RHAMT_EXTENSION)));
+        return addon;
     }
 
     private Collection<URL> getWindupUserDirectoryXmlFiles(Path userRulesPath)
@@ -201,6 +204,6 @@ public class XMLRuleProviderLoader implements RuleProviderLoader
     }
 
     private boolean pathMatchesNamePattern(Path file) {
-        return file.getFileName().toString().toLowerCase().endsWith("." + XML_RULES_EXTENSION);
+        return file.getFileName().toString().toLowerCase().endsWith("." + XML_RULES_WINDUP_EXTENSION) || file.getFileName().toString().toLowerCase().endsWith("." + XML_RULES_RHAMT_EXTENSION);
     }
 }

--- a/config-xml/tests/src/test/java/org/jboss/windup/config/metadata/MetaDataHandlerTest.java
+++ b/config-xml/tests/src/test/java/org/jboss/windup/config/metadata/MetaDataHandlerTest.java
@@ -34,8 +34,10 @@ import org.w3c.dom.Document;
 public class MetaDataHandlerTest
 {
 
-    private static final String XML_FILE = "src/test/resources/testxml/metadata.windup.xml";
-    private static final String XML_WITH_OVERRIDE_FILE = "src/test/resources/testxml/metadata.override.windup.xml";
+    private static final String XML_WINDUP_FILE = "src/test/resources/testxml/metadata.windup.xml";
+    private static final String XML_WINDUP_WITH_OVERRIDE_FILE = "src/test/resources/testxml/metadata.override.windup.xml";
+    private static final String XML_RHAMT_FILE = "src/test/resources/testxml/metadata.rhamt.xml";
+    private static final String XML_RHAMT_WITH_OVERRIDE_FILE = "src/test/resources/testxml/metadata.override.rhamt.xml";
 
     @Deployment
     @AddonDependencies({
@@ -55,9 +57,21 @@ public class MetaDataHandlerTest
     private GraphContextFactory graphContextFactory;
 
     @Test
-    public void testXmlParsinfOfRulesetMetadata() throws Exception
+    public void testWindupXmlParsinfOfRulesetMetadata() throws Exception
     {
-        File fXmlFile = new File(XML_FILE);
+        File fXmlFile = new File(XML_WINDUP_FILE);
+        testXmlParsinfOfRulesetMetadata(fXmlFile);
+    }
+
+    @Test
+    public void testRhamtXmlParsinfOfRulesetMetadata() throws Exception
+    {
+        File fXmlFile = new File(XML_RHAMT_FILE);
+        testXmlParsinfOfRulesetMetadata(fXmlFile);
+    }
+
+    private void testXmlParsinfOfRulesetMetadata(File fXmlFile) throws Exception
+    {
         RuleLoaderContext loaderContext = new RuleLoaderContext(Collections.singleton(fXmlFile.toPath()), null);
         ParserContext parser = new ParserContext(furnace, loaderContext);
         DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
@@ -99,9 +113,21 @@ public class MetaDataHandlerTest
     }
 
     @Test
-    public void testXmlRuleOverrideProviderMetadata() throws Exception
+    public void testWindupXmlRuleOverrideProviderMetadata() throws Exception
     {
-        File fXmlFile = new File(XML_WITH_OVERRIDE_FILE);
+        File fXmlFile = new File(XML_WINDUP_WITH_OVERRIDE_FILE);
+        testXmlRuleOverrideProviderMetadata(fXmlFile);
+    }
+
+    @Test
+    public void testRhamtXmlRuleOverrideProviderMetadata() throws Exception
+    {
+        File fXmlFile = new File(XML_RHAMT_WITH_OVERRIDE_FILE);
+        testXmlRuleOverrideProviderMetadata(fXmlFile);
+    }
+
+    public void testXmlRuleOverrideProviderMetadata(File fXmlFile) throws Exception
+    {
         RuleLoaderContext loaderContext = new RuleLoaderContext(Collections.singleton(fXmlFile.toPath()), null);
         ParserContext parser = new ParserContext(furnace, loaderContext);
         DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();

--- a/config-xml/tests/src/test/java/org/jboss/windup/config/parser/XMLRuleProviderLoaderTest.java
+++ b/config-xml/tests/src/test/java/org/jboss/windup/config/parser/XMLRuleProviderLoaderTest.java
@@ -46,7 +46,7 @@ public class XMLRuleProviderLoaderTest
     })
     public static AddonArchive getDeployment()
     {
-        return  ShrinkWrap.create(AddonArchive.class)
+        return ShrinkWrap.create(AddonArchive.class)
                     .addBeansXML()
                     .addAsResource(new File("src/test/resources/testxml/Test1.windup.xml"));
     }
@@ -54,7 +54,7 @@ public class XMLRuleProviderLoaderTest
     @Deployment(name = "rhamt,1")
     public static AddonArchive getRhamtDeployment()
     {
-        return  ShrinkWrap.create(AddonArchive.class)
+        return ShrinkWrap.create(AddonArchive.class)
                     .addBeansXML()
                     .addAsResource(new File("src/test/resources/testxml/Test2.rhamt.xml"));
     }

--- a/config-xml/tests/src/test/java/org/jboss/windup/config/parser/XMLRuleProviderLoaderTest.java
+++ b/config-xml/tests/src/test/java/org/jboss/windup/config/parser/XMLRuleProviderLoaderTest.java
@@ -13,8 +13,10 @@ import org.jboss.forge.arquillian.AddonDependency;
 import org.jboss.forge.arquillian.archive.AddonArchive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.windup.config.RuleProvider;
+import org.jboss.windup.config.builder.RuleProviderBuilder;
 import org.jboss.windup.config.loader.RuleLoaderContext;
 import org.jboss.windup.config.phase.DiscoveryPhase;
+import org.jboss.windup.config.phase.ReportGenerationPhase;
 import org.jboss.windup.graph.GraphContextFactory;
 import org.junit.Assert;
 import org.junit.Test;
@@ -44,9 +46,17 @@ public class XMLRuleProviderLoaderTest
     })
     public static AddonArchive getDeployment()
     {
-        return ShrinkWrap.create(AddonArchive.class)
+        return  ShrinkWrap.create(AddonArchive.class)
                     .addBeansXML()
                     .addAsResource(new File("src/test/resources/testxml/Test1.windup.xml"));
+    }
+
+    @Deployment(name = "rhamt,1")
+    public static AddonArchive getRhamtDeployment()
+    {
+        return  ShrinkWrap.create(AddonArchive.class)
+                    .addBeansXML()
+                    .addAsResource(new File("src/test/resources/testxml/Test2.rhamt.xml"));
     }
 
     @Inject
@@ -62,13 +72,10 @@ public class XMLRuleProviderLoaderTest
         RuleLoaderContext ruleLoaderContext = new RuleLoaderContext();
         List<RuleProvider> providers = loader.getProviders(ruleLoaderContext);
         Assert.assertNotNull(providers);
-        Assert.assertTrue(providers.size() == 1);
+        Assert.assertTrue(providers.size() == 2);
 
-        RuleProvider provider = providers.get(0);
-        String id = provider.getMetadata().getID();
-        Assert.assertEquals("testruleprovider", id);
-        Assert.assertEquals(DiscoveryPhase.class, provider.getMetadata().getPhase());
-        Assert.assertTrue(provider.getMetadata().getOrigin().matches("jar:file:.*/DEFAULT.*/Test1.windup.xml"));
+        RuleProvider provider = providers.get(providers.indexOf(RuleProviderBuilder.begin("testruleprovider")));
+        checkWindupMetadata(provider);
         List<Rule> rules = provider.getConfiguration(null).getRules();
         Assert.assertEquals(4, rules.size());
 
@@ -83,7 +90,40 @@ public class XMLRuleProviderLoaderTest
 
         RuleBuilder rule3 = (RuleBuilder) rules.get(3);
         checkRule3(rule3);
+
+        provider = providers.get(providers.indexOf(RuleProviderBuilder.begin("testruleprovider2")));
+        checkRhamtMetadata(provider);
+        rules = provider.getConfiguration(null).getRules();
+        Assert.assertEquals(4, rules.size());
+
+        RuleBuilder rule = (RuleBuilder) rules.get(0);
+        checkRule1(rule);
+
+        rule = (RuleBuilder) rules.get(1);
+        checkRule2(rule);
+
+        rule = (RuleBuilder) rules.get(2);
+        checkRule2_Otherwise(rule);
+
+        rule = (RuleBuilder) rules.get(3);
+        checkRule3(rule);
     }
+
+    private void checkWindupMetadata(RuleProvider provider)
+    {
+        String id = provider.getMetadata().getID();
+        Assert.assertEquals("testruleprovider", id);
+        Assert.assertEquals(DiscoveryPhase.class, provider.getMetadata().getPhase());
+        Assert.assertTrue(provider.getMetadata().getOrigin().matches("jar:file:.*/DEFAULT.*/Test1.windup.xml"));
+     }
+
+    private void checkRhamtMetadata(RuleProvider provider)
+    {
+        String id = provider.getMetadata().getID();
+        Assert.assertEquals("testruleprovider2", id);
+        Assert.assertEquals(ReportGenerationPhase.class, provider.getMetadata().getPhase());
+        Assert.assertTrue(provider.getMetadata().getOrigin().matches("jar:file:.*/rhamt-1.*/Test2.rhamt.xml"));
+     }
 
     private void checkRule1(RuleBuilder rule)
     {

--- a/config-xml/tests/src/test/resources/testxml/Test2.rhamt.xml
+++ b/config-xml/tests/src/test/resources/testxml/Test2.rhamt.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0"?>
+<ruleset xmlns="http://windup.jboss.org/schema/jboss-ruleset" id="testruleprovider2" phase="ReportGenerationPhase">
+
+    <!-- This defaults to MIGRATION_RULES, set a non-default value for test purposes -->
+
+    <rules>
+
+        <rule>
+            <when>
+                <true/>
+            </when>
+            <perform>
+                <log message="test log message"/>
+            </perform>
+        </rule>
+
+        <rule>
+            <when>
+                <true/>
+            </when>
+            <perform>
+                <iteration>
+                    <when>
+                        <true/>
+                    </when>
+                    <perform>
+                        <log message="test {foo} iteration perform"/>
+                    </perform>
+                    <otherwise>
+                        <log message="test {foo} iteration otherwise"/>
+                    </otherwise>
+                </iteration>
+            </perform>
+            <otherwise>
+                <log message="test rule {foo} otherwise"/>
+            </otherwise>
+            <where param="foo">
+                <matches pattern="\d+"/>
+            </where>
+        </rule>
+        
+        <rule id="withNested">
+            <when><true/></when>
+            <perform>
+                <log message="mainperform"/>
+                <rule>
+                    <when><true/></when>
+                    <perform>
+                        <log message="subsetperform"/>
+                    </perform>
+                </rule>
+            </perform>
+        </rule>
+
+    </rules>
+</ruleset>

--- a/config-xml/tests/src/test/resources/testxml/metadata.override.rhamt.xml
+++ b/config-xml/tests/src/test/resources/testxml/metadata.override.rhamt.xml
@@ -1,0 +1,51 @@
+<ruleset xmlns="http://windup.jboss.org/schema/jboss-ruleset" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="
+        http://windup.jboss.org/schema/jboss-ruleset http://windup.jboss.org/schema/jboss-ruleset/windup-jboss-ruleset.xsd"
+         id="WLS_10_12_TO_EAP_6" phase="testPhase">
+
+    <metadata>
+        <dependencies>
+            <addon id="org.jboss.windup.rules,windup-rules-javaee,2.0.1.Final" />
+            <addon id="org.jboss.windup.rules,windup-rules-java,2.0.0.Final" />
+        </dependencies>
+        <sourceTechnology id="weblogic" versionRange="(10,12]" />
+        <sourceTechnology id="ejb" versionRange="(2,3]" />
+        <sourceTechnology id="servlet"/>
+        <targetTechnology id="eap" versionRange="(5,6]" />
+        <targetTechnology id="ejb" versionRange="(2,3]" />
+        <targetTechnology id="jsp"/>
+        <phase>PostMigrationRulesPhase</phase>
+        <executeAfter>AfterId</executeAfter>
+        <executeBefore>BeforeId</executeBefore>
+        <overrideRules>true</overrideRules>
+        <tag>require-stateless</tag>
+        <tag>require-nofilesystem-io</tag>
+    </metadata>
+
+    <rules>
+        <rule>
+            <when>
+                <true />
+            </when>
+            <perform>
+                <iteration>
+                    <when>
+                        <true />
+                    </when>
+                    <perform>
+                        <log message="test {foo} iteration perform" />
+                    </perform>
+                    <otherwise>
+                        <log message="test {foo} iteration otherwise" />
+                    </otherwise>
+                </iteration>
+            </perform>
+            <otherwise>
+                <log message="test rule {foo} otherwise" />
+            </otherwise>
+            <where param="foo">
+                <matches pattern="\d+" />
+            </where>
+        </rule>
+    </rules>
+</ruleset>

--- a/config-xml/tests/src/test/resources/testxml/metadata.rhamt.xml
+++ b/config-xml/tests/src/test/resources/testxml/metadata.rhamt.xml
@@ -1,0 +1,50 @@
+<ruleset xmlns="http://windup.jboss.org/schema/jboss-ruleset" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="
+        http://windup.jboss.org/schema/jboss-ruleset http://windup.jboss.org/schema/jboss-ruleset/windup-jboss-ruleset.xsd"
+    id="WLS_10_12_TO_EAP_6" phase="testPhase">
+
+    <metadata>
+        <dependencies>
+            <addon id="org.jboss.windup.rules,windup-rules-javaee,2.0.1.Final" />
+            <addon id="org.jboss.windup.rules,windup-rules-java,2.0.0.Final" />
+        </dependencies>
+        <sourceTechnology id="weblogic" versionRange="(10,12]" />
+        <sourceTechnology id="ejb" versionRange="(2,3]" />
+        <sourceTechnology id="servlet"/>
+        <targetTechnology id="eap" versionRange="(5,6]" />
+        <targetTechnology id="ejb" versionRange="(2,3]" />
+        <targetTechnology id="jsp"/>
+        <phase>PostMigrationRulesPhase</phase>
+        <executeAfter>AfterId</executeAfter>
+        <executeBefore>BeforeId</executeBefore>
+        <tag>require-stateless</tag>
+        <tag>require-nofilesystem-io</tag>
+    </metadata>
+
+    <rules>
+        <rule>
+            <when>
+                <true />
+            </when>
+            <perform>
+                <iteration>
+                    <when>
+                        <true />
+                    </when>
+                    <perform>
+                        <log message="test {foo} iteration perform" />
+                    </perform>
+                    <otherwise>
+                        <log message="test {foo} iteration otherwise" />
+                    </otherwise>
+                </iteration>
+            </perform>
+            <otherwise>
+                <log message="test rule {foo} otherwise" />
+            </otherwise>
+            <where param="foo">
+                <matches pattern="\d+" />
+            </where>
+        </rule>
+    </rules>
+</ruleset>

--- a/exec/api/src/main/java/org/jboss/windup/exec/configuration/options/UserRulesDirectoryOption.java
+++ b/exec/api/src/main/java/org/jboss/windup/exec/configuration/options/UserRulesDirectoryOption.java
@@ -33,7 +33,7 @@ public class UserRulesDirectoryOption extends AbstractPathConfigurationOption
     @Override
     public String getDescription()
     {
-        return "User Rules Directory (Search pattern: *.windup.groovy and *.windup.xml).";
+        return "User Rules Directory (Search pattern: *.windup.groovy, *.windup.xml, *.rhamt.groovy and *.rhamt.xml).";
     }
 
     @Override

--- a/reporting/impl/src/main/resources/reports/templates/ruleprovidersummary.ftl
+++ b/reporting/impl/src/main/resources/reports/templates/ruleprovidersummary.ftl
@@ -38,7 +38,7 @@
                 </h1>
                 <div class="desc">
                     This report lists "rule providers", or sets of ${getWindupBrandName()} rules.
-                    They may originate from a <code>.windup.xml</code> file
+                    They may originate from a <code>.windup.xml</code> or <code>.rhamt.xml</code> file
                     or a Java class implementing <code>RuleProvider</code>.
                 </div>
             </div>

--- a/reporting/tests/src/test/java/org/jboss/windup/reporting/handlers/ClassificationHandlerTest.java
+++ b/reporting/tests/src/test/java/org/jboss/windup/reporting/handlers/ClassificationHandlerTest.java
@@ -33,7 +33,8 @@ import org.w3c.dom.Element;
 public class ClassificationHandlerTest
 {
 
-    private static final String CLASSIFICATION_XML_FILE = "src/test/resources/handler/classification.windup.xml";
+    private static final String CLASSIFICATION_XML_WINDUP_FILE = "src/test/resources/handler/classification.windup.xml";
+    private static final String CLASSIFICATION_XML_RHAMT_FILE = "src/test/resources/handler/classification.rhamt.xml";
 
     @Deployment
     @AddonDependencies({
@@ -51,9 +52,21 @@ public class ClassificationHandlerTest
     private Furnace furnace;
 
     @Test
-    public void testClassificationParsing() throws Exception
+    public void testWindupClassificationParsing() throws Exception
     {
-        File fXmlFile = new File(CLASSIFICATION_XML_FILE);
+        File fXmlFile = new File(CLASSIFICATION_XML_WINDUP_FILE);
+        testClassificationParsing(fXmlFile);
+    }
+
+    @Test
+    public void testRhamtClassificationParsing() throws Exception
+    {
+        File fXmlFile = new File(CLASSIFICATION_XML_RHAMT_FILE);
+        testClassificationParsing(fXmlFile);
+    }
+
+    public void testClassificationParsing(File fXmlFile) throws Exception
+    {
         RuleLoaderContext loaderContext = new RuleLoaderContext(Collections.singleton(fXmlFile.toPath()), null);
         ParserContext parser = new ParserContext(furnace, loaderContext);
         DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
@@ -93,9 +106,21 @@ public class ClassificationHandlerTest
     }
 
     @Test(expected = WindupException.class)
-    public void testClassificationWithoutMessage() throws Exception
+    public void testWindupClassificationWithoutMessage() throws Exception
     {
-        File fXmlFile = new File(CLASSIFICATION_XML_FILE);
+        File fXmlFile = new File(CLASSIFICATION_XML_WINDUP_FILE);
+        testClassificationWithoutMessage(fXmlFile);
+    }
+
+    @Test(expected = WindupException.class)
+    public void testRhamtClassificationWithoutMessage() throws Exception
+    {
+        File fXmlFile = new File(CLASSIFICATION_XML_RHAMT_FILE);
+        testClassificationWithoutMessage(fXmlFile);
+    }
+
+    public void testClassificationWithoutMessage(File fXmlFile) throws Exception
+    {
         RuleLoaderContext loaderContext = new RuleLoaderContext(Collections.singleton(fXmlFile.toPath()), null);
         ParserContext parser = new ParserContext(furnace, loaderContext);
         DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
@@ -108,9 +133,21 @@ public class ClassificationHandlerTest
     }
 
     @Test(expected = WindupException.class)
-    public void testClassificationWithWrongEffort() throws Exception
+    public void testWindupClassificationWithWrongEffort() throws Exception
     {
-        File fXmlFile = new File(CLASSIFICATION_XML_FILE);
+        File fXmlFile = new File(CLASSIFICATION_XML_WINDUP_FILE);
+        testClassificationWithWrongEffort(fXmlFile);
+    }
+
+    @Test(expected = WindupException.class)
+    public void testRhamtClassificationWithWrongEffort() throws Exception
+    {
+        File fXmlFile = new File(CLASSIFICATION_XML_RHAMT_FILE);
+        testClassificationWithWrongEffort(fXmlFile);
+    }
+
+    public void testClassificationWithWrongEffort(File fXmlFile) throws Exception
+    {
         RuleLoaderContext loaderContext = new RuleLoaderContext(Collections.singleton(fXmlFile.toPath()), null);
         ParserContext parser = new ParserContext(furnace, loaderContext);
         DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();

--- a/reporting/tests/src/test/java/org/jboss/windup/reporting/handlers/HasClassificationHandlerTest.java
+++ b/reporting/tests/src/test/java/org/jboss/windup/reporting/handlers/HasClassificationHandlerTest.java
@@ -34,7 +34,8 @@ import org.w3c.dom.Element;
 public class HasClassificationHandlerTest
 {
 
-    private static final String HINT_XML_FILE = "src/test/resources/handler/hasclassification.windup.xml";
+    private static final String HINT_XML_WINDUP_FILE = "src/test/resources/handler/hasclassification.windup.xml";
+    private static final String HINT_XML_RHAMT_FILE = "src/test/resources/handler/hasclassification.rhamt.xml";
 
     @Deployment
     @AddonDependencies({
@@ -54,9 +55,21 @@ public class HasClassificationHandlerTest
     private Furnace furnace;
 
     @Test
-    public void testHintHandler() throws Exception
+    public void testWindupHintHandler() throws Exception
     {
-        File fXmlFile = new File(HINT_XML_FILE);
+        File fXmlFile = new File(HINT_XML_WINDUP_FILE);
+        testHintHandler(fXmlFile);
+    }
+
+    @Test
+    public void testRhamtHintHandler() throws Exception
+    {
+        File fXmlFile = new File(HINT_XML_RHAMT_FILE);
+        testHintHandler(fXmlFile);
+    }
+
+    public void testHintHandler(File fXmlFile) throws Exception
+    {
         RuleLoaderContext loaderContext = new RuleLoaderContext(Collections.singleton(fXmlFile.toPath()), null);
         ParserContext parser = new ParserContext(furnace, loaderContext);
         DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();

--- a/reporting/tests/src/test/java/org/jboss/windup/reporting/handlers/HasHintHandlerTest.java
+++ b/reporting/tests/src/test/java/org/jboss/windup/reporting/handlers/HasHintHandlerTest.java
@@ -34,7 +34,8 @@ import org.w3c.dom.Element;
 public class HasHintHandlerTest
 {
 
-    private static final String HINT_XML_FILE = "src/test/resources/handler/hashint.windup.xml";
+    private static final String HINT_XML_WINDUP_FILE = "src/test/resources/handler/hashint.windup.xml";
+    private static final String HINT_XML_RHAMT_FILE = "src/test/resources/handler/hashint.rhamt.xml";
 
     @Deployment
     @AddonDependencies({
@@ -54,9 +55,21 @@ public class HasHintHandlerTest
     private Furnace furnace;
 
     @Test
-    public void testHintHandler() throws Exception
+    public void testWindupHintHandler() throws Exception
     {
-        File fXmlFile = new File(HINT_XML_FILE);
+        File fXmlFile = new File(HINT_XML_WINDUP_FILE);
+        testHintHandler(fXmlFile);
+    }
+
+    @Test
+    public void testRhamtHintHandler() throws Exception
+    {
+        File fXmlFile = new File(HINT_XML_RHAMT_FILE);
+        testHintHandler(fXmlFile);
+    }
+
+    public void testHintHandler(File fXmlFile) throws Exception
+    {
         RuleLoaderContext loaderContext = new RuleLoaderContext(Collections.singleton(fXmlFile.toPath()), null);
         ParserContext parser = new ParserContext(furnace, loaderContext);
         DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();

--- a/reporting/tests/src/test/java/org/jboss/windup/reporting/handlers/HintHandlerTest.java
+++ b/reporting/tests/src/test/java/org/jboss/windup/reporting/handlers/HintHandlerTest.java
@@ -34,7 +34,8 @@ import org.w3c.dom.Element;
 public class HintHandlerTest
 {
 
-    private static final String HINT_XML_FILE = "src/test/resources/handler/hint.windup.xml";
+    private static final String HINT_XML_WINDUP_FILE = "src/test/resources/handler/hint.windup.xml";
+    private static final String HINT_XML_RHAMT_FILE = "src/test/resources/handler/hint.rhamt.xml";
 
     @Deployment
     @AddonDependencies({
@@ -54,9 +55,21 @@ public class HintHandlerTest
     private Furnace furnace;
 
     @Test
-    public void testHintHandler() throws Exception
+    public void testWindupHintHandler() throws Exception
     {
-        File fXmlFile = new File(HINT_XML_FILE);
+        File fXmlFile = new File(HINT_XML_WINDUP_FILE);
+        testHintHandler(fXmlFile);
+    }
+
+    @Test
+    public void testRhamtHintHandler() throws Exception
+    {
+        File fXmlFile = new File(HINT_XML_RHAMT_FILE);
+        testHintHandler(fXmlFile);
+    }
+
+    public void testHintHandler(File fXmlFile) throws Exception
+    {
         RuleLoaderContext loaderContext = new RuleLoaderContext(Collections.singleton(fXmlFile.toPath()), null);
         ParserContext parser = new ParserContext(furnace, loaderContext);
         DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
@@ -104,9 +117,21 @@ public class HintHandlerTest
     }
 
     @Test(expected = WindupException.class)
-    public void testXmlFileWithoutPublidIdAndXpath() throws Exception
+    public void testWindupXmlFileWithoutPublidIdAndXpath() throws Exception
     {
-        File fXmlFile = new File(HINT_XML_FILE);
+        File fXmlFile = new File(HINT_XML_WINDUP_FILE);
+        testXmlFileWithoutPublidIdAndXpath(fXmlFile);
+    }
+
+    @Test(expected = WindupException.class)
+    public void testRhamtXmlFileWithoutPublidIdAndXpath() throws Exception
+    {
+        File fXmlFile = new File(HINT_XML_RHAMT_FILE);
+        testXmlFileWithoutPublidIdAndXpath(fXmlFile);
+    }
+
+    public void testXmlFileWithoutPublidIdAndXpath(File fXmlFile) throws Exception
+    {
         RuleLoaderContext loaderContext = new RuleLoaderContext(Collections.singleton(fXmlFile.toPath()), null);
         ParserContext parser = new ParserContext(furnace, loaderContext);
         DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();

--- a/reporting/tests/src/test/java/org/jboss/windup/reporting/handlers/QuickfixHandlerTest.java
+++ b/reporting/tests/src/test/java/org/jboss/windup/reporting/handlers/QuickfixHandlerTest.java
@@ -34,7 +34,8 @@ import org.w3c.dom.Element;
 @RunWith(Arquillian.class)
 public class QuickfixHandlerTest
 {
-    private static final String QUICKFIX_XML_FILE = "src/test/resources/handler/quickfix.windup.xml";
+    private static final String QUICKFIX_XML_WINDUP_FILE = "src/test/resources/handler/quickfix.windup.xml";
+    private static final String QUICKFIX_XML_RHAMT_FILE = "src/test/resources/handler/quickfix.rhamt.xml";
 
     @Deployment
     @AddonDependencies({
@@ -52,9 +53,21 @@ public class QuickfixHandlerTest
     private Furnace furnace;
 
     @Test
-    public void testClassificationParsing() throws Exception
+    public void testWindupClassificationParsing() throws Exception
     {
-        File fXmlFile = new File(QUICKFIX_XML_FILE);
+        File fXmlFile = new File(QUICKFIX_XML_WINDUP_FILE);
+        testClassificationParsing(fXmlFile);
+    }
+
+    @Test
+    public void testRhamtClassificationParsing() throws Exception
+    {
+        File fXmlFile = new File(QUICKFIX_XML_RHAMT_FILE);
+        testClassificationParsing(fXmlFile);
+    }
+
+    public void testClassificationParsing(File fXmlFile) throws Exception
+    {
         RuleLoaderContext loaderContext = new RuleLoaderContext(Collections.singleton(fXmlFile.toPath()), null);
         ParserContext parser = new ParserContext(furnace, loaderContext);
         DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
@@ -99,9 +112,21 @@ public class QuickfixHandlerTest
     }
 
     @Test
-    public void testHintParsing() throws Exception
+    public void testWindupHintParsing() throws Exception
     {
-        File fXmlFile = new File(QUICKFIX_XML_FILE);
+        File fXmlFile = new File(QUICKFIX_XML_WINDUP_FILE);
+        testHintParsing(fXmlFile);
+    }
+
+    @Test
+    public void testRhamtHintParsing() throws Exception
+    {
+        File fXmlFile = new File(QUICKFIX_XML_RHAMT_FILE);
+        testHintParsing(fXmlFile);
+    }
+
+    public void testHintParsing(File fXmlFile) throws Exception
+    {
         RuleLoaderContext loaderContext = new RuleLoaderContext(Collections.singleton(fXmlFile.toPath()), null);
         ParserContext parser = new ParserContext(furnace, loaderContext);
         DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();

--- a/reporting/tests/src/test/resources/handler/classification.rhamt.xml
+++ b/reporting/tests/src/test/resources/handler/classification.rhamt.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0"?>
+<test xmlns="http://windup.jboss.org/schema/jboss-ruleset">
+
+    <classification effort="5" title="test message" of="testVariable">
+        <description>simple description</description>
+        <link href="someUrl" title="someDescription" />
+    </classification>
+
+    <classification title="test-message" category-id='optional'>
+        <link href="url1" title="description1" />
+        <link href="url2" title="description2" />
+        <link href="url3" title="description3" />
+    </classification>
+
+    <classification in="testVariable">
+        <link href="url1" title="description1" />
+        <link href="url2" title="description2" />
+        <link href="url3" title="description3" />
+    </classification>
+
+    <classification effort="asbas" title="test-message" in="testVariable">
+        <link href="url1" title="description1" />
+        <link href="url2" title="description2" />
+        <link href="url3" title="description3" />
+    </classification>
+
+</test>
+            

--- a/reporting/tests/src/test/resources/handler/hasclassification.rhamt.xml
+++ b/reporting/tests/src/test/resources/handler/hasclassification.rhamt.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<test xmlns="http://windup.jboss.org/schema/jboss-ruleset">
+
+    <has-classification />
+    <has-classification title="test-message" />
+    <has-classification title="test-message" in="test-in" />
+
+</test>

--- a/reporting/tests/src/test/resources/handler/hashint.rhamt.xml
+++ b/reporting/tests/src/test/resources/handler/hashint.rhamt.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<test xmlns="http://windup.jboss.org/schema/jboss-ruleset">
+
+    <has-hint />
+    <has-hint message="test-message" />
+    <has-hint message="test-message" />
+
+</test>
+            

--- a/reporting/tests/src/test/resources/handler/hint.rhamt.xml
+++ b/reporting/tests/src/test/resources/handler/hint.rhamt.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<test xmlns="http://windup.jboss.org/schema/jboss-ruleset">
+	<hint effort="5" message="test message" in="testVariable">
+		<link href="someUrl" title="someDescription"/>
+	</hint>
+
+	<hint message="test-message" category-id="mandatory">
+		<link href="url1" title="description1"/>
+		<link href="url2" title="description2"/>
+		<link href="url3" title="description3"/>
+        <tag>java-ee-6</tag>
+        <tag>jpa-2</tag>
+        <tag>jpa</tag>
+	</hint>
+
+	<hint effort="asadsa" message="TEST MESSAGE" in="testVariable">
+		<link href="url1" title="description1"/>
+		<link href="url2" title="description2"/>
+		<link href="url3" title="description3"/>
+        <tag>foo</tag>
+	</hint>
+
+</test>
+

--- a/reporting/tests/src/test/resources/handler/quickfix.rhamt.xml
+++ b/reporting/tests/src/test/resources/handler/quickfix.rhamt.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0"?>
+<test xmlns="http://windup.jboss.org/schema/jboss-ruleset">
+
+    <classification in="testVariable" title="test-classification">
+        <quickfix name="test1 qf" type="INSERT_LINE">
+            <newline>something new</newline>
+        </quickfix>
+        <quickfix name="test2 qf" type="REPLACE">
+            <search>test1</search>
+            <replacement>test2</replacement>
+        </quickfix>
+    </classification>
+
+    <classification effort="1" title="test-message">
+        <link href="url1" title="description1" />
+        <link href="url2" title="description2" />
+        <link href="url3" title="description3" />
+        <quickfix name="test delete" type="DELETE_LINE"/>
+    </classification>
+    
+    <hint effort="2" message="test message" in="testVariable">
+        <link href="url1" title="description1"/>
+        <link href="url2" title="description2"/>
+        <quickfix name="test1 quickfix" type="DELETE_LINE"/>
+        <quickfix name="test2 quickfix" type="INSERT_LINE">
+            <newline>something new</newline>
+        </quickfix>
+        <quickfix name="test3 quickfix" type="REPLACE">
+            <search>what</search>
+            <replacement>when</replacement>
+        </quickfix>
+    </hint>
+
+</test>

--- a/rules-base/tests/src/test/resources/xml/FileContentXmlExample.rhamt.xml
+++ b/rules-base/tests/src/test/resources/xml/FileContentXmlExample.rhamt.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<ruleset xmlns="http://windup.jboss.org/schema/jboss-ruleset" id="xmltestrules_2" phase="PostMigrationRulesPhase">
+  <rules>
+    <rule>
+      <when>
+        <filecontent pattern="for the {xml} rule" filename="{filename}.txt"/>
+      </when>
+      <perform>
+        <hint>
+        	<message>File Content {xml}</message>
+        </hint>
+      </perform>
+    </rule>
+  </rules>
+</ruleset>

--- a/rules-base/tests/src/test/resources/xml/FileXmlExample.rhamt.xml
+++ b/rules-base/tests/src/test/resources/xml/FileXmlExample.rhamt.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<ruleset xmlns="http://windup.jboss.org/schema/jboss-ruleset" id="xmltestrules_3" phase="PostMigrationRulesPhase">
+  <rules>
+    <rule>
+      <when>
+        <file filename="file{number}.txt"/>
+      </when>
+      <perform>
+        <classification title="Test Title {number}">
+        	<description>File Content {number}</description>
+        </classification>
+      </perform>
+    </rule>
+  </rules>
+</ruleset>

--- a/rules-java/tests/src/test/java/org/jboss/windup/rule/groovy/GroovyExtensionJavaRulesTest.java
+++ b/rules-java/tests/src/test/java/org/jboss/windup/rule/groovy/GroovyExtensionJavaRulesTest.java
@@ -64,13 +64,16 @@ public class GroovyExtensionJavaRulesTest
                     .addBeansXML()
                     .addClass(TestHintsClassificationsTestRuleProvider.class)
                     .addAsResource(new File("src/test/resources/groovy/GroovyClassificationsAndHints.windup.groovy"),
-                                GROOVY_CLASSIFICATION_AND_HINT_FILE);
+                                GROOVY_CLASSIFICATION_AND_HINT_WINDUP_FILE)
+                    .addAsResource(new File("src/test/resources/groovy/GroovyClassificationsAndHints.rhamt.groovy"),
+                                GROOVY_CLASSIFICATION_AND_HINT_RHAMT_FILE);
     }
 
     @Inject
     private WindupProcessor processor;
 
-    public static String GROOVY_CLASSIFICATION_AND_HINT_FILE = "/org/jboss/windup/addon/groovy/GroovyClassificationsAndHints.windup.groovy";
+    public static String GROOVY_CLASSIFICATION_AND_HINT_WINDUP_FILE = "/org/jboss/windup/addon/groovy/GroovyClassificationsAndHints.windup.groovy";
+    public static String GROOVY_CLASSIFICATION_AND_HINT_RHAMT_FILE = "/org/jboss/windup/addon/groovy/GroovyClassificationsAndHints.rhamt.groovy";
 
     @Inject
     private GraphContextFactory factory;
@@ -129,7 +132,7 @@ public class GroovyExtensionJavaRulesTest
                 Iterable<JavaTypeReferenceModel> typeReferences = typeRefService.findAll();
                 Assert.assertTrue(typeReferences.iterator().hasNext());
                 List<InlineHintModel> hints = Iterators.asList(hintService.findAll());
-                Assert.assertEquals(4, hints.size());
+                Assert.assertEquals(8, hints.size());
                 List<ClassificationModel> classifications = Iterators.asList(classificationService.findAll());
                 Assert.assertEquals(1, classifications.size());
 

--- a/rules-java/tests/src/test/java/org/jboss/windup/rules/java/handlers/AnnotationConditionHandlerTest.java
+++ b/rules-java/tests/src/test/java/org/jboss/windup/rules/java/handlers/AnnotationConditionHandlerTest.java
@@ -30,7 +30,8 @@ import org.w3c.dom.Element;
 public class AnnotationConditionHandlerTest
 {
 
-    private static final String ANNOTATION_HANDLER_XML_FILE = "src/test/resources/handler/annotationcondition.windup.xml";
+    private static final String ANNOTATION_HANDLER_XML_WINDUP_FILE = "src/test/resources/handler/annotationcondition.windup.xml";
+    private static final String ANNOTATION_HANDLER_XML_RHAMT_FILE = "src/test/resources/handler/annotationcondition.rhamt.xml";
 
     @Deployment
     @AddonDependencies({
@@ -53,9 +54,21 @@ public class AnnotationConditionHandlerTest
     private Furnace furnace;
 
     @Test
-    public void testCondition() throws Exception
+    public void testWindupCondition() throws Exception
     {
-        File fXmlFile = new File(ANNOTATION_HANDLER_XML_FILE);
+        File fXmlFile = new File(ANNOTATION_HANDLER_XML_WINDUP_FILE);
+        testCondition(fXmlFile);
+    }
+
+    @Test
+    public void testRhamtCondition() throws Exception
+    {
+        File fXmlFile = new File(ANNOTATION_HANDLER_XML_RHAMT_FILE);
+        testCondition(fXmlFile);
+    }
+
+    public void testCondition(File fXmlFile) throws Exception
+    {
         RuleLoaderContext loaderContext = new RuleLoaderContext(Collections.singleton(fXmlFile.toPath()), null);
         ParserContext parser = new ParserContext(furnace, loaderContext);
         DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();

--- a/rules-java/tests/src/test/java/org/jboss/windup/rules/java/handlers/JavaClassHandlerTest.java
+++ b/rules-java/tests/src/test/java/org/jboss/windup/rules/java/handlers/JavaClassHandlerTest.java
@@ -33,7 +33,8 @@ import org.w3c.dom.Element;
 public class JavaClassHandlerTest
 {
 
-    private static final String JAVA_CLASS_XML_FILE = "src/test/resources/handler/javaclass.windup.xml";
+    private static final String JAVA_CLASS_XML_WINDUP_FILE = "src/test/resources/handler/javaclass.windup.xml";
+    private static final String JAVA_CLASS_XML_RHAMT_FILE = "src/test/resources/handler/javaclass.rhamt.xml";
 
     @Deployment
     @AddonDependencies({
@@ -56,9 +57,21 @@ public class JavaClassHandlerTest
     private Furnace furnace;
 
     @Test
-    public void testJavaClassCondition() throws Exception
+    public void testWindupJavaClassCondition() throws Exception
     {
-        File fXmlFile = new File(JAVA_CLASS_XML_FILE);
+        File fXmlFile = new File(JAVA_CLASS_XML_WINDUP_FILE);
+        testJavaClassCondition(fXmlFile);
+    }
+
+    @Test
+    public void testRhamtJavaClassCondition() throws Exception
+    {
+        File fXmlFile = new File(JAVA_CLASS_XML_RHAMT_FILE);
+        testJavaClassCondition(fXmlFile);
+    }
+
+    public void testJavaClassCondition(File fXmlFile) throws Exception
+    {
         RuleLoaderContext loaderContext = new RuleLoaderContext(Collections.singleton(fXmlFile.toPath()), null);
         ParserContext parser = new ParserContext(furnace, loaderContext);
         DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
@@ -93,9 +106,21 @@ public class JavaClassHandlerTest
     }
 
     @Test(expected = WindupException.class)
-    public void testXmlFileWithoutPublidIdAndXpath() throws Exception
+    public void testWindupXmlFileWithoutPublidIdAndXpath() throws Exception
     {
-        File fXmlFile = new File(JAVA_CLASS_XML_FILE);
+        File fXmlFile = new File(JAVA_CLASS_XML_WINDUP_FILE);
+        testXmlFileWithoutPublidIdAndXpath(fXmlFile);
+    }
+
+    @Test(expected = WindupException.class)
+    public void testRhamtXmlFileWithoutPublidIdAndXpath() throws Exception
+    {
+        File fXmlFile = new File(JAVA_CLASS_XML_RHAMT_FILE);
+        testXmlFileWithoutPublidIdAndXpath(fXmlFile);
+    }
+
+    public void testXmlFileWithoutPublidIdAndXpath(File fXmlFile) throws Exception
+    {
         RuleLoaderContext loaderContext = new RuleLoaderContext(Collections.singleton(fXmlFile.toPath()), null);
         ParserContext parser = new ParserContext(furnace, loaderContext);
         DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();

--- a/rules-java/tests/src/test/java/org/jboss/windup/rules/java/handlers/JavaClassHandlerTest2.java
+++ b/rules-java/tests/src/test/java/org/jboss/windup/rules/java/handlers/JavaClassHandlerTest2.java
@@ -31,7 +31,8 @@ import org.w3c.dom.Element;
 public class JavaClassHandlerTest2
 {
 
-    private static final String JAVA_CLASS_XML_FILE = "src/test/resources/handler/javaclass-enumconst.windup.xml";
+    private static final String JAVA_CLASS_XML_WINDUP_FILE = "src/test/resources/handler/javaclass-enumconst.windup.xml";
+    private static final String JAVA_CLASS_XML_RHAMT_FILE = "src/test/resources/handler/javaclass-enumconst.rhamt.xml";
 
     @Deployment
     @AddonDependencies({
@@ -53,9 +54,21 @@ public class JavaClassHandlerTest2
     private Furnace furnace;
 
     @Test
-    public void testJavaClassEnumLocationCondition() throws Exception
+    public void testWindupJavaClassEnumLocationCondition() throws Exception
     {
-        File fXmlFile = new File(JAVA_CLASS_XML_FILE);
+        File fXmlFile = new File(JAVA_CLASS_XML_WINDUP_FILE);
+        testJavaClassEnumLocationCondition(fXmlFile);
+    }
+
+    @Test
+    public void testRhamtJavaClassEnumLocationCondition() throws Exception
+    {
+        File fXmlFile = new File(JAVA_CLASS_XML_RHAMT_FILE);
+        testJavaClassEnumLocationCondition(fXmlFile);
+    }
+
+    public void testJavaClassEnumLocationCondition(File fXmlFile) throws Exception
+    {
         RuleLoaderContext loaderContext = new RuleLoaderContext(Collections.singleton(fXmlFile.toPath()), null);
         ParserContext parser = new ParserContext(furnace, loaderContext);
         DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();

--- a/rules-java/tests/src/test/resources/groovy/GroovyClassificationsAndHints.rhamt.groovy
+++ b/rules-java/tests/src/test/resources/groovy/GroovyClassificationsAndHints.rhamt.groovy
@@ -1,0 +1,20 @@
+import org.jboss.windup.ast.java.data.TypeReferenceLocation
+import org.jboss.windup.config.phase.PostMigrationRulesPhase
+import org.jboss.windup.reporting.config.Hint
+import org.jboss.windup.reporting.config.Link
+import org.jboss.windup.reporting.config.classification.Classification
+import org.jboss.windup.rules.apps.java.condition.JavaClass
+
+
+ruleSet("ExampleJavaRhamtGroovy").setPhase(PostMigrationRulesPhase.class)
+
+    .addRule()
+    .when(
+        JavaClass.references("org.jboss.forge.furnace.{*}").at(TypeReferenceLocation.IMPORT)
+    )
+    .perform(
+         Classification.as("Furnace Service").with(Link.to("JBoss Forge", "http://forge.jboss.org")).withEffort(0)
+                    .and(Hint.withText("Furnace type references imply that the client code must be run within a Furnace container.")
+                             .withEffort(8))
+    )
+    

--- a/rules-java/tests/src/test/resources/handler/annotationcondition.rhamt.xml
+++ b/rules-java/tests/src/test/resources/handler/annotationcondition.rhamt.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<test xmlns="http://windup.jboss.org/schema/jboss-ruleset">
+    <javaclass as="testVariable" references="org.apache.commons.{*}" in="{*}File1">
+        <location>METHOD_CALL</location>
+        <annotation-list name="firstName" index="1">
+            <annotation-literal pattern="firstPattern"/>
+        </annotation-list>
+    </javaclass>
+    <javaclass references="org.apache.commons.{*}" matchesSource="source-match">
+        <location>IMPORT</location>
+        <location>METHOD_CALL</location>
+        <location>INHERITANCE</location>
+        <annotation-type name="secondName" pattern="secondPattern">
+            <annotation-literal name="subLiteral" pattern="subLiteralPattern"/>
+        </annotation-type>
+    </javaclass>
+</test>
+

--- a/rules-java/tests/src/test/resources/handler/javaclass-enumconst.rhamt.xml
+++ b/rules-java/tests/src/test/resources/handler/javaclass-enumconst.rhamt.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<test xmlns="http://windup.jboss.org/schema/jboss-ruleset">
+    <javaclass as="testVariable" references="java.nio.file.AccessMode.{*}" in="{*}File3">
+               <location>ENUM_CONSTANT</location>
+    </javaclass>
+    <javaclass references="java.nio.file.AccessMode"/>
+</test>

--- a/rules-java/tests/src/test/resources/handler/javaclass.rhamt.xml
+++ b/rules-java/tests/src/test/resources/handler/javaclass.rhamt.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<test xmlns="http://windup.jboss.org/schema/jboss-ruleset">
+	<javaclass as="testVariable" references="org.apache.commons.{*}" in="{*}File1">
+               <location>METHOD_CALL</location>
+    </javaclass>
+    <javaclass references="org.apache.commons.{*}" matchesSource="source-match">
+               <location>IMPORT</location>
+               <location>METHOD_CALL</location>
+               <location>INHERITANCE</location>
+    </javaclass>
+     <javaclass as="testVariable" in="{*}File1">
+               <location>METHOD_CALL</location>
+    </javaclass>
+</test>
+            

--- a/rules-xml/tests/src/test/java/org/jboss/windup/rules/apps/xml/groovy/GroovyExtensionXmlRulesTest.java
+++ b/rules-xml/tests/src/test/java/org/jboss/windup/rules/apps/xml/groovy/GroovyExtensionXmlRulesTest.java
@@ -53,15 +53,17 @@ public class GroovyExtensionXmlRulesTest
         final AddonArchive archive = ShrinkWrap.create(AddonArchive.class)
                     .addBeansXML()
                     .addAsResource(new File("src/test/resources/groovy/GroovyXmlFileClassificationsAndHints.windup.groovy"),
-                                GROOVY_FILE);
-
+                                GROOVY_WINDUP_FILE)
+                    .addAsResource(new File("src/test/resources/groovy/GroovyXmlFileClassificationsAndHints.rhamt.groovy"),
+                                GROOVY_RHAMT_FILE);
         return archive;
     }
 
     @Inject
     private WindupProcessor processor;
 
-    public static String GROOVY_FILE = "/org/jboss/windup/addon/groovy/GroovyXmlFileClassificationsAndHints.windup.groovy";
+    public static String GROOVY_WINDUP_FILE = "/org/jboss/windup/addon/groovy/GroovyXmlFileClassificationsAndHints.windup.groovy";
+    public static String GROOVY_RHAMT_FILE = "/org/jboss/windup/addon/groovy/GroovyXmlFileClassificationsAndHints.rhamt.groovy";
 
     @Inject
     private GraphContextFactory factory;
@@ -98,7 +100,7 @@ public class GroovyExtensionXmlRulesTest
                         ClassificationModel.class);
 
             List<InlineHintModel> hints = Iterators.asList(hintService.findAll());
-            Assert.assertEquals(2, hints.size());
+            Assert.assertEquals(4, hints.size());
             List<ClassificationModel> classifications = Iterators.asList(classificationService.findAll());
             for (ClassificationModel model : classifications)
             {

--- a/rules-xml/tests/src/test/java/org/jboss/windup/rules/apps/xml/operation/xslt/XSLTTransformationHandlerTest.java
+++ b/rules-xml/tests/src/test/java/org/jboss/windup/rules/apps/xml/operation/xslt/XSLTTransformationHandlerTest.java
@@ -47,7 +47,8 @@ import org.w3c.dom.Element;
 public class XSLTTransformationHandlerTest
 {
 
-    private static final String XSLT_FILE = "src/test/resources/unit/xslt.windup.xml";
+    private static final String XSLT_WINDUP_FILE = "src/test/resources/unit/xslt.windup.xml";
+    private static final String XSLT_RHAMT_FILE = "src/test/resources/unit/xslt.rhamt.xml";
 
     @Deployment
     @AddonDependencies({
@@ -77,9 +78,21 @@ public class XSLTTransformationHandlerTest
     private Addon addon;
 
     @Test
-    public void testXSLTOperation() throws Exception
+    public void testWindupXSLTOperation() throws Exception
     {
-        File fXmlFile = new File(XSLT_FILE);
+        File fXmlFile = new File(XSLT_WINDUP_FILE);
+        testXSLTOperation(fXmlFile);
+    }
+
+    @Test
+    public void testRhamtXSLTOperation() throws Exception
+    {
+        File fXmlFile = new File(XSLT_RHAMT_FILE);
+        testXSLTOperation(fXmlFile);
+    }
+
+    public void testXSLTOperation(File fXmlFile) throws Exception
+    {
         RuleLoaderContext loaderContext = new RuleLoaderContext(Collections.singleton(fXmlFile.toPath()), null);
         ParserContext parser = new ParserContext(furnace, loaderContext);
         parser.setAddonContainingInputXML(addon);
@@ -143,9 +156,21 @@ public class XSLTTransformationHandlerTest
     }
 
     @Test(expected = WindupException.class)
-    public void testXSLTWithoutExtension() throws Exception
+    public void testWindupXSLTWithoutExtension() throws Exception
     {
-        File fXmlFile = new File(XSLT_FILE);
+        File fXmlFile = new File(XSLT_WINDUP_FILE);
+        testXSLTWithoutExtension(fXmlFile);
+    }
+
+    @Test(expected = WindupException.class)
+    public void testRhamtXSLTWithoutExtension() throws Exception
+    {
+        File fXmlFile = new File(XSLT_RHAMT_FILE);
+        testXSLTWithoutExtension(fXmlFile);
+    }
+
+    public void testXSLTWithoutExtension(File fXmlFile) throws Exception
+    {
         RuleLoaderContext loaderContext = new RuleLoaderContext(Collections.singleton(fXmlFile.toPath()), null);
         ParserContext parser = new ParserContext(furnace, loaderContext);
         parser.setAddonContainingInputXML(addon);
@@ -160,9 +185,21 @@ public class XSLTTransformationHandlerTest
     }
 
     @Test(expected = WindupException.class)
-    public void testXSLTWithoutTemplate() throws Exception
+    public void testWindupXSLTWithoutTemplate() throws Exception
     {
-        File fXmlFile = new File(XSLT_FILE);
+        File fXmlFile = new File(XSLT_WINDUP_FILE);
+        testXSLTWithoutTemplate(fXmlFile);
+    }
+
+    @Test(expected = WindupException.class)
+    public void testRhamtXSLTWithoutTemplate() throws Exception
+    {
+        File fXmlFile = new File(XSLT_RHAMT_FILE);
+        testXSLTWithoutTemplate(fXmlFile);
+    }
+
+    public void testXSLTWithoutTemplate(File fXmlFile) throws Exception
+    {
         RuleLoaderContext loaderContext = new RuleLoaderContext(Collections.singleton(fXmlFile.toPath()), null);
         ParserContext parser = new ParserContext(furnace, loaderContext);
         parser.setAddonContainingInputXML(addon);

--- a/rules-xml/tests/src/test/resources/groovy/GroovyXmlFileClassificationsAndHints.rhamt.groovy
+++ b/rules-xml/tests/src/test/resources/groovy/GroovyXmlFileClassificationsAndHints.rhamt.groovy
@@ -1,0 +1,30 @@
+import org.jboss.windup.config.operation.GraphOperation;
+import org.jboss.windup.config.GraphRewrite;
+import org.jboss.windup.config.phase.RulePhase;
+import org.jboss.windup.config.metadata.RuleMetadataType;
+import org.jboss.windup.config.phase.RulePhase;
+import org.jboss.windup.config.phase.PostMigrationRulesPhase;
+import org.jboss.windup.reporting.config.classification.Classification;
+import org.jboss.windup.reporting.config.Hint;
+import org.jboss.windup.reporting.config.Link;
+import org.jboss.windup.rules.apps.java.condition.JavaClass;
+import org.jboss.windup.ast.java.data.TypeReferenceLocation;
+import org.jboss.windup.rules.apps.xml.condition.XmlFile;
+import org.jboss.windup.util.Logging;
+import org.ocpsoft.rewrite.config.True;
+import org.ocpsoft.rewrite.context.EvaluationContext;
+
+
+ruleSet("ExampleRhamtJavaGroovy").setPhase(PostMigrationRulesPhase.class)
+
+        .addRule()
+        
+        .when(XmlFile.matchesXpath("/abc:ejb-jar")
+              .namespace("abc", "http://java.sun.com/xml/ns/javaee"))
+        
+        .perform(Classification.as("Maven POM File")
+            .with(Link.to("Apache Maven POM Reference", "http://maven.apache.org/pom.html"))
+            .withEffort(0)
+          .and(Hint.withText("simple text").withEffort(2))
+        )
+        .withMetadata(RuleMetadataType.TAGS, "Basic")

--- a/rules-xml/tests/src/test/resources/unit/xslt.rhamt.xml
+++ b/rules-xml/tests/src/test/resources/unit/xslt.rhamt.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<test xmlns="http://windup.jboss.org/schema/jboss-ruleset">
+	<xslt of="testVariable_instance" title="XSLT Tranformed Output" extension="-test-result.html" template="simpleXSLT.xsl" />
+	<xslt title="XSLT Tranformed Output" extension="-test-result.html" template="simpleXSLT.xsl" />
+	<xslt of="testVariable_instance" title="XSLT Tranformed Output" template="simpleXSLT.xsl" />
+	<xslt of="testVariable_instance" title="XSLT Tranformed Output" extension="-test-result.html"  />
+</test>
+            

--- a/tooling/impl/src/main/java/org/jboss/windup/tooling/rules/RuleProviderRegistryImpl.java
+++ b/tooling/impl/src/main/java/org/jboss/windup/tooling/rules/RuleProviderRegistryImpl.java
@@ -126,7 +126,7 @@ public class RuleProviderRegistryImpl implements RuleProviderRegistry
     {
         if (origin == null)
             return RuleProvider.RuleProviderType.JAVA;
-        else if (origin.startsWith("file:") && origin.endsWith(".windup.xml"))
+        else if (origin.startsWith("file:") && (origin.endsWith(".windup.xml") || origin.endsWith(".rhamt.xml")))
             return RuleProvider.RuleProviderType.XML;
         else if (origin.startsWith("file:") && origin.endsWith(".windup.groovy"))
             return RuleProvider.RuleProviderType.GROOVY;

--- a/tooling/tests/src/test/java/org/jboss/windup/tooling/ExecutionBuilderTest.java
+++ b/tooling/tests/src/test/java/org/jboss/windup/tooling/ExecutionBuilderTest.java
@@ -139,7 +139,7 @@ public class ExecutionBuilderTest
                     .filter(provider -> provider.getOrigin() != null)
                     .filter(provider -> provider.getRuleProviderType() == RuleProvider.RuleProviderType.XML)
                     .collect(Collectors.toList());
-        Assert.assertTrue(xmlProviders.size() > 0);
+        Assert.assertTrue(xmlProviders.size() == 4);
     }
     
     @Test

--- a/tooling/tests/src/test/resources/rules/XmlExample.rhamt.xml
+++ b/tooling/tests/src/test/resources/rules/XmlExample.rhamt.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0"?>
+<ruleset xmlns="http://windup.jboss.org/schema/jboss-ruleset" id="xmltestrules_2">
+    <rules>
+        <rule>
+            <when>
+                <javaclass references="javax.servlet.http.HttpServletRequest">
+                    <location>METHOD_PARAMETER</location>
+                </javaclass>
+            </when>
+            <perform>
+                <hint title="javax.servlet.http.HttpServletRequest usage">
+                    <message>"Message from XML Rule</message>
+                    <link href="http://example.com" title="Description from XML Hint Link"/>
+                    <tag>TestTag</tag>
+                </hint>
+            </perform>
+        </rule>
+
+        <rule>
+            <when>
+                <xmlfile matches="/w:web-app/w:resource-ref/w:res-auth[text() = 'Container']">
+                    <namespace prefix="w" uri="http://java.sun.com/xml/ns/javaee"/>
+                </xmlfile>
+            </when>
+            <perform>
+                <hint title="Title for Hint from XML">
+                    <message>Container Auth</message>
+                    <tag>TestTag2</tag>
+                </hint>
+                <xslt title="Example XSLT Conversion" extension="-converted-example.xml" template="/exampleconversion.xsl"/>
+            </perform>
+        </rule>
+
+        <!-- for jsp test -->
+        <rule>
+            <when>
+                <javaclass references="http://www.example.com/othertaglib">
+                    <location>TAGLIB_IMPORT</location>
+                </javaclass>
+            </when>
+            <perform>
+                <hint title="Other Taglib Import">
+                    <message>This is importing another taglib</message>
+                    <tag>taglib</tag>
+                </hint>
+            </perform>
+        </rule>
+    </rules>
+</ruleset>

--- a/utils/src/main/java/org/jboss/windup/util/furnace/FurnaceClasspathScanner.java
+++ b/utils/src/main/java/org/jboss/windup/util/furnace/FurnaceClasspathScanner.java
@@ -64,7 +64,8 @@ public class FurnaceClasspathScanner
                 if (ruleFile != null)
                     discoveredURLs.add(ruleFile);
             }
-            result.put(addon, discoveredURLs);
+            if (!discoveredURLs.isEmpty())
+                result.put(addon, discoveredURLs);
         }
         return result;
     }


### PR DESCRIPTION
- `org.jboss.windup.config.parser.XMLRuleProviderLoader` added `rhamt.xml` extension handling
- `org.jboss.windup.util.furnace.FurnaceClasspathScanner.scanForAddonMap(Predicate<String>)` now adds an `Addon` to the result `Map` [only if the `discoveredURLs` is not empty](https://github.com/windup/windup/compare/master...mrizzi:taiga_T921?expand=1#diff-3a906af129780ff3ec760dc872a80ba8R67). In the case of running it two times ([one for each extension](https://github.com/windup/windup/compare/master...mrizzi:taiga_T921?expand=1#diff-b5e0dd11f5f1abceb2ed9530c72e5d99R158)), this change is necessary otherwise the second time the `Addon` with the first extension will be added with an empty `discoveredURLs`. 
- `org.jboss.windup.tooling.rules.RuleProviderRegistryImpl.getProviderType(String)` with its test `org.jboss.windup.tooling.ExecutionBuilderTest.testRuleProviderRegistry()`
- `org.jboss.windup.config.parser.XMLRuleProviderLoaderTest`[#77](https://github.com/windup/windup/compare/master...mrizzi:taiga_T921?expand=1#diff-9a9ec48ea0a43161570c6c0318933bccR77): get by `indexOf` because `org.jboss.windup.config.parser.XMLRuleProviderLoader.getProviders(RuleLoaderContext)` cycles through a `Map` implemented by an `java.util.IdentityHashMap<K,V>` that "[makes no guarantees as to the order of the map; in particular, it does not guarantee that the order will remain constant over time.](https://docs.oracle.com/javase/8/docs/api/java/util/IdentityHashMap.html)"
- updated many tests that uses a `*.windup.xml` file to also have a test for a `*.rhamt.xml` file (e.g. `org.jboss.windup.reporting.handlers.*`)

_NOT CHANGED_
- `org.jboss.windup.tests.bootstrap.AbstractBootstrapTestWithRules` otherwise all the tests that extend it should be duplicated

_TO DISCUSS_
- Is `org.jboss.windup.config.parser.XMLRuleProviderLoaderTest` with the two deployments the right way to change the tests with `AddonArchive` and `Deployments`?