### PR TITLE
WINDUP-1682 WINDUPRULE-285 WINDUP-1687 WINDUP-1688

### DIFF
--- a/config-xml/schema/windup-jboss-ruleset.xsd
+++ b/config-xml/schema/windup-jboss-ruleset.xsd
@@ -12,7 +12,7 @@
             <xs:sequence>
                 <xs:element name="testDataPath" minOccurs="1" type="xs:string" />
                 <xs:element name="sourceMode" minOccurs="0" maxOccurs="1" type="xs:boolean" />
-                <xs:element name="rulePath" minOccurs="0" type="xs:string" />
+                <xs:element name="rulePath" minOccurs="0" maxOccurs="unbounded" type="xs:string" />
                 <xs:element name="source" minOccurs="0" maxOccurs="1" type="xs:string" />
                 <xs:element name="target" minOccurs="0" maxOccurs="1" type="xs:string" />
                 <xs:element ref="ruleset" minOccurs="0" maxOccurs="unbounded" />
@@ -272,9 +272,15 @@
    <xs:element name="lineitem-exists">
       <xs:complexType>
          <xs:attribute type="xs:string" name="message" use="required"/>
-         <xs:attribute type="xs:string" name="in"/>
       </xs:complexType>
    </xs:element>
+
+    <xs:element name="technology-tag-exists">
+        <xs:complexType>
+            <xs:attribute type="xs:string" name="technology-tag" use="required"/>
+            <xs:attribute type="xs:string" name="in"/>
+        </xs:complexType>
+    </xs:element>
 
    <!-- OPERATION DEFINITIONS -->
 
@@ -436,6 +442,28 @@
         </xs:complexType>
     </xs:element>
 
+    <xs:element name="technology-tag">
+        <xs:complexType>
+            <xs:simpleContent>
+                <xs:extension base="xs:string">
+                    <xs:attribute name="level" type="technology-tag-level" />
+                </xs:extension>
+            </xs:simpleContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:simpleType name="technology-tag-level">
+        <xs:annotation>
+            <xs:documentation><![CDATA[
+               This defines the level of a technology tag.
+            ]]></xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="INFORMATIONAL"/>
+            <xs:enumeration value="IMPORTANT"/>
+        </xs:restriction>
+    </xs:simpleType>
+
     <!-- MAIN BUILDING BLOCKS -->
     <xs:complexType name="where">
         <xs:sequence>
@@ -470,6 +498,7 @@
             <xs:element name="iterable-filter" type="iterable-filter" minOccurs="0" maxOccurs="unbounded" />
             <xs:element name="to-file-model" type="when-base" minOccurs="0" maxOccurs="unbounded" />
             <xs:element name="graph-query" type="graph-query" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element ref="technology-tag-exists" minOccurs="0" maxOccurs="unbounded" />
         </xs:choice>
     </xs:complexType>
 
@@ -516,6 +545,7 @@
             <xs:element ref="hint-exists" minOccurs="0" maxOccurs="unbounded" />
             <xs:element ref="lineitem-exists" minOccurs="0" maxOccurs="unbounded" />
             <xs:element name="technology-identified" type="technology-identified" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element ref="technology-tag" minOccurs="0" maxOccurs="unbounded" />
         </xs:choice>
         <xs:attribute type="xs:string" name="over" />
         <!-- <xs:attribute type="xs:string" name="as" /> not supported in handler yet -->

