### PR TITLE
WINDUP-1665 DiscoverWebXmlRuleProvider fix for geronimo-web-xml

### DIFF
--- a/rules-java-ee/addon/src/main/java/org/jboss/windup/rules/apps/javaee/rules/DiscoverWebXmlRuleProvider.java
+++ b/rules-java-ee/addon/src/main/java/org/jboss/windup/rules/apps/javaee/rules/DiscoverWebXmlRuleProvider.java
@@ -12,6 +12,7 @@ import org.jboss.windup.config.GraphRewrite;
 import org.jboss.windup.config.metadata.RuleMetadata;
 import org.jboss.windup.config.phase.InitialAnalysisPhase;
 import org.jboss.windup.config.query.Query;
+import org.jboss.windup.config.query.QueryPropertyComparisonType;
 import org.jboss.windup.config.ruleprovider.IteratingRuleProvider;
 import org.jboss.windup.graph.GraphContext;
 import org.jboss.windup.reporting.model.TechnologyTagLevel;
@@ -52,7 +53,7 @@ public class DiscoverWebXmlRuleProvider extends IteratingRuleProvider<XmlFileMod
     @Override
     public ConditionBuilder when()
     {
-        return Query.fromType(XmlFileModel.class).withProperty(XmlFileModel.ROOT_TAG_NAME, "web-app");
+        return Query.fromType(XmlFileModel.class).withProperty(XmlFileModel.ROOT_TAG_NAME, "web-app").withProperty(XmlFileModel.FILE_NAME, QueryPropertyComparisonType.NOT_EQUALS,  "geronimo-web.xml");
     }
 
     public void perform(GraphRewrite event, EvaluationContext context, XmlFileModel payload)

--- a/rules-java-ee/tests/src/test/java/org/jboss/windup/rules/apps/javaee/tests/DiscoverWebXmlTest.java
+++ b/rules-java-ee/tests/src/test/java/org/jboss/windup/rules/apps/javaee/tests/DiscoverWebXmlTest.java
@@ -1,0 +1,74 @@
+package org.jboss.windup.rules.apps.javaee.tests;
+
+import com.google.common.collect.Iterables;
+import org.apache.commons.io.FileUtils;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.forge.furnace.util.OperatingSystemUtils;
+import org.jboss.windup.exec.WindupProcessor;
+import org.jboss.windup.exec.configuration.WindupConfiguration;
+import org.jboss.windup.graph.GraphContext;
+import org.jboss.windup.graph.GraphContextFactory;
+import org.jboss.windup.graph.model.LinkModel;
+import org.jboss.windup.graph.model.ProjectModel;
+import org.jboss.windup.graph.model.WindupConfigurationModel;
+import org.jboss.windup.graph.model.resource.FileModel;
+import org.jboss.windup.graph.service.GraphService;
+import org.jboss.windup.rules.apps.javaee.AbstractTest;
+import org.jboss.windup.rules.apps.javaee.model.EjbMessageDrivenModel;
+import org.jboss.windup.rules.apps.javaee.model.WebXmlModel;
+import org.jboss.windup.rules.apps.javaee.rules.DiscoverWebXmlRuleProvider;
+import org.jboss.windup.rules.apps.javaee.rules.jboss.GenerateJBossWebDescriptorRuleProvider;
+import org.jboss.windup.rules.apps.xml.model.XmlFileModel;
+import org.jboss.windup.testutil.basics.WindupTestUtilMethods;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.inject.Inject;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.UUID;
+
+@RunWith(Arquillian.class)
+public class DiscoverWebXmlTest extends AbstractTest
+{
+    @Inject
+    private WindupProcessor processor;
+
+    @Inject
+    private GraphContextFactory factory;
+
+    @Test
+    public void testWebXmlMetadataExtraction() throws Exception
+    {
+        try (GraphContext context = factory.create())
+        {
+            ProjectModel pm = context.getFramed().addVertex(null, ProjectModel.class);
+            pm.setName("Main Project");
+            FileModel inputPath = context.getFramed().addVertex(null, FileModel.class);
+            inputPath.setFilePath("src/test/resources/web-xml/");
+
+            Path outputPath = Paths.get(FileUtils.getTempDirectory().toString(), "windup_"
+                        + UUID.randomUUID().toString());
+            FileUtils.deleteDirectory(outputPath.toFile());
+            Files.createDirectories(outputPath);
+
+            pm.addFileModel(inputPath);
+            pm.setRootFileModel(inputPath);
+            WindupConfiguration windupConfiguration = new WindupConfiguration()
+                        .setGraphContext(context);
+            windupConfiguration.addInputPath(Paths.get(inputPath.getFilePath()));
+            windupConfiguration.setOutputDirectory(outputPath);
+            processor.execute(windupConfiguration);
+
+            GraphService<WebXmlModel> webXmlModelGraphService = new GraphService<>(context, WebXmlModel.class);
+            Iterator<WebXmlModel> models = webXmlModelGraphService.findAll().iterator();
+            Assert.assertTrue(models.hasNext());
+            models.next();
+            Assert.assertFalse(models.hasNext());
+        }
+    }
+}

