### PR TITLE
WINDUP-1732 <annotation-list> w/o 'name' attribute

### DIFF
--- a/rules-java/api/src/main/java/org/jboss/windup/rules/apps/java/xml/JavaClassHandler.java
+++ b/rules-java/api/src/main/java/org/jboss/windup/rules/apps/java/xml/JavaClassHandler.java
@@ -65,33 +65,54 @@ public class JavaClassHandler implements ElementHandler<JavaClassBuilderAt>
         List<AnnotationTypeCondition> additionalAnnotationConditions = new ArrayList<>();
         for (Element child : children)
         {
+            String name = child.getAttribute(AnnotationConditionHandler.NAME);
             switch (child.getNodeName())
             {
-            case "location":
-                TypeReferenceLocation location = handlerManager.processElement(child);
-                locations.add(location);
-                break;
-            case AnnotationTypeConditionHandler.ANNOTATION_TYPE:
-            case AnnotationListConditionHandler.ANNOTATION_LIST_CONDITION:
-            case AnnotationLiteralConditionHandler.ANNOTATION_LITERAL:
-                String name = child.getAttribute(AnnotationConditionHandler.NAME);
-                AnnotationCondition annotationCondition = handlerManager.processElement(child);
-                if (StringUtils.isBlank(name))
-                {
-                    if (!(annotationCondition instanceof AnnotationTypeCondition))
+                case "location":
+                    TypeReferenceLocation location = handlerManager.processElement(child);
+                    locations.add(location);
+                    break;
+                case AnnotationTypeConditionHandler.ANNOTATION_TYPE:
+                    AnnotationCondition annotationCondition = handlerManager.processElement(child);
+                    if (StringUtils.isBlank(name))
+                    {
+                        additionalAnnotationConditions.add((AnnotationTypeCondition) annotationCondition);
+                    }
+                    else
+                    {
+                        if (conditionMap.containsKey(name))
+                            throw new WindupException("Duplicate condition detected on annotation element: " + name);
+                        conditionMap.put(name, annotationCondition);
+                    }
+                    break;
+                case AnnotationListConditionHandler.ANNOTATION_LIST_CONDITION:
+                    annotationCondition = handlerManager.processElement(child);
+                    if (StringUtils.isBlank(name))
+                    {
+                        name = "value";
+                    }
+                    if (conditionMap.containsKey(name))
+                        throw new WindupException("Duplicate condition detected on annotation element: " + name);
+                    else
+                    {
+                        conditionMap.put(name, annotationCondition);
+                    }
+                    break;
+                case AnnotationLiteralConditionHandler.ANNOTATION_LITERAL:
+                    annotationCondition = handlerManager.processElement(child);
+                    if (StringUtils.isBlank(name))
+                    {
                         throw new WindupException("Additional Annotation Condition must be an " +
                                 AnnotationTypeConditionHandler.ANNOTATION_TYPE + " condition. Could it be that the '" +
                                 AnnotationConditionHandler.NAME + "' property is missing?");
-
-                    additionalAnnotationConditions.add((AnnotationTypeCondition)annotationCondition);
-                }
-                else
-                {
-                    if (conditionMap.containsKey(name))
-                        throw new WindupException("Duplicate condition detected on annotation element: " + name);
-                    conditionMap.put(name, annotationCondition);
-                }
-                break;
+                    }
+                    else
+                    {
+                        if (conditionMap.containsKey(name))
+                            throw new WindupException("Duplicate condition detected on annotation element: " + name);
+                        conditionMap.put(name, annotationCondition);
+                    }
+                    break;
             }
         }
         JavaClassBuilder javaClassReferences;

--- a/rules-java/tests/src/test/java/org/jboss/windup/rules/java/JavaClassAnnotationFilteringTest.java
+++ b/rules-java/tests/src/test/java/org/jboss/windup/rules/java/JavaClassAnnotationFilteringTest.java
@@ -122,6 +122,7 @@ public class JavaClassAnnotationFilteringTest
             processor.execute(processorConfig);
 
             Assert.assertEquals(1, complexProvider.baseRuleHitCount);
