### PR TITLE
WINDUPRULE-250+251 Rename 'WebSphere WS Extension/Binding'

### DIFF
--- a/rules-java-ee/addon/src/main/java/org/jboss/windup/rules/apps/javaee/rules/websphere/ResolveWebSphereWsBindingXmlRuleProvider.java
+++ b/rules-java-ee/addon/src/main/java/org/jboss/windup/rules/apps/javaee/rules/websphere/ResolveWebSphereWsBindingXmlRuleProvider.java
@@ -39,7 +39,7 @@ public class ResolveWebSphereWsBindingXmlRuleProvider extends IteratingRuleProvi
     {
         ClassificationService classificationService = new ClassificationService(event.getGraphContext());
         ClassificationModel classificationModel = classificationService.attachClassification(event, context, payload, IssueCategoryRegistry.MANDATORY,
-                    "WebSphere WS Binding",
+                    "WebSphere web service binding descriptor (ibm-webservices-bnd)",
                     "WebSphere Webservice Binding XML Deployment Descriptor.  \n"
                                 + "This deployment descriptor extension is IBM specific and it needs to be migrated to JBossWS.  \n"
                                 + "JBossWS implements the latest JAX-WS specification, which users can reference for any vendor-agnostic web service usage need.  \n"

--- a/rules-java-ee/addon/src/main/java/org/jboss/windup/rules/apps/javaee/rules/websphere/ResolveWebSphereWsExtensionXmlRuleProvider.java
+++ b/rules-java-ee/addon/src/main/java/org/jboss/windup/rules/apps/javaee/rules/websphere/ResolveWebSphereWsExtensionXmlRuleProvider.java
@@ -39,7 +39,7 @@ public class ResolveWebSphereWsExtensionXmlRuleProvider extends IteratingRulePro
     {
         ClassificationService classificationService = new ClassificationService(event.getGraphContext());
         ClassificationModel classificationModel = classificationService.attachClassification(event, context, payload, IssueCategoryRegistry.MANDATORY,
-                    "WebSphere WS Extension",
+                    "WebSphere web service extension descriptor (ibm-webservices-ext)",
                     "WebSphere Webservice Extension XML Deployment Descriptor.  \n"
                                 + "This deployment descriptor extension is IBM specific and it needs to be migrated to JBossWS.  \n"
                                 + "JBossWS implements the latest JAX-WS specification, which users can reference for any vendor-agnostic web service usage need.  \n"


### PR DESCRIPTION
Required classifications' title changes:

- “WebSphere WS Extension” → “WebSphere web service extension descriptor (ibm-webservices-ext)”
- “WebSphere WS Binding” → “WebSphere web service binding descriptor (ibm-webservices-bnd)”
