### PR TITLE
WINDUP-1726 Generated files' name

### DIFF
--- a/reporting/api/src/main/java/org/jboss/windup/reporting/freemarker/FreeMarkerIterationOperation.java
+++ b/reporting/api/src/main/java/org/jboss/windup/reporting/freemarker/FreeMarkerIterationOperation.java
@@ -95,10 +95,8 @@ public class FreeMarkerIterationOperation extends AbstractIterationOperation<Rep
             final GraphContext grCtx = event.getGraphContext();
             ReportService reportService = new ReportService(grCtx);
 
-            Path outputDir = reportService.getReportDirectory();
-            Files.createDirectories(outputDir);
-
-            Path outputPath = outputDir.resolve(outputFilename);
+            Path outputPath = reportService.getReportDirectory().resolve(outputFilename);
+            Files.createDirectories(outputPath.getParent());
 
             LOG.info("Reporting: Writing template \"" + templatePath + "\" to output file \"" + outputPath.toAbsolutePath().toString() + "\"");
 

--- a/rules-java-ee/addon/src/main/java/org/jboss/windup/rules/apps/javaee/rules/jboss/GenerateJBossEjbDescriptorRuleProvider.java
+++ b/rules-java-ee/addon/src/main/java/org/jboss/windup/rules/apps/javaee/rules/jboss/GenerateJBossEjbDescriptorRuleProvider.java
@@ -114,7 +114,7 @@ public class GenerateJBossEjbDescriptorRuleProvider extends AbstractRuleProvider
 
             ReportService reportService = new ReportService(context);
             String ancestorFolder = projectModel.getName();
-            if (ejbDescriptor.getProjectModel().getName().equals(ancestorFolder))
+            if (ejbDescriptor.getProjectModel().getName() == null || ancestorFolder.equals(ejbDescriptor.getProjectModel().getName()))
             {
                 applicationReportModel.setReportFilename(reportService.getUniqueFilename("jboss-web", "xml", false, ancestorFolder));
             } else

--- a/rules-java-ee/addon/src/main/java/org/jboss/windup/rules/apps/javaee/rules/jboss/GenerateJBossEjbDescriptorRuleProvider.java
+++ b/rules-java-ee/addon/src/main/java/org/jboss/windup/rules/apps/javaee/rules/jboss/GenerateJBossEjbDescriptorRuleProvider.java
@@ -113,7 +113,14 @@ public class GenerateJBossEjbDescriptorRuleProvider extends AbstractRuleProvider
             applicationReportModel.setRelatedResource(additionalData);
 
             ReportService reportService = new ReportService(context);
-            reportService.setUniqueFilename(applicationReportModel, "jboss-ejb3_" + projectModel.getName(), "xml");
+            String ancestorFolder = projectModel.getName();
+            if (ejbDescriptor.getProjectModel().getName().equals(ancestorFolder))
+            {
+                applicationReportModel.setReportFilename(reportService.getUniqueFilename("jboss-web", "xml", false, ancestorFolder));
+            } else
+            {
+                applicationReportModel.setReportFilename(reportService.getUniqueFilename("jboss-web", "xml", false, ancestorFolder, ejbDescriptor.getProjectModel().getName()));
+            }
 
             LOG.info("Generated jboss-ejb3.xml for " + ejbDescriptor.getFilePath() + " at: " + applicationReportModel.getReportFilename());
 

--- a/rules-java-ee/addon/src/main/java/org/jboss/windup/rules/apps/javaee/rules/jboss/GenerateJBossWebDescriptorRuleProvider.java
+++ b/rules-java-ee/addon/src/main/java/org/jboss/windup/rules/apps/javaee/rules/jboss/GenerateJBossWebDescriptorRuleProvider.java
@@ -104,7 +104,14 @@ public class GenerateJBossWebDescriptorRuleProvider extends AbstractRuleProvider
             applicationReportModel.setRelatedResource(additionalData);
 
             ReportService reportService = new ReportService(context);
-            reportService.setUniqueFilename(applicationReportModel, "jboss-web_" + projectModel.getName(), "xml");
+            String ancestorFolder = projectModel.getName();
+            if (webDescriptor.getProjectModel().getName().equals(ancestorFolder))
+            {
+                applicationReportModel.setReportFilename(reportService.getUniqueFilename("jboss-web", "xml", false, ancestorFolder));
+            } else
+            {
+                applicationReportModel.setReportFilename(reportService.getUniqueFilename("jboss-web", "xml", false, ancestorFolder, webDescriptor.getProjectModel().getName()));
+            }
 
             LOG.info("Generated jboss-web.xml for " + webDescriptor.getFilePath() + " at: " + applicationReportModel.getReportFilename());
             LinkModel link = linkService.create();