--- a/reporting/api/src/main/java/org/jboss/windup/reporting/config/TechnologyTag.java
+++ b/reporting/api/src/main/java/org/jboss/windup/reporting/config/TechnologyTag.java
@@ -1,0 +1,102 @@
+package org.jboss.windup.reporting.config;
+
+import org.jboss.windup.config.GraphRewrite;
+import org.jboss.windup.config.operation.Iteration;
+import org.jboss.windup.config.parameters.ParameterizedIterationOperation;
+import org.jboss.windup.graph.GraphContext;
+import org.jboss.windup.graph.model.FileReferenceModel;
+import org.jboss.windup.graph.model.WindupVertexFrame;
+import org.jboss.windup.graph.model.resource.FileModel;
+import org.jboss.windup.reporting.model.TechnologyTagLevel;
+import org.jboss.windup.reporting.service.TechnologyTagService;
+import org.jboss.windup.util.ExecutionStatistics;
+import org.jboss.windup.util.Logging;
+import org.ocpsoft.rewrite.context.EvaluationContext;
+import org.ocpsoft.rewrite.param.ParameterStore;
+import org.ocpsoft.rewrite.param.RegexParameterizedPatternBuilder;
+
+import java.util.*;
+import java.util.logging.Logger;
+
+/**
+ * Classifies a {@link FileModel} {@link Iteration} payload.
+ *
+ */
+public class TechnologyTag extends ParameterizedIterationOperation<FileModel>
+{
+    private static final Logger LOG = Logging.get(TechnologyTag.class);
+
+    private final RegexParameterizedPatternBuilder nameBuilder;
+    private TechnologyTagLevel technologyTagLevel;
+
+    private TechnologyTag(String tagName)
+    {
+        this.nameBuilder = new RegexParameterizedPatternBuilder(tagName);
+        this.technologyTagLevel = TechnologyTagLevel.INFORMATIONAL;
+    }
+
+    public static TechnologyTag withName(String tagName)
+    {
+        return new TechnologyTag(tagName);
+    }
+
+    public TechnologyTag withTechnologyTagLevel(TechnologyTagLevel technologyTagLevel)
+    {
+        this.technologyTagLevel = technologyTagLevel;
+        return this;
+    }
+
+    @Override
+    public FileModel resolvePayload(GraphRewrite event, EvaluationContext context, WindupVertexFrame payload)
+    {
+        checkVariableName(event, context);
+        if (payload instanceof FileReferenceModel)
+        {
+            return ((FileReferenceModel) payload).getFile();
+        }
+        if (payload instanceof FileModel)
+        {
+            return (FileModel) payload;
+        }
+        return null;
+    }
+
+    @Override
+    public void performParameterized(GraphRewrite event, EvaluationContext context, FileModel payload)
+    {
+        ExecutionStatistics.get().begin("TechnologyTag.performParameterized");
+        try
+        {
+            GraphContext graphContext = event.getGraphContext();
+            TechnologyTagService technologyTagService = new TechnologyTagService(graphContext);
+            technologyTagService.addTagToFileModel(payload, this.nameBuilder.build(event, context), this.technologyTagLevel);
+            LOG.info("TechnologyTag added to " + payload.getPrettyPathWithinProject() + " [" + this + "] ");
+        }
+        finally
+        {
+            ExecutionStatistics.get().end("TechnologyTag.performParameterized");
+        }
+    }
+
+    @Override
+    public String toString()
+    {
+        StringBuilder result = new StringBuilder();
+        result.append("TechnologyTag.withName(").append(this.nameBuilder.toString()).append(")");
+        result.append(".withTechnologyTagLevel(").append(this.technologyTagLevel).append(")");
+        return result.toString();
+    }
+
+    @Override
+    public Set<String> getRequiredParameterNames()
+    {
+        return new HashSet<>(this.nameBuilder.getRequiredParameterNames());
+    }
+
+    @Override
+    public void setParameterStore(ParameterStore store)
+    {
+        this.nameBuilder.setParameterStore(store);
+    }
+
+}

--- a/reporting/api/src/main/java/org/jboss/windup/reporting/config/TechnologyTagExists.java
+++ b/reporting/api/src/main/java/org/jboss/windup/reporting/config/TechnologyTagExists.java
@@ -1,0 +1,71 @@
+package org.jboss.windup.reporting.config;
+
+import com.tinkerpop.blueprints.Vertex;
+import com.tinkerpop.gremlin.java.GremlinPipeline;
+import org.apache.commons.lang3.StringUtils;
+import org.jboss.windup.config.GraphRewrite;
+import org.jboss.windup.config.condition.GraphCondition;
+import org.jboss.windup.config.query.Query;
+import org.jboss.windup.config.query.QueryBuilderFind;
+import org.jboss.windup.config.query.QueryGremlinCriterion;
+import org.jboss.windup.config.query.QueryPropertyComparisonType;
+import org.jboss.windup.graph.model.resource.FileModel;
+import org.jboss.windup.reporting.model.TechnologyTagModel;
+import org.ocpsoft.rewrite.context.EvaluationContext;
+
+/**
+ * Returns true if there are {@link TechnologyTag} entries that match the given technology tag name.
+ */
+public class TechnologyTagExists extends GraphCondition
+{
+    private String namePattern;
+    private String filename;
+
+    private TechnologyTagExists(String namePattern)
+    {
+        this.namePattern = "[\\s\\S]*" + namePattern + "[\\s\\S]*";
+    }
+
+    /**
+     * Specifies the regular expression to use when searching {@link TechnologyTagModel} entries.
+     */
+    public static TechnologyTagExists withName(String namePattern)
+    {
+        return new TechnologyTagExists(namePattern);
+    }
+
+    /**
+     * Only consider entries that reference a file with the given filename.
+     */
+    public TechnologyTagExists in(String filename)
+    {
+        this.filename = filename;
+        return this;
+    }
+
+
+    @Override
+    public boolean evaluate(GraphRewrite event, EvaluationContext context)
+    {
+        QueryBuilderFind q = Query.fromType(TechnologyTagModel.class);
+        if (StringUtils.isNotBlank(filename))
+        {
+            q.piped(new QueryGremlinCriterion()
+            {
+                private static final String TECHNOLOGYTAG_STEP = "technologyTagModel";
+
+                @Override
+                public void query(GraphRewrite event, GremlinPipeline<Vertex, Vertex> pipeline)
+                {
+                    pipeline.as(TECHNOLOGYTAG_STEP);
+                    pipeline.out(TechnologyTagModel.TECH_TAG_TO_FILE_MODEL);
+                    pipeline.has(FileModel.FILE_NAME, filename);
+                    pipeline.back(TECHNOLOGYTAG_STEP);
+                }
+            });
+        }
+        q.withProperty(TechnologyTagModel.NAME, QueryPropertyComparisonType.REGEX, namePattern);
+        return q.evaluate(event, context);
+    }
+
+}

