### PR TITLE
WINDUP-1494 sort apps case insensitive

### DIFF
--- a/reporting/api/src/main/java/org/jboss/windup/reporting/freemarker/GetEffortDescriptionForPoints.java
+++ b/reporting/api/src/main/java/org/jboss/windup/reporting/freemarker/GetEffortDescriptionForPoints.java
@@ -2,7 +2,6 @@ package org.jboss.windup.reporting.freemarker;
 
 import java.util.List;
 
-import org.jboss.windup.config.GraphRewrite;
 import org.jboss.windup.reporting.service.EffortReportService;
 import org.jboss.windup.reporting.service.EffortReportService.Verbosity;
 import org.jboss.windup.util.ExecutionStatistics;

--- a/reporting/api/src/main/java/org/jboss/windup/reporting/freemarker/IterableToListMethod.java
+++ b/reporting/api/src/main/java/org/jboss/windup/reporting/freemarker/IterableToListMethod.java
@@ -1,0 +1,56 @@
+package org.jboss.windup.reporting.freemarker;
+
+import java.util.List;
+
+import org.jboss.windup.config.GraphRewrite;
+import org.jboss.windup.util.ExecutionStatistics;
+
+import freemarker.ext.beans.BeanModel;
+
+import freemarker.template.TemplateModelException;
+import java.util.ArrayList;
+
+/**
+ * Turns the given Iterable into a List.
+ *
+ * Example call: iteratorToList(Iterable).
+ *
+ * @author <a href="mailto:zizka@seznam.cz">Ondrej Zizka</a>
+ */
+public class IterableToListMethod implements WindupFreeMarkerMethod
+{
+    private static final String NAME = "iterableToList";
+
+    @Override
+    public void setContext(GraphRewrite event)
+    {
+    }
+
+    @Override
+    public Object exec(@SuppressWarnings("rawtypes") List arguments) throws TemplateModelException
+    {
+        ExecutionStatistics.get().begin(NAME);
+        if (arguments.size() != 1)
+            throw new TemplateModelException("Error, method expects one argument (an Iterable)");
+
+        BeanModel iterableModelArg = (BeanModel) arguments.get(0);
+        Iterable iterable = (Iterable) iterableModelArg.getWrappedObject();
+        List list = new ArrayList();
+        iterable.iterator().forEachRemaining(list::add);
+        ExecutionStatistics.get().end(NAME);
+        return list;
+    }
+
+    @Override
+    public String getMethodName()
+    {
+        return NAME;
+    }
+
+    @Override
+    public String getDescription()
+    {
+        return "Turns the given Iterable into a List.";
+    }
+
+}

--- a/reporting/api/src/main/java/org/jboss/windup/reporting/freemarker/SortApplicationsListMethod.java
+++ b/reporting/api/src/main/java/org/jboss/windup/reporting/freemarker/SortApplicationsListMethod.java
@@ -1,0 +1,59 @@
+package org.jboss.windup.reporting.freemarker;
+
+import java.util.List;
+
+import org.jboss.windup.config.GraphRewrite;
+import org.jboss.windup.graph.GraphContext;
+import org.jboss.windup.util.ExecutionStatistics;
+
+import freemarker.template.DefaultListAdapter;
+
+import freemarker.template.TemplateModelException;
+import java.util.Collections;
+import org.jboss.windup.reporting.model.ApplicationReportModel;
+import org.jboss.windup.reporting.rules.CreateApplicationListReportRuleProvider;
+
+/**
+ * Sorts the given list of ApplicationReportModel's by it's root filename or, for VIRTUAL apps, by the name.
+ *
+ * @author <a href="mailto:zizka@seznam.cz">Ondrej Zizka</a>
+ */
+public class SortApplicationsListMethod implements WindupFreeMarkerMethod
+{
+    private static final String NAME = "sortApplicationsList";
+    private GraphContext context;
+
+    @Override
+    public void setContext(GraphRewrite event)
+    {
+        this.context = event.getGraphContext();
+    }
+
+    @Override
+    public Object exec(@SuppressWarnings("rawtypes") List arguments) throws TemplateModelException
+    {
+        ExecutionStatistics.get().begin(NAME);
+        if (arguments.size() != 1)
+            throw new TemplateModelException("Error, method expects one argument (an Iterable)");
+
+        DefaultListAdapter listModelArg = (DefaultListAdapter) arguments.get(0);
+        List<ApplicationReportModel> list = (List<ApplicationReportModel>) listModelArg.getWrappedObject();
+        Collections.sort(list, new CreateApplicationListReportRuleProvider.AppRootFileNameComparator());
+
+        ExecutionStatistics.get().end(NAME);
+        return list;
+    }
+
+    @Override
+    public String getMethodName()
+    {
+        return NAME;
+    }
+
+    @Override
+    public String getDescription()
+    {
+        return "Sorts the given list of ApplicationReportModel's by it's root filename or, for VIRTUAL apps, by the name.";
+    }
+
+}

