### PR TITLE
Upgrade Freemarker 2.3.23 to 2.3.26-incubating

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
         <version.furnace>2.25.4.Final</version.furnace>
         <version.titangraph>0.5.4</version.titangraph>
         <version.tinkerpop.blueprints>2.5.0</version.tinkerpop.blueprints>
-        <version.freemarker>2.3.23</version.freemarker>
+        <version.freemarker>2.3.26-incubating</version.freemarker>
         <version.jacoco>0.7.9</version.jacoco>
 
         <windup.scm.connection>scm:git:https://github.com/windup/windup.git</windup.scm.connection>


### PR DESCRIPTION
Better support for `Iterable`.
Sorry for the new branch, I forgot github creates them in upstream.