--- a/reporting/impl/src/main/java/org/jboss/windup/reporting/xml/TechnologyTagExistsHandler.java
+++ b/reporting/impl/src/main/java/org/jboss/windup/reporting/xml/TechnologyTagExistsHandler.java
@@ -1,0 +1,52 @@
+package org.jboss.windup.reporting.xml;
+
+import org.apache.commons.lang.StringUtils;
+import org.jboss.windup.config.exception.ConfigurationException;
+import org.jboss.windup.config.parser.ElementHandler;
+import org.jboss.windup.config.parser.NamespaceElementHandler;
+import org.jboss.windup.config.parser.ParserContext;
+import org.jboss.windup.reporting.config.TechnologyTagExists;
+import org.jboss.windup.util.exception.WindupException;
+import org.w3c.dom.Element;
+
+import static org.joox.JOOX.$;
+
+/**
+ * Creates a {@link TechnologyTagExists} that searches for the given classification text. Example usage:
+ *
+ * <pre>
+ *     &lt;rule&gt;
+ *         &lt;when&gt;
+ *             &lt;not&gt;
+ *                 &lt;technology-tag-exists technology-tag="technologyname" in="filename"/&gt;
+ *             &lt;/not&gt;
+ *         &lt;/when&gt;
+ *         &lt;perform&gt;
+ *             [...]
+ *         &lt;/perform&gt;
+ *     &lt;/rule&gt;
+ * </pre>
+ * 
+ * @author mrizzi
+ *
+ */
+@NamespaceElementHandler(elementName = TechnologyTagExistsHandler.ELEMENT_NAME, namespace = "http://windup.jboss.org/schema/jboss-ruleset")
+public class TechnologyTagExistsHandler implements ElementHandler<TechnologyTagExists>
+{
+    static final String ELEMENT_NAME = "technology-tag-exists";
+    private static final String NAME = "technology-tag";
+
+    @Override
+    public TechnologyTagExists processElement(ParserContext handlerManager, Element element) throws ConfigurationException
+    {
+        String technologyTagPattern = $(element).attr(NAME);
+        String in = $(element).attr("in");
+
+        if (StringUtils.isBlank(technologyTagPattern))
+        {
+            throw new WindupException("Error, '" + ELEMENT_NAME + "' element must have a non-empty '" + NAME + "' attribute");
+        }
+
+        return TechnologyTagExists.withName(technologyTagPattern).in(in);
+    }
+}

