### PR TITLE
T842 Add the path to the archive that failed to unzip

### DIFF
--- a/graph/api/src/main/java/org/jboss/windup/graph/model/ProjectModel.java
+++ b/graph/api/src/main/java/org/jboss/windup/graph/model/ProjectModel.java
@@ -52,6 +52,10 @@ public interface ProjectModel extends WindupVertexFrame
     @Adjacency(label = ROOT_FILE_MODEL, direction = Direction.OUT)
     void setRootFileModel(FileModel fileModel);
 
+    /**
+     * This represents the root directory (in the case of a source-based analysis) or root archive (for binary analysis) containing this particular
+     * project.
+     */
     @Adjacency(label = ROOT_FILE_MODEL, direction = Direction.OUT)
     FileModel getRootFileModel();
 

--- a/graph/api/src/main/java/org/jboss/windup/graph/model/resource/FileModel.java
+++ b/graph/api/src/main/java/org/jboss/windup/graph/model/resource/FileModel.java
@@ -252,6 +252,8 @@ public interface FileModel extends ResourceModel, BelongsToProject
             }
             else if (projectModel.getRootFileModel().getFilePath().equals(getFilePath()))
             {
+                // FIXME: Not quite sure if this is the right thing to return here.
+                // Maybe it should rather be the file name? Depends on where it ends up being used.
                 result = "";
             }
             else

--- a/reporting/api/src/main/java/org/jboss/windup/reporting/freemarker/problemsummary/GetProblemSummariesMethod.java
+++ b/reporting/api/src/main/java/org/jboss/windup/reporting/freemarker/problemsummary/GetProblemSummariesMethod.java
@@ -58,8 +58,8 @@ public class GetProblemSummariesMethod implements WindupFreeMarkerMethod
         Set<String> excludeTags = FreeMarkerUtil.simpleSequenceToSet((SimpleSequence) arguments.get(3));
 
         Set<ProjectModel> projectModels = getProjects(projectModel);
-        Map<IssueCategoryModel, List<ProblemSummary>> problemSummariesOriginal = ProblemSummaryService.getProblemSummaries(event.getGraphContext(), projectModels, includeTags,
-                    excludeTags);
+        Map<IssueCategoryModel, List<ProblemSummary>> problemSummariesOriginal
+                = ProblemSummaryService.getProblemSummaries(event.getGraphContext(), projectModels, includeTags, excludeTags);
 
         // Convert the keys to String to make Freemarker happy
         Comparator<IssueCategoryModel> severityComparator = new IssueCategoryModel.IssueSummaryPriorityComparator();

--- a/reporting/impl/src/main/resources/reports/templates/migration-issues.ftl
+++ b/reporting/impl/src/main/resources/reports/templates/migration-issues.ftl
@@ -18,7 +18,6 @@
         <td class="text-right"><strong>Incidents Found</strong></td>
         <td colspan="3"><strong>Hint</strong></td>
     </tr>
-
 </#macro>
 
 <#function getIncidentsFound problemSummaries>
@@ -294,6 +293,16 @@
 
         </script>
 
+        <!#-- We are using short variable names because they repeat a lot in the generated HTML
+              and using short reduces the file sizes significantly.
+              
+              {l} - label
+              {oc} - occurences
+              {h} - href
+              {t} - link title
+
+              The actual data are generated lower into MIGRATION_ISSUES_DETAILS[] .
+        -->
         <#noparse>
         <script id="detail-row-template" type="text/x-handlebars-template">
             {{#each problemSummaries}}

--- a/rules-java/api/src/main/java/org/jboss/windup/rules/apps/java/reporting/freemarker/RenderLinkDirective.java
+++ b/rules-java/api/src/main/java/org/jboss/windup/rules/apps/java/reporting/freemarker/RenderLinkDirective.java
@@ -33,6 +33,7 @@ import freemarker.template.SimpleScalar;
 import freemarker.template.TemplateDirectiveBody;
 import freemarker.template.TemplateException;
 import freemarker.template.TemplateModel;
+import org.jboss.windup.graph.model.ArchiveModel;
 import org.jboss.windup.util.IterableConverter;
 
 /**
@@ -325,6 +326,11 @@ public class RenderLinkDirective implements WindupFreeMarkerTemplateDirective
             String filename = StringUtils.removeEndIgnoreCase(fileModel.getFileName(), ".java");
             String packageName = javaSourceModel.getPackageName();
             return packageName == null || packageName.isEmpty() ? filename : packageName + "." + filename;
+        }
+        // This is used for instance when showing unparsable files in the Issues Report.
+        else if (fileModel instanceof ArchiveModel)
+        {
+            return fileModel.getPrettyPath();
         }
         else
         {

--- a/rules-java/api/src/main/java/org/jboss/windup/rules/apps/java/scan/operation/UnzipArchiveToOutputFolder.java
+++ b/rules-java/api/src/main/java/org/jboss/windup/rules/apps/java/scan/operation/UnzipArchiveToOutputFolder.java
@@ -105,7 +105,7 @@ public class UnzipArchiveToOutputFolder extends AbstractIterationOperation<Archi
                 canonicalArchive = ((DuplicateArchiveModel)canonicalArchive).getCanonicalArchive();
 
             ClassificationService classificationService = new ClassificationService(event.getGraphContext());
-            classificationService.attachClassification(event, context, canonicalArchive, MALFORMED_ARCHIVE, "Cannot unzip the file");
+            classificationService.attachClassification(event, context, canonicalArchive, MALFORMED_ARCHIVE, "Cannot unzip the file:  \n`" + inputZipFile.getPath() + "`");
             archiveModel.setParseError("Cannot unzip the file: " + e.getMessage());
             LOG.warning("Cannot unzip the file " + inputZipFile.getPath() + " to " + appArchiveFolder.toString()
                         + ". The ArchiveModel was classified as malformed.");

--- a/rules-java/api/src/main/java/org/jboss/windup/rules/apps/java/scan/operation/UnzipArchiveToOutputFolder.java
+++ b/rules-java/api/src/main/java/org/jboss/windup/rules/apps/java/scan/operation/UnzipArchiveToOutputFolder.java
@@ -105,7 +105,7 @@ public class UnzipArchiveToOutputFolder extends AbstractIterationOperation<Archi
                 canonicalArchive = ((DuplicateArchiveModel)canonicalArchive).getCanonicalArchive();
 
             ClassificationService classificationService = new ClassificationService(event.getGraphContext());
-            classificationService.attachClassification(event, context, canonicalArchive, MALFORMED_ARCHIVE, "Cannot unzip the file:  \n`" + inputZipFile.getPath() + "`");
+            classificationService.attachClassification(event, context, canonicalArchive, MALFORMED_ARCHIVE + " " + inputZipFile.getName(), "Cannot unzip the file:  \n`" + inputZipFile.getPath() + "`");
             archiveModel.setParseError("Cannot unzip the file: " + e.getMessage());
             LOG.warning("Cannot unzip the file " + inputZipFile.getPath() + " to " + appArchiveFolder.toString()
                         + ". The ArchiveModel was classified as malformed.");


### PR DESCRIPTION
The task wanted a link. But is that the right solution? Is the user expected to download it and try to unzip manually? Although, we would have to store the archive exceptionally as a part of the report, which we normally don't do unless --keepWorkDirs .

So I am only adding the path.