+            Assert.assertEquals(1, complexProvider.nestedAnnotationHitCount);
         }
     }
 
@@ -190,6 +191,7 @@ public class JavaClassAnnotationFilteringTest
     public static class ComplexAnnotationScanProvider extends AbstractRuleProvider
     {
         private int baseRuleHitCount = 0;
+        private int nestedAnnotationHitCount = 0;
 
         public ComplexAnnotationScanProvider()
         {
@@ -214,6 +216,21 @@ public class JavaClassAnnotationFilteringTest
                         public void perform(GraphRewrite event, EvaluationContext context, JavaTypeReferenceModel payload)
                         {
                             baseRuleHitCount++;
+                        }
+                    })
+                    .addRule().when(
+                            JavaClass.references("javax.annotation.sql.DataSourceDefinitions")
+                                    .at(TypeReferenceLocation.ANNOTATION)
+                                    .annotationMatches(
+                                            "value",
+                                            new AnnotationListCondition(0).addCondition(new AnnotationTypeCondition("javax.annotation.sql.DataSourceDefinition"))
+                                    )
+                    ).perform(new AbstractIterationOperation<JavaTypeReferenceModel>()
+                    {
+                        @Override
+                        public void perform(GraphRewrite event, EvaluationContext context, JavaTypeReferenceModel payload)
+                        {
+                            nestedAnnotationHitCount++;
                         }
                     });
         }

--- a/rules-java/tests/src/test/java/org/jboss/windup/rules/java/JavaClassAnnotationFilteringTest.java
+++ b/rules-java/tests/src/test/java/org/jboss/windup/rules/java/JavaClassAnnotationFilteringTest.java
@@ -123,6 +123,7 @@ public class JavaClassAnnotationFilteringTest
 
             Assert.assertEquals(1, complexProvider.baseRuleHitCount);
             Assert.assertEquals(1, complexProvider.nestedAnnotationHitCount);
+            Assert.assertEquals(0, complexProvider.nestedAnnotationWrongNameHitCount);
         }
     }
 
@@ -192,6 +193,7 @@ public class JavaClassAnnotationFilteringTest
     {
         private int baseRuleHitCount = 0;
         private int nestedAnnotationHitCount = 0;
+        private int nestedAnnotationWrongNameHitCount = 0;
 
         public ComplexAnnotationScanProvider()
         {
@@ -231,6 +233,21 @@ public class JavaClassAnnotationFilteringTest
                         public void perform(GraphRewrite event, EvaluationContext context, JavaTypeReferenceModel payload)
                         {
                             nestedAnnotationHitCount++;
+                        }
+                    })
+                    .addRule().when(
+                            JavaClass.references("javax.annotation.sql.DataSourceDefinitions")
+                                    .at(TypeReferenceLocation.ANNOTATION)
+                                    .annotationMatches(
+                                            "wrongValue",
+                                            new AnnotationListCondition(0).addCondition(new AnnotationTypeCondition("javax.annotation.sql.DataSourceDefinition"))
+                                    )
+                    ).perform(new AbstractIterationOperation<JavaTypeReferenceModel>()
+                    {
+                        @Override
+                        public void perform(GraphRewrite event, EvaluationContext context, JavaTypeReferenceModel payload)
+                        {
+                            nestedAnnotationWrongNameHitCount++;
                         }
                     });
         }

--- a/rules-java/tests/src/test/java/org/jboss/windup/rules/java/handlers/AnnotationConditionHandlerTest.java
+++ b/rules-java/tests/src/test/java/org/jboss/windup/rules/java/handlers/AnnotationConditionHandlerTest.java
@@ -91,5 +91,12 @@ public class AnnotationConditionHandlerTest
         System.out.println("Condition 2: " + asString2);
         Assert.assertTrue(asString2.contains("AnnotationTypeCondition{pattern={*}, conditions={secondName"));
         Assert.assertTrue(asString2.contains("{subLiteral=AnnotationLiteralCondition{pattern=subLiteralPattern}"));
