### PR TITLE
Revert deleting BelongsToProject

### DIFF
--- a/graph/api/src/main/java/org/jboss/windup/graph/model/BelongsToProject.java
+++ b/graph/api/src/main/java/org/jboss/windup/graph/model/BelongsToProject.java
@@ -5,6 +5,13 @@ package org.jboss.windup.graph.model;
  */
 public interface BelongsToProject
 {
+    /**
+     * Checks if current model belongs to given project model
+     *
+     * @param projectModel
+     * @return true if model belongs to project model, otherwise false
+     */
+    boolean belongsToProject(ProjectModel projectModel);
 
     /**
      * Gets all root project models for current model (This will be mostly 1, but there are few exceptions which have multiple project models, so it

--- a/graph/api/src/main/java/org/jboss/windup/graph/model/resource/FileModel.java
+++ b/graph/api/src/main/java/org/jboss/windup/graph/model/resource/FileModel.java
@@ -243,6 +243,10 @@ public interface FileModel extends ResourceModel, BelongsToProject
 
     @Override
     @JavaHandler
+    boolean belongsToProject(ProjectModel projectModel);
+
+    @Override
+    @JavaHandler
     Iterable<ProjectModel> getRootProjectModels();
 
     abstract class Impl implements FileModel, JavaHandlerContext<Vertex>, BelongsToProject
@@ -357,6 +361,12 @@ public interface FileModel extends ResourceModel, BelongsToProject
                 return null;
 
             return new File(getFilePath());
+        }
+
+        @Override
+        public boolean belongsToProject(ProjectModel projectModel)
+        {
+            return this.getProjectModel().equals(this.getCanonicalProjectModel(projectModel));
         }
 
         @Override

--- a/rules-java-ee/addon/src/main/java/org/jboss/windup/rules/apps/javaee/model/HasApplications.java
+++ b/rules-java-ee/addon/src/main/java/org/jboss/windup/rules/apps/javaee/model/HasApplications.java
@@ -19,10 +19,29 @@ public interface HasApplications extends BelongsToProject
 
     @Override
     @JavaHandler
+    boolean belongsToProject(ProjectModel projectModel);
+
+    @Override
+    @JavaHandler
     Iterable<ProjectModel> getRootProjectModels();
 
     abstract class Impl implements HasApplications, JavaHandlerContext<Vertex>, BelongsToProject
     {
+        @Override
+        public boolean belongsToProject(ProjectModel project)
+        {
+            ProjectModel canonicalProjectModel = this.getCanonicalProjectModel(project);
+
+            for (ProjectModel currentProject : this.getApplications())
+            {
+                if (currentProject.equals(canonicalProjectModel))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
 
         @Override
         public Iterable<ProjectModel> getRootProjectModels()

--- a/rules-java/api/src/main/java/org/jboss/windup/rules/apps/java/model/JavaClassModel.java
+++ b/rules-java/api/src/main/java/org/jboss/windup/rules/apps/java/model/JavaClassModel.java
@@ -196,10 +196,26 @@ public interface JavaClassModel extends WindupVertexFrame, BelongsToProject
 
     @JavaHandler
     @Override
+    boolean belongsToProject(ProjectModel projectModel);
+
+    @JavaHandler
+    @Override
     Iterable<ProjectModel> getRootProjectModels();
 
     abstract class Impl implements JavaHandlerContext<Vertex>, JavaClassModel, BelongsToProject
     {
+        @Override
+        public boolean belongsToProject(ProjectModel projectModel)
+        {
+            FileModel sourceModel = this.getSourceFile();
+
+            if (sourceModel == null)
+            {
+                return false;
+            }
+
+            return sourceModel.belongsToProject(projectModel);
+        }
 
         @Override
         public Iterable<ProjectModel> getRootProjectModels()


### PR DESCRIPTION
`BelongsToProject` is actually used on multiple places.

- https://github.com/windup/windup/blob/master/rules-java-ee/addon/src/main/java/org/jboss/windup/rules/apps/javaee/model/stats/TechnologiesStatsService.java#L259
https://github.com/windup/windup-web/blob/master/addons/web-support/impl/src/main/java/org/jboss/windup/web/addons/websupport/rest/graph/EJBResourceImpl.java#L68 (which is now causing build failures on windup-web)


We should rather fix its behavior to deal correctly with shared libraries. Or find some better solution how to group data to project.