### PR TITLE
WINDUP-1659 Source code page:orange refs hidden from top nav bar

### DIFF
--- a/reporting/impl/src/main/resources/reports/templates/source.ftl
+++ b/reporting/impl/src/main/resources/reports/templates/source.ftl
@@ -197,6 +197,13 @@
                  }
             });
             $(window).sausage({ page: 'li.box' });
+            $(window).resize(function () {
+                $('div.sausage-set').css('top', parseInt($('#main-navbar').css("height")));
+            });
+
+            $(window).load(function () {
+                $('div.sausage-set').css('top', parseInt($('#main-navbar').css("height")));
+            });
         });
 
         function qs(key) {


### PR DESCRIPTION
I tried to create it in `div.container-fluid` and not in `$(window)` (see [._create() method](https://christophercliff.com/sausage/docs/jquery.sausage.html#section-6)) but, after debugging, it doesn’t work (found on open issue on sausage repo [issue-9](https://github.com/christophercliff/sausage/issues/9))
Final solution: override top value in CSS to equal `#main-navbar`’s height using JS.

Tested with application `rhq-enterprise-server-ear-1.3.0.EmbJopr.1.3.0-4.ear`
in source for file `rhq-portal.war/WEB-INF/classes/ApplicationResources.properties` for `Hard-coded IP address` rule.

See [WINDUP-1659](https://issues.jboss.org/browse/WINDUP-1659) for screenshots