--- a/rules-java-ee/addon/src/main/java/org/jboss/windup/rules/apps/javaee/rules/jboss/GenerateJBossWebDescriptorRuleProvider.java
+++ b/rules-java-ee/addon/src/main/java/org/jboss/windup/rules/apps/javaee/rules/jboss/GenerateJBossWebDescriptorRuleProvider.java
@@ -105,7 +105,7 @@ public class GenerateJBossWebDescriptorRuleProvider extends AbstractRuleProvider
 
             ReportService reportService = new ReportService(context);
             String ancestorFolder = projectModel.getName();
-            if (webDescriptor.getProjectModel().getName().equals(ancestorFolder))
+            if (webDescriptor.getProjectModel().getName() == null || ancestorFolder.equals(webDescriptor.getProjectModel().getName()))
             {
                 applicationReportModel.setReportFilename(reportService.getUniqueFilename("jboss-web", "xml", false, ancestorFolder));
             } else

--- a/rules-java-ee/tests/src/test/java/org/jboss/windup/rules/apps/javaee/tests/GenerateJBossEjbDescriptorTest.java
+++ b/rules-java-ee/tests/src/test/java/org/jboss/windup/rules/apps/javaee/tests/GenerateJBossEjbDescriptorTest.java
@@ -46,14 +46,17 @@ public class GenerateJBossEjbDescriptorTest extends AbstractTest
     public void initData(GraphContext context)
     {
         ProjectModel parentProject1 = context.getFramed().addVertex(null, ProjectModel.class);
+        parentProject1.setName("parentProject1");
         FileModel parentFileModel1 = context.getFramed().addVertex(null, FileModel.class);
         parentProject1.addFileModel(parentFileModel1);
 
         ProjectModel parentProject2 = context.getFramed().addVertex(null, ProjectModel.class);
+        parentProject2.setName("parentProject2");
         FileModel parentFileModel2 = context.getFramed().addVertex(null, FileModel.class);
         parentProject2.addFileModel(parentFileModel2);
 
         ProjectModel pm1 = context.getFramed().addVertex(null, ProjectModel.class);
+        pm1.setName("pm1");
         pm1.setParentProject(parentProject1);
 
         ProjectModel pm2 = context.getFramed().addVertex(null, ProjectModel.class);

--- a/rules-java-ee/tests/src/test/java/org/jboss/windup/rules/apps/javaee/tests/GenerateJbossWebDescriptorTest.java
+++ b/rules-java-ee/tests/src/test/java/org/jboss/windup/rules/apps/javaee/tests/GenerateJbossWebDescriptorTest.java
@@ -45,14 +45,17 @@ public class GenerateJbossWebDescriptorTest extends AbstractTest
     public void initData(GraphContext context)
     {
         ProjectModel parentProject1 = context.getFramed().addVertex(null, ProjectModel.class);
+        parentProject1.setName("parentProject1");
         FileModel parentFileModel1 = context.getFramed().addVertex(null, FileModel.class);
         parentProject1.addFileModel(parentFileModel1);
 
         ProjectModel parentProject2 = context.getFramed().addVertex(null, ProjectModel.class);
+        parentProject2.setName("parentProject2");
         FileModel parentFileModel2 = context.getFramed().addVertex(null, FileModel.class);
         parentProject2.addFileModel(parentFileModel2);
 
         ProjectModel pm1 =context.getFramed().addVertex(null, ProjectModel.class);
+        pm1.setName("pm1");
         pm1.setParentProject(parentProject1);
 
         ProjectModel pm2 =context.getFramed().addVertex(null, ProjectModel.class);

--- a/rules-xml/api/src/main/java/org/jboss/windup/rules/apps/xml/operation/xslt/XSLTTransformation.java
+++ b/rules-xml/api/src/main/java/org/jboss/windup/rules/apps/xml/operation/xslt/XSLTTransformation.java
@@ -267,9 +267,8 @@ public class XSLTTransformation extends AbstractIterationOperation<XmlFileModel>
         fileName = fileName + extension;
 
         XsltTransformationService xsltTransformationService = new XsltTransformationService(graphContext);
-        Path outputPath = xsltTransformationService.getTransformedXSLTPath();
 
-        Path resultPath = outputPath.resolve(fileName);
+        Path resultPath = xsltTransformationService.getTransformedXSLTPath(payload).resolve(fileName);
 
         Source xmlSource = new DOMSource(payload.asDocument());
         Result xmlResult = new StreamResult(resultPath.toFile());
@@ -296,7 +295,7 @@ public class XSLTTransformation extends AbstractIterationOperation<XmlFileModel>
             GraphService<LinkModel> linkService = new GraphService<>(graphContext, LinkModel.class);
             LinkModel linkModel = linkService.create();
             linkModel.setDescription(description);
-            linkModel.setLink(XsltTransformationService.TRANSFORMEDXML_DIR_NAME + "/" + fileName);
+            linkModel.setLink(xsltTransformationService.getRelativeTransformedXSLTPath(payload).resolve(fileName).toString());
             payload.addLinkToTransformedFile(linkModel);
             // classificationModel.addLink(linkModel);
         }

--- a/rules-xml/api/src/main/java/org/jboss/windup/rules/apps/xml/service/XsltTransformationService.java
+++ b/rules-xml/api/src/main/java/org/jboss/windup/rules/apps/xml/service/XsltTransformationService.java
@@ -3,11 +3,14 @@ package org.jboss.windup.rules.apps.xml.service;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 
 import org.jboss.windup.graph.GraphContext;
+import org.jboss.windup.graph.model.resource.FileModel;
 import org.jboss.windup.graph.service.GraphService;
 import org.jboss.windup.reporting.service.ReportService;
 import org.jboss.windup.rules.apps.xml.model.XsltTransformationModel;
+import org.jboss.windup.util.PathUtil;
 import org.jboss.windup.util.exception.WindupException;
 
 /**
@@ -27,10 +30,11 @@ public class XsltTransformationService extends GraphService<XsltTransformationMo
     /**
      * Gets the path used for the results of XSLT Transforms.
      */
-    public Path getTransformedXSLTPath()
+    public Path getTransformedXSLTPath(FileModel payload)
     {
         ReportService reportService = new ReportService(getGraphContext());
-        Path outputPath = reportService.getReportDirectory().resolve(TRANSFORMEDXML_DIR_NAME);
+        Path outputPath = reportService.getReportDirectory();
+        outputPath = outputPath.resolve(this.getRelativeTransformedXSLTPath(payload));
         if (!Files.isDirectory(outputPath))
         {
             try
@@ -45,4 +49,21 @@ public class XsltTransformationService extends GraphService<XsltTransformationMo
         }
         return outputPath;
     }
+
+    public Path getRelativeTransformedXSLTPath(FileModel payload)
+    {
+        Path outputPath = Paths.get("");
+        if (payload != null)
+        {
+            String ancestorFolder = payload.getProjectModel().getRootProjectModel().getName();
+            outputPath = outputPath.resolve(PathUtil.cleanFileName(ancestorFolder));
+            if (!ancestorFolder.equals(payload.getProjectModel().getName()))
+            {
+                outputPath = outputPath.resolve(PathUtil.cleanFileName(payload.getProjectModel().getName()));
+            }
+        }
+        outputPath = outputPath.resolve(TRANSFORMEDXML_DIR_NAME);
+        return outputPath;
+    }
+
 }

