### PR TITLE
WINDUP-1730: fixing validation of input/output options

### DIFF
--- a/bootstrap/src/main/java/org/jboss/windup/bootstrap/Bootstrap.java
+++ b/bootstrap/src/main/java/org/jboss/windup/bootstrap/Bootstrap.java
@@ -458,19 +458,19 @@ public class Bootstrap
         return true;
     }
 
-    private File getWindupAddonsDir()
-    {
-        return new File(getWindupHome(), "addons");
-    }
+//    private File getWindupAddonsDir()
+//    {
+//        return new File(getWindupHome(), "addons");
+//    }
 
-    private File getWindupHome()
-    {
-        String windupHome = System.getProperty(WINDUP_HOME);
-        if (windupHome == null)
-        {
-            Path path = new File("").toPath();
-            return path.toFile();
-        }
-        return Paths.get(windupHome).toFile();
-    }
+//    private File getWindupHome()
+//    {
+//        String windupHome = System.getProperty(WINDUP_HOME);
+//        if (windupHome == null)
+//        {
+//            Path path = new File("").toPath();
+//            return path.toFile();
+//        }
+//        return Paths.get(windupHome).toFile();
+//    }
 }

--- a/bootstrap/src/main/java/org/jboss/windup/bootstrap/commands/windup/RunWindupCommand.java
+++ b/bootstrap/src/main/java/org/jboss/windup/bootstrap/commands/windup/RunWindupCommand.java
@@ -335,7 +335,8 @@ public class RunWindupCommand implements Command, FurnaceDependent
 
     private void setDefaultOutputPath(Map<String, Object> optionValues)
     {
-        if (!optionValues.containsKey(OutputPathOption.NAME))
+        Object obj = optionValues.getOrDefault(OutputPathOption.NAME, null);
+        if (obj == null || (obj instanceof File && StringUtils.isBlank( ((File) obj).getPath())) )
         {
             Iterable<Path> paths = (Iterable<Path>) optionValues.get(InputPathOption.NAME);
             if (paths != null && paths.iterator().hasNext())

--- a/config/api/src/main/java/org/jboss/windup/config/AbstractPathConfigurationOption.java
+++ b/config/api/src/main/java/org/jboss/windup/config/AbstractPathConfigurationOption.java
@@ -73,7 +73,7 @@ public abstract class AbstractPathConfigurationOption extends AbstractConfigurat
         if ( (fileObject == null && isRequired()) ||
              (fileObject instanceof Collection && isRequired() && ((Collection) fileObject).isEmpty()) )
         {
-            return new ValidationResult(ValidationResult.Level.ERROR, getLabel() + " must be specified.");
+            return new ValidationResult(ValidationResult.Level.ERROR, getName() + " must be specified.");
         }
         else if (fileObject == null)
         {

--- a/config/api/src/main/java/org/jboss/windup/config/AbstractPathConfigurationOption.java
+++ b/config/api/src/main/java/org/jboss/windup/config/AbstractPathConfigurationOption.java
@@ -3,6 +3,7 @@ package org.jboss.windup.config;
 import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Collection;
 
 import org.jboss.windup.util.exception.WindupException;
 
@@ -65,12 +66,14 @@ public abstract class AbstractPathConfigurationOption extends AbstractConfigurat
         return ValidationResult.SUCCESS;
     }
 
+    @SuppressWarnings("rawtypes")
     @Override
     public ValidationResult validate(Object fileObject)
     {
-        if (fileObject == null && isRequired())
+        if ( (fileObject == null && isRequired()) ||
+             (fileObject instanceof Collection && isRequired() && ((Collection) fileObject).isEmpty()) )
         {
-            return new ValidationResult(ValidationResult.Level.ERROR, getName() + " is required!");
+            return new ValidationResult(ValidationResult.Level.ERROR, getLabel() + " must be specified.");
         }
         else if (fileObject == null)
         {

--- a/exec/api/src/main/java/org/jboss/windup/exec/configuration/options/OutputPathOption.java
+++ b/exec/api/src/main/java/org/jboss/windup/exec/configuration/options/OutputPathOption.java
@@ -77,16 +77,18 @@ public class OutputPathOption extends AbstractPathConfigurationOption
         return validateInputsAndOutputPaths(Collections.singletonList(inputPath), outputPath);
     }
 
+    @SuppressWarnings("rawtypes")
     public static ValidationResult validateInputsAndOutputPaths(Collection inputPaths, Path outputPath)
     {
-        if (outputPath == null)
-        {
-            return new ValidationResult(ValidationResult.Level.ERROR, "Output path must be specified.");
-        }
 
         if (inputPaths == null || inputPaths.isEmpty())
         {
             return new ValidationResult(ValidationResult.Level.ERROR, "Input path must be specified.");
+        }
+        
+        if (outputPath == null)
+        {
+            return new ValidationResult(ValidationResult.Level.ERROR, "Output path must be specified.");
         }
 
         File outputFile = outputPath.toFile();

--- a/tests/src/test/java/org/jboss/windup/tests/bootstrap/migrate/NoInputOrOutputPathTest.java
+++ b/tests/src/test/java/org/jboss/windup/tests/bootstrap/migrate/NoInputOrOutputPathTest.java
@@ -71,6 +71,6 @@ public class NoInputOrOutputPathTest extends AbstractBootstrapTestWithRules {
     public void NoInputPath() {
         bootstrap("--input", " ", "--target", "eap7");
 
-        assertTrue(capturedOutput().contains("ERROR: Input paths must be specified."));
+        assertTrue(capturedOutput().contains("ERROR: input must be specified."));
     }
 }

--- a/tests/src/test/java/org/jboss/windup/tests/bootstrap/migrate/NoInputOrOutputPathTest.java
+++ b/tests/src/test/java/org/jboss/windup/tests/bootstrap/migrate/NoInputOrOutputPathTest.java
@@ -1,0 +1,76 @@
+package org.jboss.windup.tests.bootstrap.migrate;
+
+import org.apache.commons.io.FileUtils;
+import org.jboss.windup.tests.bootstrap.AbstractBootstrapTestWithRules;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.File;
+import java.io.IOException;
+
+
+public class NoInputOrOutputPathTest extends AbstractBootstrapTestWithRules {
+
+    private static final String TEST_FILE_WAR = "../test-files/Windup1x-javaee-example-tiny.war";
+    private static final File TEST_FILE_OUTPUT_DIR = new File(TEST_FILE_WAR+".report");
+
+    @Rule
+    public final TemporaryFolder tmp = new TemporaryFolder();
+
+    @Before
+    public void cleanup() {
+        try {
+            FileUtils.deleteDirectory(TEST_FILE_OUTPUT_DIR);
+        } catch (IOException ex) {}
+    }
+    
+    /**
+     * Test should show error about empty output argument
+     */
+    @Test()
+    public void InputAndNoOutputPath() {
+        bootstrap("--input", TEST_FILE_WAR,
+                "--output", "",
+                "--target", "eap7");
+
+        try
+        {
+            System.out.println(TEST_FILE_OUTPUT_DIR.getCanonicalPath()+" -> comparison");
+            assertTrue(capturedOutput().contains("Output Path:"+TEST_FILE_OUTPUT_DIR.getCanonicalPath()));
+        } catch (IOException ex) {
+            fail("Something happend while getting canonical path.");
+        }
+    }
+
+    /**
+     * Test should show error about space and therefore empty output argument
+     */
+    @Test
+    public void InputAndSpaceAsOutputPath() {
+        bootstrap("--input", TEST_FILE_WAR,
+                "--output", " ",
+                "--target", "eap7");
+        try
+        {
+            System.out.println(TEST_FILE_OUTPUT_DIR.getCanonicalPath()+" -> comparison");
+            assertTrue(capturedOutput().contains("Output Path:" +TEST_FILE_OUTPUT_DIR.getCanonicalPath()));
+        } catch (IOException ex) {
+            fail("Something happend while getting canonical path.");
+        }
+    }
+    
+    /**
+     * Test should show error about empty input argument
+     */
+    @Test
+    public void NoInputPath() {
+        bootstrap("--input", " ", "--target", "eap7");
+
+        assertTrue(capturedOutput().contains("ERROR: Input paths must be specified."));
+    }
+}


### PR DESCRIPTION
https://issues.jboss.org/browse/WINDUP-1730

I created new test for faililing soon `NoInputOrOutputPathTest`

I am not able to shift Target prompt if none is given as it would fail on validation.
