### PR TITLE
WINDUPRULE-289 Adding EjbBeanBaseModel handling

### DIFF
--- a/rules-java-ee/addon/src/main/java/org/jboss/windup/rules/apps/javaee/TechnologyIdentified.java
+++ b/rules-java-ee/addon/src/main/java/org/jboss/windup/rules/apps/javaee/TechnologyIdentified.java
@@ -13,6 +13,7 @@ import org.jboss.windup.graph.model.WindupVertexFrame;
 import org.jboss.windup.graph.model.resource.FileModel;
 import org.jboss.windup.reporting.model.TagSetModel;
 import org.jboss.windup.reporting.service.TagSetService;
+import org.jboss.windup.rules.apps.javaee.model.EjbBeanBaseModel;
 import org.jboss.windup.rules.apps.javaee.model.JNDIResourceModel;
 import org.jboss.windup.rules.apps.javaee.model.stats.TechnologyUsageStatisticsModel;
 import org.jboss.windup.util.Logging;
@@ -126,6 +127,10 @@ public class TechnologyIdentified extends AbstractIterationOperation<WindupVerte
         {
             JNDIResourceModel jndiResourceModel = (JNDIResourceModel)payload;
             jndiResourceModel.getApplications().forEach(projects::add);
+        } else if (payload instanceof EjbBeanBaseModel)
+        {
+            EjbBeanBaseModel ejbBeanBaseModel = (EjbBeanBaseModel) payload;
+            ejbBeanBaseModel.getApplications().forEach(projects::add);
         }
         else
         {

--- a/rules-java-ee/addon/src/main/java/org/jboss/windup/rules/apps/javaee/TechnologyUsageStatisticsModelExists.java
+++ b/rules-java-ee/addon/src/main/java/org/jboss/windup/rules/apps/javaee/TechnologyUsageStatisticsModelExists.java
@@ -34,8 +34,8 @@ public class TechnologyUsageStatisticsModelExists extends GraphCondition
     public boolean evaluate(GraphRewrite event, EvaluationContext context)
     {
         TechnologyUsageStatisticsService service = new TechnologyUsageStatisticsService(event.getGraphContext());
-        //Iterable<TechnologyUsageStatisticsModel> models = service.findAllByProperty(TechnologyUsageStatisticsModel.NAME, this.technologyName);
-        Iterable<TechnologyUsageStatisticsModel> models = service.findAll();
+        Iterable<TechnologyUsageStatisticsModel> models = service.findAllByProperty(TechnologyUsageStatisticsModel.NAME, this.technologyName);
+//        Iterable<TechnologyUsageStatisticsModel> models = service.findAll();
 
         boolean result = false;
         for (TechnologyUsageStatisticsModel model : models)


### PR DESCRIPTION
- added handling for `EjbBeanBaseModel` otherwise windup/windup-rulesets#263 wasn't able to add the technologies it finds
- after talking with @jsight, using `findAllByProperty(TechnologyUsageStatisticsModel.NAME, this.technologyName);` has better performance than `findAll();` that is still there commented to be used to debug in this phase of heavy creation of new rules