--- a/reporting/api/src/main/java/org/jboss/windup/reporting/model/WindupVertexListModel.java
+++ b/reporting/api/src/main/java/org/jboss/windup/reporting/model/WindupVertexListModel.java
@@ -13,9 +13,10 @@ import com.tinkerpop.frames.modules.typedgraph.TypeValue;
 
 /**
  * Contains a list of {@link WindupVertexFrame} objects and (for convenience) implements the {@link Iterable} interface as well.
- * 
- * @author <a href="mailto:jesse.sightler@gmail.com">Jesse Sightler</a>
  *
+ * NOTE that this currently doesn't keep the order of the elements. So it's more of a 
+ *
+ * @author <a href="mailto:jesse.sightler@gmail.com">Jesse Sightler</a>
  */
 @TypeValue(WindupVertexListModel.TYPE)
 public interface WindupVertexListModel<T extends WindupVertexFrame> extends WindupVertexFrame, Iterable<T>

--- a/reporting/api/src/main/java/org/jboss/windup/reporting/rules/CreateApplicationListReportRuleProvider.java
+++ b/reporting/api/src/main/java/org/jboss/windup/reporting/rules/CreateApplicationListReportRuleProvider.java
@@ -46,6 +46,8 @@ import org.ocpsoft.rewrite.context.EvaluationContext;
 )
 public class CreateApplicationListReportRuleProvider extends AbstractRuleProvider
 {
+    private static final Logger LOG = Logger.getLogger(CreateApplicationListReportRuleProvider.class);
+
     public static final String APPLICATION_LIST_REPORT = "Application List";
     private static final String OUTPUT_FILENAME = "../index.html";
     public static final String TEMPLATE_PATH = "/reports/templates/application_list.ftl";
@@ -98,8 +100,8 @@ public class CreateApplicationListReportRuleProvider extends AbstractRuleProvide
         }
 
         // Our current model doesn't keep the list order, but once I wrote, I'm leaving the sorting here for when it does.
-        Collections.sort(appsList, new AppRootFileNameComparator());
-        Logger.getLogger(CreateApplicationListReportRuleProvider.class).info("AppList sorted:\n    " + StringUtils.join(appsList, "\n    "));///
+        //Collections.sort(appsList, new AppRootFileNameComparator());
+        LOG.info("AppList sorted:\n    " + StringUtils.join(appsList, "\n    "));///
         WindupVertexListModel<ApplicationReportModel> appsListVertex = listService.create();
         relatedData.put("applications", appsListVertex);
         for (ApplicationReportModel applicationReportModel : appsList)
@@ -109,20 +111,24 @@ public class CreateApplicationListReportRuleProvider extends AbstractRuleProvide
         List<ApplicationReportModel> appsSorted = new ArrayList<>();
         appsListVertex.getList().iterator().forEachRemaining(appsSorted::add);
         String names = appsSorted.stream().map(arm -> arm.getProjectModel().getRootFileModel().getFileName()).collect(Collectors.joining("\n    "));