--- a/reporting/impl/src/main/java/org/jboss/windup/reporting/xml/TechnologyTagHandler.java
+++ b/reporting/impl/src/main/java/org/jboss/windup/reporting/xml/TechnologyTagHandler.java
@@ -1,0 +1,39 @@
+package org.jboss.windup.reporting.xml;
+
+import org.apache.commons.lang3.StringUtils;
+import org.jboss.windup.config.exception.ConfigurationException;
+import org.jboss.windup.config.parser.ElementHandler;
+import org.jboss.windup.config.parser.NamespaceElementHandler;
+import org.jboss.windup.config.parser.ParserContext;
+import org.jboss.windup.config.parser.xml.RuleProviderHandler;
+import org.jboss.windup.reporting.config.TechnologyTag;
+import org.jboss.windup.reporting.model.TechnologyTagLevel;
+import org.jboss.windup.util.exception.WindupException;
+import org.w3c.dom.Element;
+
+@NamespaceElementHandler(elementName = TechnologyTagHandler.TECHNOLOGY_TAG, namespace = RuleProviderHandler.WINDUP_RULE_NAMESPACE)
+public class TechnologyTagHandler implements ElementHandler<Object>
+{
+    public static final String TECHNOLOGY_TAG = "technology-tag";
+    private static final String LEVEL = "level";
+
+    @Override
+    public TechnologyTag processElement(ParserContext handlerManager, Element element) throws ConfigurationException
+    {
+        String tag = element.getTextContent();
+        if (StringUtils.isNotBlank(tag))
+        {
+            tag = tag.trim();
+        } else
+        {
+            throw new WindupException("Error, '" + TechnologyTagHandler.TECHNOLOGY_TAG + "' element must have non-empty content");
+        }
+        TechnologyTagLevel issueCategory = TechnologyTagLevel.INFORMATIONAL;
+        String category = element.getAttribute(TechnologyTagHandler.LEVEL);
+        if (StringUtils.isNotBlank(category))
+        {
+            issueCategory = TechnologyTagLevel.valueOf(category);
+        }
+        return TechnologyTag.withName(tag).withTechnologyTagLevel(issueCategory);
+    }
+}

--- a/rules-java-ee/addon/src/main/java/org/jboss/windup/rules/apps/javaee/TechnologyIdentified.java
+++ b/rules-java-ee/addon/src/main/java/org/jboss/windup/rules/apps/javaee/TechnologyIdentified.java
@@ -13,6 +13,7 @@ import org.jboss.windup.graph.model.ProjectModel;
 import org.jboss.windup.graph.model.WindupVertexFrame;
 import org.jboss.windup.reporting.model.ClassificationModel;
 import org.jboss.windup.reporting.model.TagSetModel;
+import org.jboss.windup.reporting.model.TechnologyTagModel;
 import org.jboss.windup.reporting.service.TagSetService;
 import org.jboss.windup.graph.model.HasApplications;
 import org.jboss.windup.rules.apps.javaee.model.stats.TechnologyUsageStatisticsModel;
@@ -132,6 +133,9 @@ public class TechnologyIdentified extends AbstractIterationOperation<WindupVerte
             {
                 projects.add(projectModel);
             }
+        } else if (payload instanceof TechnologyTagModel)
+        {
+            ((TechnologyTagModel) payload).getFileModels().forEach(fileModel -> projects.add(fileModel.getProjectModel()));
         }
         else
         {


### PR DESCRIPTION
This PR fixes:

- [WINDUP-1682](https://issues.jboss.org/browse/WINDUP-1682) "_Create a TechnologyTag operation as well as handlers so that this can be supported in xml rules_"
- [WINDUP-1687](https://issues.jboss.org/browse/WINDUP-1687) "_windup-jboss-ruleset.xsd: wrong "lineitem-exists" definition_"
- [WINDUP-1688](https://issues.jboss.org/browse/WINDUP-1688) "_Multiple <rulePath> tags in XML tests_"

This PR is related to:
- #1177 because this PR makes #1177 obsolete and hence to be closed without merging it
- windup/windup-rulesets#267 because new XML rules can be created to discover libraries usage.

This PR contains:
- new `<technology-tag>` for `<perform>` operation in XML rules with
  - text within the tag used as technology name (e.g. `Apache Wicket (embedded)`, `Spring MVC (embedded)`)
  - attribute `level` to set the [`TechnologyTagLevel`](https://github.com/windup/windup/blob/master/reporting/api/src/main/java/org/jboss/windup/reporting/model/TechnologyTagLevel.java) (default is `INFORMATIONAL`)
- new `<technology-tag-exists>` to be used for testing the `<technology-tag>` tag with:
  - `technology-tag` attribute (required) to set with the name of the technology to search for (e.g. `Apache Wicket`)
  - `in` attribute to only consider entries that reference a file with the file name given in this attribute
- handlers and operations for the new tags
- tag `<rulePath>` from XML rule tests can be used multiple times in the same test in order to be able to execute more rules inside the same analysis (e.g. a rule for discovering a library and then the rule to associate a technology usage for technology report)