### PR TITLE
WINDUPRULE-285 Rule Providers to identify MVC libraries

### DIFF
--- a/rules-java-ee/addon/src/main/java/org/jboss/windup/rules/apps/javaee/TechnologyIdentified.java
+++ b/rules-java-ee/addon/src/main/java/org/jboss/windup/rules/apps/javaee/TechnologyIdentified.java
@@ -12,6 +12,7 @@ import org.jboss.windup.graph.model.ProjectModel;
 import org.jboss.windup.graph.model.WindupVertexFrame;
 import org.jboss.windup.graph.model.resource.FileModel;
 import org.jboss.windup.reporting.model.TagSetModel;
+import org.jboss.windup.reporting.model.TechnologyTagModel;
 import org.jboss.windup.reporting.service.TagSetService;
 import org.jboss.windup.rules.apps.javaee.model.EjbBeanBaseModel;
 import org.jboss.windup.rules.apps.javaee.model.JNDIResourceModel;
@@ -131,6 +132,9 @@ public class TechnologyIdentified extends AbstractIterationOperation<WindupVerte
         {
             EjbBeanBaseModel ejbBeanBaseModel = (EjbBeanBaseModel) payload;
             ejbBeanBaseModel.getApplications().forEach(projects::add);
+        } else if (payload instanceof TechnologyTagModel)
+        {
+            ((TechnologyTagModel)payload).getFileModels().forEach(fileModel -> fileModel.getRootProjectModels().forEach(projects::add));
         }
         else
         {

--- a/rules-java-ee/addon/src/main/java/org/jboss/windup/rules/apps/javaee/rules/DiscoverEmbeddedGwtLibraryRuleProvider.java
+++ b/rules-java-ee/addon/src/main/java/org/jboss/windup/rules/apps/javaee/rules/DiscoverEmbeddedGwtLibraryRuleProvider.java
@@ -1,0 +1,57 @@
+package org.jboss.windup.rules.apps.javaee.rules;
+
+import org.jboss.windup.config.AbstractRuleProvider;
+import org.jboss.windup.config.GraphRewrite;
+import org.jboss.windup.config.loader.RuleLoaderContext;
+import org.jboss.windup.config.metadata.RuleMetadata;
+import org.jboss.windup.config.operation.iteration.AbstractIterationOperation;
+import org.jboss.windup.config.phase.InitialAnalysisPhase;
+import org.jboss.windup.config.query.Query;
+import org.jboss.windup.config.query.QueryPropertyComparisonType;
+import org.jboss.windup.graph.model.resource.FileModel;
+import org.jboss.windup.reporting.category.IssueCategoryRegistry;
+import org.jboss.windup.reporting.model.ClassificationModel;
+import org.jboss.windup.reporting.model.TechnologyTagLevel;
+import org.jboss.windup.reporting.service.ClassificationService;
+import org.jboss.windup.reporting.service.TechnologyTagService;
+import org.jboss.windup.rules.apps.java.model.JarArchiveModel;
+import org.ocpsoft.rewrite.config.Configuration;
+import org.ocpsoft.rewrite.config.ConfigurationBuilder;
+import org.ocpsoft.rewrite.context.EvaluationContext;
+
+@RuleMetadata(phase = InitialAnalysisPhase.class, perform = "Discover GWT libraries embedded")
+public class DiscoverEmbeddedGwtLibraryRuleProvider extends AbstractRuleProvider
+{
+
+    @Override
+    public Configuration getConfiguration(RuleLoaderContext context)
+    {
+        String ruleIDPrefix = getClass().getSimpleName();
+        int ruleIDSuffix = 1;
+        return ConfigurationBuilder.begin()
+                    .addRule()
+                    .when(Query.fromType(JarArchiveModel.class)
+                                .withProperty(FileModel.FILE_NAME, QueryPropertyComparisonType.REGEX, ".*gwt.*\\.jar$"))
+                    .perform(
+                                new AbstractIterationOperation<JarArchiveModel>()
+                                {
+                                    public void perform(GraphRewrite event, EvaluationContext context, JarArchiveModel fileResourceModel)
+                                    {
+                                        ClassificationService classificationService = new ClassificationService(event.getGraphContext());
+                                        ClassificationModel classificationModel = classificationService.attachClassification(event, context,
+                                                    fileResourceModel,
+                                                    IssueCategoryRegistry.OPTIONAL,
+                                                    "Embedded library - GWT",
+                                                    "The application embedds a GWT library.");
+                                        classificationModel.setEffort(0);
+
+                                        TechnologyTagService technologyTagService = new TechnologyTagService(event.getGraphContext());
+                                        technologyTagService.addTagToFileModel(fileResourceModel, "GWT (embedded)",
+                                                    TechnologyTagLevel.INFORMATIONAL);
+
+                                    }
+                                })
+                    .withId(ruleIDPrefix + "_" + ruleIDSuffix++);
+    }
+
+}

--- a/rules-java-ee/addon/src/main/java/org/jboss/windup/rules/apps/javaee/rules/DiscoverEmbeddedSpringMVCLibraryRuleProvider.java
+++ b/rules-java-ee/addon/src/main/java/org/jboss/windup/rules/apps/javaee/rules/DiscoverEmbeddedSpringMVCLibraryRuleProvider.java
@@ -1,0 +1,57 @@
+package org.jboss.windup.rules.apps.javaee.rules;
+
+import org.jboss.windup.config.AbstractRuleProvider;
+import org.jboss.windup.config.GraphRewrite;
+import org.jboss.windup.config.loader.RuleLoaderContext;
+import org.jboss.windup.config.metadata.RuleMetadata;
+import org.jboss.windup.config.operation.iteration.AbstractIterationOperation;
+import org.jboss.windup.config.phase.InitialAnalysisPhase;
+import org.jboss.windup.config.query.Query;
+import org.jboss.windup.config.query.QueryPropertyComparisonType;
+import org.jboss.windup.graph.model.resource.FileModel;
+import org.jboss.windup.reporting.category.IssueCategoryRegistry;
+import org.jboss.windup.reporting.model.ClassificationModel;
+import org.jboss.windup.reporting.model.TechnologyTagLevel;
+import org.jboss.windup.reporting.service.ClassificationService;
+import org.jboss.windup.reporting.service.TechnologyTagService;
+import org.jboss.windup.rules.apps.java.model.JarArchiveModel;
+import org.ocpsoft.rewrite.config.Configuration;
+import org.ocpsoft.rewrite.config.ConfigurationBuilder;
+import org.ocpsoft.rewrite.context.EvaluationContext;
+
+@RuleMetadata(phase = InitialAnalysisPhase.class, perform = "Discover Spring MVC libraries embedded")
+public class DiscoverEmbeddedSpringMVCLibraryRuleProvider extends AbstractRuleProvider
+{
+
+    @Override
+    public Configuration getConfiguration(RuleLoaderContext context)
+    {
+        String ruleIDPrefix = getClass().getSimpleName();
+        int ruleIDSuffix = 1;
+        return ConfigurationBuilder.begin()
+                    .addRule()
+                    .when(Query.fromType(JarArchiveModel.class)
+                                .withProperty(FileModel.FILE_NAME, QueryPropertyComparisonType.REGEX, ".*spring-webmvc.*\\.jar$"))
+                    .perform(
+                                new AbstractIterationOperation<JarArchiveModel>()
+                                {
+                                    public void perform(GraphRewrite event, EvaluationContext context, JarArchiveModel fileResourceModel)
+                                    {
+                                        ClassificationService classificationService = new ClassificationService(event.getGraphContext());
+                                        ClassificationModel classificationModel = classificationService.attachClassification(event, context,
+                                                    fileResourceModel,
+                                                    IssueCategoryRegistry.OPTIONAL,
+                                                    "Embedded library - Spring MVC",
+                                                    "The application embedds a Spring MVC library.");
+                                        classificationModel.setEffort(0);
+
+                                        TechnologyTagService technologyTagService = new TechnologyTagService(event.getGraphContext());
+                                        technologyTagService.addTagToFileModel(fileResourceModel, "Spring MVC (embedded)",
+                                                    TechnologyTagLevel.INFORMATIONAL);
+
+                                    }
+                                })
+                    .withId(ruleIDPrefix + "_" + ruleIDSuffix++);
+    }
+
+}

--- a/rules-java-ee/addon/src/main/java/org/jboss/windup/rules/apps/javaee/rules/DiscoverEmbeddedStrutsLibraryRuleProvider.java
+++ b/rules-java-ee/addon/src/main/java/org/jboss/windup/rules/apps/javaee/rules/DiscoverEmbeddedStrutsLibraryRuleProvider.java
@@ -1,0 +1,57 @@
+package org.jboss.windup.rules.apps.javaee.rules;
+
+import org.jboss.windup.config.AbstractRuleProvider;
+import org.jboss.windup.config.GraphRewrite;
+import org.jboss.windup.config.loader.RuleLoaderContext;
+import org.jboss.windup.config.metadata.RuleMetadata;
+import org.jboss.windup.config.operation.iteration.AbstractIterationOperation;
+import org.jboss.windup.config.phase.InitialAnalysisPhase;
+import org.jboss.windup.config.query.Query;
+import org.jboss.windup.config.query.QueryPropertyComparisonType;
+import org.jboss.windup.graph.model.resource.FileModel;
+import org.jboss.windup.reporting.category.IssueCategoryRegistry;
+import org.jboss.windup.reporting.model.ClassificationModel;
+import org.jboss.windup.reporting.model.TechnologyTagLevel;
+import org.jboss.windup.reporting.service.ClassificationService;
+import org.jboss.windup.reporting.service.TechnologyTagService;
+import org.jboss.windup.rules.apps.java.model.JarArchiveModel;
+import org.ocpsoft.rewrite.config.Configuration;
+import org.ocpsoft.rewrite.config.ConfigurationBuilder;
+import org.ocpsoft.rewrite.context.EvaluationContext;
+
+@RuleMetadata(phase = InitialAnalysisPhase.class, perform = "Discover Apache Struts libraries embedded")
+public class DiscoverEmbeddedStrutsLibraryRuleProvider extends AbstractRuleProvider
+{
+
+    @Override
+    public Configuration getConfiguration(RuleLoaderContext context)
+    {
+        String ruleIDPrefix = getClass().getSimpleName();
+        int ruleIDSuffix = 1;
+        return ConfigurationBuilder.begin()
+                    .addRule()
+                    .when(Query.fromType(JarArchiveModel.class)
+                                .withProperty(FileModel.FILE_NAME, QueryPropertyComparisonType.REGEX, ".*struts.*\\.jar$"))
+                    .perform(
+                                new AbstractIterationOperation<JarArchiveModel>()
+                                {
+                                    public void perform(GraphRewrite event, EvaluationContext context, JarArchiveModel fileResourceModel)
+                                    {
+                                        ClassificationService classificationService = new ClassificationService(event.getGraphContext());
+                                        ClassificationModel classificationModel = classificationService.attachClassification(event, context,
+                                                    fileResourceModel,
+                                                    IssueCategoryRegistry.OPTIONAL,
+                                                    "Embedded library - Apache Struts",
+                                                    "The application embedds a Apache Struts library.");
+                                        classificationModel.setEffort(0);
+
+                                        TechnologyTagService technologyTagService = new TechnologyTagService(event.getGraphContext());
+                                        technologyTagService.addTagToFileModel(fileResourceModel, "Apache Struts (embedded)",
+                                                    TechnologyTagLevel.INFORMATIONAL);
+
+                                    }
+                                })
+                    .withId(ruleIDPrefix + "_" + ruleIDSuffix++);
+    }
+
+}

--- a/rules-java-ee/addon/src/main/java/org/jboss/windup/rules/apps/javaee/rules/DiscoverEmbeddedWicketLibraryRuleProvider.java
+++ b/rules-java-ee/addon/src/main/java/org/jboss/windup/rules/apps/javaee/rules/DiscoverEmbeddedWicketLibraryRuleProvider.java
@@ -1,0 +1,57 @@
+package org.jboss.windup.rules.apps.javaee.rules;
+
+import org.jboss.windup.config.AbstractRuleProvider;
+import org.jboss.windup.config.GraphRewrite;
+import org.jboss.windup.config.loader.RuleLoaderContext;
+import org.jboss.windup.config.metadata.RuleMetadata;
+import org.jboss.windup.config.operation.iteration.AbstractIterationOperation;
+import org.jboss.windup.config.phase.InitialAnalysisPhase;
+import org.jboss.windup.config.query.Query;
+import org.jboss.windup.config.query.QueryPropertyComparisonType;
+import org.jboss.windup.graph.model.resource.FileModel;
+import org.jboss.windup.reporting.category.IssueCategoryRegistry;
+import org.jboss.windup.reporting.model.ClassificationModel;
+import org.jboss.windup.reporting.model.TechnologyTagLevel;
+import org.jboss.windup.reporting.service.ClassificationService;
+import org.jboss.windup.reporting.service.TechnologyTagService;
+import org.jboss.windup.rules.apps.java.model.JarArchiveModel;
+import org.ocpsoft.rewrite.config.Configuration;
+import org.ocpsoft.rewrite.config.ConfigurationBuilder;
+import org.ocpsoft.rewrite.context.EvaluationContext;
+
+@RuleMetadata(phase = InitialAnalysisPhase.class, perform = "Discover Apache Wicket libraries embedded")
+public class DiscoverEmbeddedWicketLibraryRuleProvider extends AbstractRuleProvider
+{
+
+    @Override
+    public Configuration getConfiguration(RuleLoaderContext context)
+    {
+        String ruleIDPrefix = getClass().getSimpleName();
+        int ruleIDSuffix = 1;
+        return ConfigurationBuilder.begin()
+                    .addRule()
+                    .when(Query.fromType(JarArchiveModel.class)
+                                .withProperty(FileModel.FILE_NAME, QueryPropertyComparisonType.REGEX, ".*wicket.*\\.jar$"))
+                    .perform(
+                                new AbstractIterationOperation<JarArchiveModel>()
+                                {
+                                    public void perform(GraphRewrite event, EvaluationContext context, JarArchiveModel fileResourceModel)
+                                    {
+                                        ClassificationService classificationService = new ClassificationService(event.getGraphContext());
+                                        ClassificationModel classificationModel = classificationService.attachClassification(event, context,
+                                                    fileResourceModel,
+                                                    IssueCategoryRegistry.OPTIONAL,
+                                                    "Embedded library - Apache Wicket",
+                                                    "The application embedds a Apache Wicket library.");
+                                        classificationModel.setEffort(0);
+
+                                        TechnologyTagService technologyTagService = new TechnologyTagService(event.getGraphContext());
+                                        technologyTagService.addTagToFileModel(fileResourceModel, "Apache Wicket (embedded)",
+                                                    TechnologyTagLevel.INFORMATIONAL);
+
+                                    }
+                                })
+                    .withId(ruleIDPrefix + "_" + ruleIDSuffix++);
+    }
+
+}


### PR DESCRIPTION
The approach for these rules has been adding a specific tag for each one of the 4 libraries (Spring MVC, Struts, Wicket and GWT). They are working in an "on/off" way to say if a library is there or not (not counting the number of jars from the same library).
It has been mandatory to add another `else if` in `TechnologyIdentified` class to handle `TechnologyTagModel` interface that can not extend `HasApplications` (and hence `BelongsToProject`) because otherwise it introduces a circular dependency (from IDE `Adding dependency on module 'windup-rules-java-ee' will introduce circular dependency between modules 'windup-reporting' and 'windup-reporting-api'.`)