-        Logger.getLogger(CreateApplicationListReportRuleProvider.class).info("AppList queried:\n    " + String.join("\n    ",  names));
+        LOG.info("AppList queried:\n    " + String.join("\n    ",  names));
 
         report.setRelatedResource(relatedData);
     }
 
 
 
-    private static class AppRootFileNameComparator implements Comparator<ApplicationReportModel>
+    public static class AppRootFileNameComparator implements Comparator<ApplicationReportModel>
     {
+        public AppRootFileNameComparator()
+        {
+        }
+
         public int compare(ApplicationReportModel o1, ApplicationReportModel o2)
         {
-            Logger.getLogger(CreateApplicationListReportRuleProvider.class).info(
-                    "Comparing " + o1.getProjectModel().getRootFileModel().getFileName() +
-                    " and      " + o2.getProjectModel().getRootFileModel().getFileName());///
+            LOG.info("\n\n"
+                    + "Comparing " + o1.getProjectModel().getRootFileModel().getFileName()
+                    + " and      " + o2.getProjectModel().getRootFileModel().getFileName());///
 
             // If the info is missing, put that to the end. This may be the case of virtual apps.
             if (null == o1.getProjectModel() || null == o1.getProjectModel().getRootFileModel() || null == o1.getProjectModel().getRootFileModel().getFileName() )
@@ -130,12 +136,16 @@ public class CreateApplicationListReportRuleProvider extends AbstractRuleProvide
             if (null == o2.getProjectModel() || null == o2.getProjectModel().getRootFileModel() || null == o2.getProjectModel().getRootFileModel().getFileName() )
                 return -1;
 
+            LOG.info("Wasn't null...");
             try {
-                return o1.getProjectModel().getRootFileModel().getFileName().compareToIgnoreCase(o2.getProjectModel().getRootFileModel().getFileName());
+                int res = o1.getProjectModel().getRootFileModel().getFileName().compareToIgnoreCase(o2.getProjectModel().getRootFileModel().getFileName());
+                LOG.info("Result: " + res);
+                return res;
                 //return Comparator.comparing((ApplicationReportModel o) -> o.getProjectModel().getRootFileModel().getFileName(), String::compareToIgnoreCase).compare(o1, o2);
             }
             catch (Throwable ex)
             {
+                LOG.info("Was null afterall? Just leave it as is.");
                 return 0;
             }
         }

--- a/reporting/api/src/main/java/org/jboss/windup/reporting/rules/CreateApplicationListReportRuleProvider.java
+++ b/reporting/api/src/main/java/org/jboss/windup/reporting/rules/CreateApplicationListReportRuleProvider.java
@@ -7,11 +7,8 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import javax.inject.Inject;
-import org.apache.commons.lang3.StringUtils;
 
 import org.jboss.forge.furnace.Furnace;
 import org.jboss.windup.config.AbstractRuleProvider;
@@ -100,18 +97,11 @@ public class CreateApplicationListReportRuleProvider extends AbstractRuleProvide
         }
 
         // Our current model doesn't keep the list order, but once I wrote, I'm leaving the sorting here for when it does.
-        //Collections.sort(appsList, new AppRootFileNameComparator());
-        LOG.info("AppList sorted:\n    " + StringUtils.join(appsList, "\n    "));///
+        Collections.sort(appsList, new AppRootFileNameComparator());
         WindupVertexListModel<ApplicationReportModel> appsListVertex = listService.create();
         relatedData.put("applications", appsListVertex);
         for (ApplicationReportModel applicationReportModel : appsList)
             appsListVertex.addItem(applicationReportModel);
-
-        /// Test whether it remains sorted when queried.
-        List<ApplicationReportModel> appsSorted = new ArrayList<>();
-        appsListVertex.getList().iterator().forEachRemaining(appsSorted::add);
-        String names = appsSorted.stream().map(arm -> arm.getProjectModel().getRootFileModel().getFileName()).collect(Collectors.joining("\n    "));
-        LOG.info("AppList queried:\n    " + String.join("\n    ",  names));
 
         report.setRelatedResource(relatedData);
     }