--- a/rules-java-ee/tests/src/test/resources/web-xml/geronimo-web.xml
+++ b/rules-java-ee/tests/src/test/resources/web-xml/geronimo-web.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+    <web-app xmlns="http://geronimo.apache.org/xml/ns/web"
+        xmlns:naming="http://geronimo.apache.org/xml/ns/naming"
+        configId="TradeWeb" parentId="Trade">
+    
+    <context-priority-classloader>false</context-priority-classloader>
+
+    <naming:resource-ref>
+        <naming:ref-name>jdbc/TestDataSource</naming:ref-name>
+        <naming:resource-link>
+            TestDataSource
+        </naming:resource-link>
+    </naming:resource-ref>
+</web-app>
+
+

--- a/rules-java-ee/tests/src/test/resources/web-xml/web.xml
+++ b/rules-java-ee/tests/src/test/resources/web-xml/web.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<web-app version="2.4"
+	xmlns="http://java.sun.com/xml/ns/j2ee"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://java.sun.com/xml/ns/j2ee http://java.sun.com/xml/ns/j2ee/web-app_2_4.xsd">
+
+      <display-name>TestWeb</display-name>
+      <session-config id="SessionConfig_1">
+         <session-timeout>30</session-timeout>
+      </session-config>
+      <welcome-file-list id="WelcomeFileList_1">
+         <welcome-file>index.html</welcome-file>
+      </welcome-file-list>
+      <resource-ref>
+         <res-ref-name>jdbc/TradeDataSource</res-ref-name>
+         <res-type>javax.sql.DataSource</res-type>
+         <res-auth>Container</res-auth>
+         <res-sharing-scope>Shareable</res-sharing-scope>
+      </resource-ref>
+      <resource-ref>
+         <res-ref-name>jms/QueueConnectionFactory</res-ref-name>
+         <res-type>javax.jms.QueueConnectionFactory</res-type>
+         <res-auth>Application</res-auth>
+         <res-sharing-scope>Shareable</res-sharing-scope>
+      </resource-ref>
+      <resource-ref>
+         <res-ref-name>jms/TopicConnectionFactory</res-ref-name>
+         <res-type>javax.jms.TopicConnectionFactory</res-type>
+         <res-auth>Application</res-auth>
+         <res-sharing-scope>Shareable</res-sharing-scope>
+      </resource-ref>
+      <ejb-ref>
+         <ejb-ref-name>ejb/Trade</ejb-ref-name>
+         <ejb-ref-type>Session</ejb-ref-type>
+         <home>org.apache.geronimo.samples.daytrader.ejb.TradeHome</home>
+         <remote>org.apache.geronimo.samples.daytrader.ejb.Trade</remote>
+         <ejb-link>TradeEJB</ejb-link>
+      </ejb-ref>
+      <ejb-ref>
+         <ejb-ref-name>ejb/Quote</ejb-ref-name>
+         <ejb-ref-type>Entity</ejb-ref-type>
+         <home>org.apache.geronimo.samples.daytrader.ejb.QuoteHome</home>
+         <remote>org.apache.geronimo.samples.daytrader.ejb.Quote</remote>
+         <ejb-link>QuoteEJB</ejb-link>
+      </ejb-ref>      
+      <ejb-local-ref>
+         <ejb-ref-name>ejb/LocalQuote</ejb-ref-name>
+         <ejb-ref-type>Entity</ejb-ref-type>
+         <local-home>org.apache.geronimo.samples.daytrader.ejb.LocalQuoteHome</local-home>
+         <local>org.apache.geronimo.samples.daytrader.ejb.LocalQuote</local>
+         <ejb-link>QuoteEJB</ejb-link>
+      </ejb-local-ref>
+      <ejb-local-ref>
+         <ejb-ref-name>ejb/LocalAccountHome</ejb-ref-name>
+         <ejb-ref-type>Entity</ejb-ref-type>
+         <local-home>org.apache.geronimo.samples.daytrader.ejb.LocalAccountHome</local-home>
+         <local>org.apache.geronimo.samples.daytrader.ejb.LocalAccount</local>
+         <ejb-link>AccountEJB</ejb-link>
+      </ejb-local-ref>
+      <message-destination-ref id="MessageDestinationRef_1">
+         <message-destination-ref-name>jms/TradeBrokerQueue</message-destination-ref-name>
+         <message-destination-type>javax.jms.Queue</message-destination-type>
+         <message-destination-usage>Produces</message-destination-usage>
+         <message-destination-link>daytrader-ejb-1.0.jar#TradeBrokerQueue</message-destination-link>
+      </message-destination-ref>
+      <message-destination-ref id="MessageDestinationRef_2">
+         <message-destination-ref-name>jms/TradeStreamerTopic</message-destination-ref-name>
+         <message-destination-type>javax.jms.Topic</message-destination-type>
+         <message-destination-usage>Produces</message-destination-usage>
+         <message-destination-link>daytrader-ejb-1.0.jar#TradeStreamerTopic</message-destination-link>
+      </message-destination-ref>
+      <service-ref>
+        <description>WSDL Service Trade</description>
+        <service-ref-name>service/Trade</service-ref-name>
+        <service-interface>org.apache.geronimo.samples.daytrader.client.ws.Trade</service-interface>
+        <wsdl-file>WEB-INF/wsdl/TradeServices.wsdl</wsdl-file>
+        <jaxrpc-mapping-file>WEB-INF/TradeServicesClient_mapping.xml</jaxrpc-mapping-file>
+        <service-qname xmlns:pfx="http://daytrader.samples.geronimo.apache.org">pfx:Trade</service-qname>
+        <port-component-ref>
+            <service-endpoint-interface>org.apache.geronimo.samples.daytrader.client.ws.TradeWSServices</service-endpoint-interface>
+        </port-component-ref>
+    </service-ref>
+</web-app>