--- a/rules-xml/tests/src/test/java/org/jboss/windup/rules/apps/xml/operation/xslt/XSLTTransformationHandlerTest.java
+++ b/rules-xml/tests/src/test/java/org/jboss/windup/rules/apps/xml/operation/xslt/XSLTTransformationHandlerTest.java
@@ -149,7 +149,7 @@ public class XSLTTransformationHandlerTest
 
             Assert.assertTrue(classificationModels.get(0).getClassification().contains("XSLT Transformed Output"));
 
-            Path transformedFile = outputPath.resolve("reports").resolve("transformedxml").resolve("sample-xml-test-result.html");
+            Path transformedFile = outputPath.resolve("reports").resolve("xslttransform").resolve("transformedxml").resolve("sample-xml-test-result.html");
             Assert.assertTrue(Files.isRegularFile(transformedFile));
             Assert.assertTrue(Files.size(transformedFile) > 0);
         }

--- a/rules-xml/tests/src/test/java/org/jboss/windup/rules/xml/XMLTransformationTest.java
+++ b/rules-xml/tests/src/test/java/org/jboss/windup/rules/xml/XMLTransformationTest.java
@@ -114,7 +114,7 @@ public class XMLTransformationTest
             Assert.assertEquals(SIMPLE_XSLT_XSL, xsltTransformation.getSourceLocation());
             Assert.assertEquals(XSLT_EXTENSION, xsltTransformation.getExtension());
             XsltTransformationService xsltTransformationService = new XsltTransformationService(context);