@@ -126,26 +116,18 @@ public class CreateApplicationListReportRuleProvider extends AbstractRuleProvide
 
         public int compare(ApplicationReportModel o1, ApplicationReportModel o2)
         {
-            LOG.info("\n\n"
-                    + "Comparing " + o1.getProjectModel().getRootFileModel().getFileName()
-                    + " and      " + o2.getProjectModel().getRootFileModel().getFileName());///
-
             // If the info is missing, put that to the end. This may be the case of virtual apps.
             if (null == o1.getProjectModel() || null == o1.getProjectModel().getRootFileModel() || null == o1.getProjectModel().getRootFileModel().getFileName() )
                 return 1;
             if (null == o2.getProjectModel() || null == o2.getProjectModel().getRootFileModel() || null == o2.getProjectModel().getRootFileModel().getFileName() )
                 return -1;
 
-            LOG.info("Wasn't null...");
             try {
-                int res = o1.getProjectModel().getRootFileModel().getFileName().compareToIgnoreCase(o2.getProjectModel().getRootFileModel().getFileName());
-                LOG.info("Result: " + res);
-                return res;
+                return o1.getProjectModel().getRootFileModel().getFileName().compareToIgnoreCase(o2.getProjectModel().getRootFileModel().getFileName());
                 //return Comparator.comparing((ApplicationReportModel o) -> o.getProjectModel().getRootFileModel().getFileName(), String::compareToIgnoreCase).compare(o1, o2);
             }
             catch (Throwable ex)
             {
-                LOG.info("Was null afterall? Just leave it as is.");
                 return 0;
             }
         }

--- a/reporting/impl/src/main/resources/reports/templates/application_list.ftl
+++ b/reporting/impl/src/main/resources/reports/templates/application_list.ftl
@@ -184,7 +184,10 @@
             <#assign virtualAppExists = false>
             <div class="real">
                 <#-- See CreateApplicationListReportRuleProvider -->
-                <#list reportModel.relatedResources.applications.list.iterator() as applicationReport>
+                <#--
+                <#list iterableToList(reportModel.relatedResources.applications.list)?sort_by(["projectModel","rootFileModel","fileName"]) as applicationReport>
+                -->
+                <#list sortApplicationsList(iterableToList(reportModel.relatedResources.applications.list)) as applicationReport>
                     <#if applicationReport.projectModel.projectType! != "VIRTUAL" >
                         <@applicationReportRenderer applicationReport/>
                     <#else>
@@ -208,7 +211,7 @@
         </div>
         <section class="apps">
             <div class="virtual">
-                <#list reportModel.relatedResources.applications.list.iterator() as applicationReport>
+                <#list iterableToList(reportModel.relatedResources.applications.list)?sort_by(["projectModel","name"]) as applicationReport>
                     <#if applicationReport.projectModel.projectType! = "VIRTUAL" >
                         <@applicationReportRenderer applicationReport/>
                     </#if>

--- a/reporting/impl/src/main/resources/reports/templates/application_list.ftl
+++ b/reporting/impl/src/main/resources/reports/templates/application_list.ftl
@@ -241,7 +241,7 @@
         });
 
         $("body.viewAppList .apps .real .appInfo").sortElements(function(a, b){
-            return $(a).find(".traits .fileName").first().text().trim() > $(b).find(".traits .fileName").first().text().trim() ? 1 : -1;
+            return $(a).find(".traits .fileName").first().text().trim().toLowerCase() > $(b).find(".traits .fileName").first().text().trim().toLowerCase() ? 1 : -1;
         });
     </script>
     <script src="reports/resources/js/bootstrap.min.js"></script>


### PR DESCRIPTION
This is sorting it at three places - first when adding it to the graph, which doesn't keep it sorted.
Then when generating it to the report, and then in JavaScript.
I am keeping all of them - 1st in case it starts keeping order, 2nd because it is necessary now, and the 3rd in case we get a request to sort it on the page by different criteria.