+
+        Element javaClass3 = javaClassList.get(2);
+        JavaClass javaClassCondition3 = parser.<JavaClass> processElement(javaClass3);
+
+        String asString3 = javaClassCondition3.toString();
+        System.out.println("Condition 3: " + asString3);
+        Assert.assertTrue(asString3.contains("AnnotationTypeCondition{pattern={*}, conditions={value=AnnotationListCondition"));
     }
 }

--- a/rules-java/tests/src/test/resources/handler/annotationcondition.rhamt.xml
+++ b/rules-java/tests/src/test/resources/handler/annotationcondition.rhamt.xml
@@ -14,5 +14,11 @@
             <annotation-literal name="subLiteral" pattern="subLiteralPattern"/>
         </annotation-type>
     </javaclass>
+    <javaclass references="javax.annotation.sql.DataSourceDefinitions" >
+        <location>ANNOTATION</location>
+        <annotation-list>
+            <annotation-type pattern="javax.annotation.sql.DataSourceDefinition" />
+        </annotation-list>
+    </javaclass>
 </test>
 

--- a/rules-java/tests/src/test/resources/handler/annotationcondition.windup.xml
+++ b/rules-java/tests/src/test/resources/handler/annotationcondition.windup.xml
@@ -14,5 +14,11 @@
             <annotation-literal name="subLiteral" pattern="subLiteralPattern"/>
         </annotation-type>
     </javaclass>
+    <javaclass references="javax.annotation.sql.DataSourceDefinitions" >
+        <location>ANNOTATION</location>
+        <annotation-list>
+            <annotation-type pattern="javax.annotation.sql.DataSourceDefinition" />
+        </annotation-list>
+    </javaclass>
 </test>
 

--- a/rules-java/tests/src/test/resources/org/jboss/windup/rules/annotationtests/complex/AnnotationMultipleDs.java
+++ b/rules-java/tests/src/test/resources/org/jboss/windup/rules/annotationtests/complex/AnnotationMultipleDs.java
@@ -1,0 +1,30 @@
+package org.jboss.windup.rules.annotationtests.complex;
+
+import javax.annotation.sql.DataSourceDefinition;
+import javax.annotation.sql.DataSourceDefinitions;
+
+/**
+ * @author <a href="mailto:dklingenberg@gmail.com">David Klingenberg</a>
+ */
+@DataSourceDefinitions({
+        @DataSourceDefinition(
+                name = "jdbc/multiple-ds-xa",
+                className="com.example.MyDataSource",
+                portNumber=6689,
+                serverName="example.com",
+                user="lance",
+                password="secret"
+        ),
+        @DataSourceDefinition(
+                name = "jdbc/multiple-ds-non-xa",
+                className="com.example.MyDataSource",
+                portNumber=6689,
+                serverName="example.com",
+                user="lance",
+                password="secret",
+                transactional = false
+        ),
+})
+public class AnnotationMultipleDs
+{
+}


### PR DESCRIPTION
This PR fixes the issue in [WINDUP-1732](https://issues.jboss.org/browse/WINDUP-1732)
- `org.jboss.windup.rules.apps.java.xml.JavaClassHandler#processElement` enhanced to better handle these three conditions:
  - `<annotation-type>` allows both blank and valued `name` attribute
  - `<annotation-list>` *now* allows blank `name` attribute to handle some nested annotation case, using the `value` value due to [`ReferenceResolvingVisitor.addAnnotationValues`](https://github.com/windup/windup/blob/master/java-ast/addon/src/main/java/org/jboss/windup/ast/java/ReferenceResolvingVisitor.java#L664)
  - `<annotation-literal>` does *not* allow blank `name` attribute
- `org.jboss.windup.rules.java.handlers.AnnotationConditionHandlerTest` tests (w/ test files `annotationcondition.[windup,rhamt].xml`) the `AnnotationListCondition` is added with `value` value
- `org.jboss.windup.rules.java.JavaClassAnnotationFilteringTest` tests (w/ test class `AnnotationMultipleDs`) that `org.jboss.windup.ast.java.ReferenceResolvingVisitor#addAnnotationValues` adds the nested annotations with `value` key