-            Path transformedPath = xsltTransformationService.getTransformedXSLTPath().resolve(
+            Path transformedPath = xsltTransformationService.getTransformedXSLTPath(inputPath).resolve(
                         xsltTransformation.getResult());
 
             Assert.assertEquals(3, xsltTransformation.getEffort());

--- a/tests/src/test/java/org/jboss/windup/tests/application/WindupArchitectureSourceModeTest.java
+++ b/tests/src/test/java/org/jboss/windup/tests/application/WindupArchitectureSourceModeTest.java
@@ -21,7 +21,9 @@ import org.jboss.forge.arquillian.AddonDependency;
 import org.jboss.forge.arquillian.archive.AddonArchive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.windup.graph.GraphContext;
+import org.jboss.windup.graph.model.ProjectModel;
 import org.jboss.windup.graph.service.GraphService;
+import org.jboss.windup.graph.service.ProjectService;
 import org.jboss.windup.reporting.model.ApplicationReportModel;
 import org.jboss.windup.reporting.model.ReportModel;
 import org.jboss.windup.reporting.service.ApplicationReportService;
@@ -34,6 +36,8 @@ import org.jboss.windup.rules.apps.javaee.rules.CreateEJBReportRuleProvider;
 import org.jboss.windup.rules.apps.javaee.rules.CreateJPAReportRuleProvider;
 import org.jboss.windup.rules.apps.javaee.rules.CreateSpringBeanReportRuleProvider;
 import org.jboss.windup.rules.apps.javaee.service.WebXmlService;
+import org.jboss.windup.rules.apps.xml.model.XmlFileModel;
+import org.jboss.windup.rules.apps.xml.service.XmlFileService;
 import org.jboss.windup.rules.apps.xml.service.XsltTransformationService;
 import org.jboss.windup.tests.application.rules.TestServletAnnotationRuleProvider;
 import org.jboss.windup.testutil.html.TestCompatibleReportUtil;
@@ -290,9 +294,15 @@ public class WindupArchitectureSourceModeTest extends WindupArchitectureTest
                     "javax.servlet.http.HttpServletRequest usage");
 
         XsltTransformationService xsltService = new XsltTransformationService(context);
-        Assert.assertTrue(Files.isRegularFile(xsltService.getTransformedXSLTPath().resolve(
+        ProjectService projectService = new ProjectService(context);
+        ProjectModel projectModel = projectService.create();
+        projectModel.setName("src_example");
+        XmlFileService xmlFileService = new XmlFileService(context);
+        XmlFileModel xmlFileModel = xmlFileService.create();
+        projectModel.addFileModel(xmlFileModel);
+        Assert.assertTrue(Files.isRegularFile(xsltService.getTransformedXSLTPath(xmlFileModel).resolve(
                     "web-xml-converted-example.xml")));
-        Assert.assertTrue(Files.isRegularFile(xsltService.getTransformedXSLTPath().resolve(
+        Assert.assertTrue(Files.isRegularFile(xsltService.getTransformedXSLTPath(xmlFileModel).resolve(
                     "web-xmluserscript-converted-example.xml")));
 
         validateSpringBeanReport(context);


### PR DESCRIPTION
The generated files from [`GenerateJBossWebDescriptorRuleProvider`](https://github.com/windup/windup/blob/master/rules-java-ee/addon/src/main/java/org/jboss/windup/rules/apps/javaee/rules/jboss/GenerateJBossWebDescriptorRuleProvider.java) and [`GenerateJBossEjbDescriptorRuleProvider`](https://github.com/windup/windup/blob/master/rules-java-ee/addon/src/main/java/org/jboss/windup/rules/apps/javaee/rules/jboss/GenerateJBossEjbDescriptorRuleProvider.java) are now placed inside folders path representing the projects they belong to in order to have a unique path to them and so having the files with _standard_ and _default_ names `jboss-web.xml` and `jboss-ejb3.xml` as requested in the [WINDUP-1726](https://issues.jboss.org/browse/WINDUP-1726)

To achieve this it has been refactored [org.jboss.windup.reporting.service.ReportService](https://github.com/windup/windup/blob/master/reporting/api/src/main/java/org/jboss/windup/reporting/service/ReportService.java) methods to have a get method to retrieve a unique file name with also ancestor folders as input.

For backward compatibility the [org.jboss.windup.reporting.service.ReportService#setUniqueFilename](https://github.com/windup/windup/blob/master/reporting/api/src/main/java/org/jboss/windup/reporting/service/ReportService.java#L94) has been refactored to call the new `getUniqueFilename`.