### PR DESCRIPTION
The issue:
1. The rule searches for "web-app" tag and if finds it in in the configuration file for geronimo `geronimo-web.xml` (it's not a regular `web.xml` file)
2. `geronimo-web.xml` has a `<naming:resource-ref>` definition, [this line from DiscoverWebXmlRuleProvider](https://github.com/windup/windup/blob/master/rules-java-ee/addon/src/main/java/org/jboss/windup/rules/apps/javaee/rules/DiscoverWebXmlRuleProvider.java#L192) is executed 
3. but what is called `res-ref-name` in `web.xml`, in `geronimo-web.xml` is called `ref-name` so method [processElement from DiscoverWebXmlRuleProvider](https://github.com/windup/windup/blob/master/rules-java-ee/addon/src/main/java/org/jboss/windup/rules/apps/javaee/rules/DiscoverWebXmlRuleProvider.java#L211) return an object without name field
4. then [GenerateJBossWebDescriptorRuleProvider](https://github.com/windup/windup/blob/master/rules-java-ee/addon/src/main/java/org/jboss/windup/rules/apps/javaee/rules/jboss/GenerateJBossWebDescriptorRuleProvider.java) doesn't create a valid transformed file

The fix:

- avoid the rule to consider file named `geronimo-web.xml` because Geronimo always searches for a configuration file named this way (ref. [Apache Geronimo docs](http://geronimo.apache.org/GMOxDOC30/geronimo-webxml.html#geronimo-web.xml-Overview))
- add a test case `DiscoverWebXmlTest` to the rule using test data from the `web-xml` folder with a file to be found from the rule (`web.xml`) and one to be discarded (`geronimo-web.xml`)


