### PR TITLE
Changed description to not confuse later for such description even id…

### DIFF
--- a/rules-java/api/src/main/java/org/jboss/windup/rules/apps/java/scan/provider/DiscoverNonMavenArchiveProjectsRuleProvider.java
+++ b/rules-java/api/src/main/java/org/jboss/windup/rules/apps/java/scan/provider/DiscoverNonMavenArchiveProjectsRuleProvider.java
@@ -90,7 +90,7 @@ public class DiscoverNonMavenArchiveProjectsRuleProvider extends AbstractRulePro
                                     projectModel = projectModelService.create();
                                     projectModel.setName(archiveModel.getArchiveName());
                                     projectModel.setRootFileModel(archiveModel);
-                                    projectModel.setDescription("Unidentified Archive");
+                                    projectModel.setDescription("Not available");
 
                                     if(ZipUtil.endsWithZipExtension(archiveModel.getArchiveName()))
                                     {


### PR DESCRIPTION
…entified

I saw multiple times in Dependency report where all fields are filled and Description with "Unidentified Archive" string.