### PR TITLE
WINDUP-1724 Reduce list {source,target,tag} commands execution time

### DIFF
--- a/bootstrap/src/main/java/org/jboss/windup/bootstrap/commands/AbstractListCommand.java
+++ b/bootstrap/src/main/java/org/jboss/windup/bootstrap/commands/AbstractListCommand.java
@@ -1,11 +1,9 @@
 package org.jboss.windup.bootstrap.commands;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 import org.jboss.forge.furnace.Furnace;
+import org.jboss.windup.bootstrap.help.Help;
 
 /**
  * @author <a href="mailto:lincolnbaxter@gmail.com">Lincoln Baxter, III</a>
@@ -38,5 +36,14 @@ public abstract class AbstractListCommand implements Command, FurnaceDependent
         {
             System.out.println("\t" + value);
         }
+    }
+
+    protected static Set<String> getOptionValuesFromHelp(String optionName)
+    {
+        Set<String> options = new HashSet<>();
+        Help.load().getOptions().stream()
+                .filter(opt -> opt.getName().equals(optionName))
+                .forEach(optionDescription -> options.addAll(optionDescription.getAvailableOptions()));
+        return options;
     }
 }

--- a/bootstrap/src/main/java/org/jboss/windup/bootstrap/commands/AbstractListCommand.java
+++ b/bootstrap/src/main/java/org/jboss/windup/bootstrap/commands/AbstractListCommand.java
@@ -1,14 +1,11 @@
 package org.jboss.windup.bootstrap.commands;
 
-import java.util.*;
-
 import org.jboss.forge.furnace.Furnace;
-import org.jboss.windup.bootstrap.help.Help;
 
 /**
  * @author <a href="mailto:lincolnbaxter@gmail.com">Lincoln Baxter, III</a>
  */
-public abstract class AbstractListCommand implements Command, FurnaceDependent
+public abstract class AbstractListCommand extends AbstractListCommandWithoutFurnace implements Command, FurnaceDependent
 {
     private Furnace furnace;
 
@@ -21,29 +18,5 @@ public abstract class AbstractListCommand implements Command, FurnaceDependent
     public void setFurnace(Furnace furnace)
     {
         this.furnace = furnace;
-    }
-
-    /**
-     * Print the given values after displaying the provided message.
-     */
-    protected static void printValuesSorted(String message, Set<String> values)
-    {
-        System.out.println();
-        System.out.println(message + ":");
-        List<String> sorted = new ArrayList<>(values);
-        Collections.sort(sorted);
-        for (String value : sorted)
-        {
-            System.out.println("\t" + value);
-        }
-    }
-
-    protected static Set<String> getOptionValuesFromHelp(String optionName)
-    {
-        Set<String> options = new HashSet<>();
-        Help.load().getOptions().stream()
-                .filter(opt -> opt.getName().equals(optionName))
-                .forEach(optionDescription -> options.addAll(optionDescription.getAvailableOptions()));
-        return options;
     }
 }

--- a/bootstrap/src/main/java/org/jboss/windup/bootstrap/commands/AbstractListCommandWithoutFurnace.java
+++ b/bootstrap/src/main/java/org/jboss/windup/bootstrap/commands/AbstractListCommandWithoutFurnace.java
@@ -1,0 +1,36 @@
+package org.jboss.windup.bootstrap.commands;
+
+import org.jboss.forge.furnace.Furnace;
+import org.jboss.windup.bootstrap.help.Help;
+
+import java.util.*;
+
+/**
+ * @author <a href="mailto:lincolnbaxter@gmail.com">Lincoln Baxter, III</a>
+ */
+public abstract class AbstractListCommandWithoutFurnace implements Command
+{
+    /**
+     * Print the given values after displaying the provided message.
+     */
+    protected static void printValuesSorted(String message, Set<String> values)
+    {
+        System.out.println();
+        System.out.println(message + ":");
+        List<String> sorted = new ArrayList<>(values);
+        Collections.sort(sorted);
+        for (String value : sorted)
+        {
+            System.out.println("\t" + value);
+        }
+    }
+
+    protected static Set<String> getOptionValuesFromHelp(String optionName)
+    {
+        Set<String> options = new HashSet<>();
+        Help.load().getOptions().stream()
+                .filter(opt -> opt.getName().equals(optionName))
+                .forEach(optionDescription -> options.addAll(optionDescription.getAvailableOptions()));
+        return options;
+    }
+}

--- a/bootstrap/src/main/java/org/jboss/windup/bootstrap/commands/windup/ListSourceTechnologiesCommand.java
+++ b/bootstrap/src/main/java/org/jboss/windup/bootstrap/commands/windup/ListSourceTechnologiesCommand.java
@@ -5,7 +5,7 @@ import org.jboss.windup.bootstrap.commands.Command;
 import org.jboss.windup.bootstrap.commands.CommandPhase;
 import org.jboss.windup.bootstrap.commands.CommandResult;
 import org.jboss.windup.bootstrap.commands.FurnaceDependent;
-import org.jboss.windup.config.metadata.RuleProviderRegistryCache;
+import org.jboss.windup.exec.configuration.options.SourceOption;
 
 /**
  * @author <a href="mailto:lincolnbaxter@gmail.com">Lincoln Baxter, III</a>
@@ -15,8 +15,7 @@ public class ListSourceTechnologiesCommand extends AbstractListCommand implement
     @Override
     public CommandResult execute()
     {
-        RuleProviderRegistryCache ruleProviderRegistryCache = getFurnace().getAddonRegistry().getServices(RuleProviderRegistryCache.class).get();
-        printValuesSorted("Available source technologies", ruleProviderRegistryCache.getAvailableSourceTechnologies());
+        printValuesSorted("Available source technologies", getOptionValuesFromHelp(SourceOption.NAME));
         return CommandResult.EXIT;
     }
 

--- a/bootstrap/src/main/java/org/jboss/windup/bootstrap/commands/windup/ListSourceTechnologiesCommand.java
+++ b/bootstrap/src/main/java/org/jboss/windup/bootstrap/commands/windup/ListSourceTechnologiesCommand.java
@@ -1,16 +1,15 @@
 package org.jboss.windup.bootstrap.commands.windup;
 
-import org.jboss.windup.bootstrap.commands.AbstractListCommand;
+import org.jboss.windup.bootstrap.commands.AbstractListCommandWithoutFurnace;
 import org.jboss.windup.bootstrap.commands.Command;
 import org.jboss.windup.bootstrap.commands.CommandPhase;
 import org.jboss.windup.bootstrap.commands.CommandResult;
-import org.jboss.windup.bootstrap.commands.FurnaceDependent;
 import org.jboss.windup.exec.configuration.options.SourceOption;
 
 /**
  * @author <a href="mailto:lincolnbaxter@gmail.com">Lincoln Baxter, III</a>
  */
-public class ListSourceTechnologiesCommand extends AbstractListCommand implements Command, FurnaceDependent
+public class ListSourceTechnologiesCommand extends AbstractListCommandWithoutFurnace implements Command
 {
     @Override
     public CommandResult execute()
@@ -22,6 +21,6 @@ public class ListSourceTechnologiesCommand extends AbstractListCommand implement
     @Override
     public CommandPhase getPhase()
     {
-        return CommandPhase.PRE_EXECUTION;
+        return CommandPhase.PRE_CONFIGURATION;
     }
 }

--- a/bootstrap/src/main/java/org/jboss/windup/bootstrap/commands/windup/ListTagsCommand.java
+++ b/bootstrap/src/main/java/org/jboss/windup/bootstrap/commands/windup/ListTagsCommand.java
@@ -5,7 +5,7 @@ import org.jboss.windup.bootstrap.commands.Command;
 import org.jboss.windup.bootstrap.commands.CommandPhase;
 import org.jboss.windup.bootstrap.commands.CommandResult;
 import org.jboss.windup.bootstrap.commands.FurnaceDependent;
-import org.jboss.windup.config.metadata.RuleProviderRegistryCache;
+import org.jboss.windup.exec.configuration.options.IncludeTagsOption;
 
 /**
  * @author <a href="mailto:lincolnbaxter@gmail.com">Lincoln Baxter, III</a>
@@ -15,8 +15,7 @@ public class ListTagsCommand extends AbstractListCommand implements Command, Fur
     @Override
     public CommandResult execute()
     {
-        RuleProviderRegistryCache ruleProviderRegistryCache = getFurnace().getAddonRegistry().getServices(RuleProviderRegistryCache.class).get();
-        printValuesSorted("Available tags", ruleProviderRegistryCache.getAvailableTags());
+        printValuesSorted("Available tags", getOptionValuesFromHelp(IncludeTagsOption.NAME));
         return CommandResult.EXIT;
     }
 

--- a/bootstrap/src/main/java/org/jboss/windup/bootstrap/commands/windup/ListTagsCommand.java
+++ b/bootstrap/src/main/java/org/jboss/windup/bootstrap/commands/windup/ListTagsCommand.java
@@ -1,16 +1,15 @@
 package org.jboss.windup.bootstrap.commands.windup;
 
-import org.jboss.windup.bootstrap.commands.AbstractListCommand;
+import org.jboss.windup.bootstrap.commands.AbstractListCommandWithoutFurnace;
 import org.jboss.windup.bootstrap.commands.Command;
 import org.jboss.windup.bootstrap.commands.CommandPhase;
 import org.jboss.windup.bootstrap.commands.CommandResult;
-import org.jboss.windup.bootstrap.commands.FurnaceDependent;
 import org.jboss.windup.exec.configuration.options.IncludeTagsOption;
 
 /**
  * @author <a href="mailto:lincolnbaxter@gmail.com">Lincoln Baxter, III</a>
  */
-public class ListTagsCommand extends AbstractListCommand implements Command, FurnaceDependent
+public class ListTagsCommand extends AbstractListCommandWithoutFurnace implements Command
 {
     @Override
     public CommandResult execute()
@@ -22,7 +21,7 @@ public class ListTagsCommand extends AbstractListCommand implements Command, Fur
     @Override
     public CommandPhase getPhase()
     {
-        return CommandPhase.PRE_EXECUTION;
+        return CommandPhase.PRE_CONFIGURATION;
     }
 
 }

--- a/bootstrap/src/main/java/org/jboss/windup/bootstrap/commands/windup/ListTargetTechnologiesCommand.java
+++ b/bootstrap/src/main/java/org/jboss/windup/bootstrap/commands/windup/ListTargetTechnologiesCommand.java
@@ -5,7 +5,7 @@ import org.jboss.windup.bootstrap.commands.Command;
 import org.jboss.windup.bootstrap.commands.CommandPhase;
 import org.jboss.windup.bootstrap.commands.CommandResult;
 import org.jboss.windup.bootstrap.commands.FurnaceDependent;
-import org.jboss.windup.config.metadata.RuleProviderRegistryCache;
+import org.jboss.windup.exec.configuration.options.TargetOption;
 
 /**
  * @author <a href="mailto:lincolnbaxter@gmail.com">Lincoln Baxter, III</a>
@@ -15,8 +15,7 @@ public class ListTargetTechnologiesCommand extends AbstractListCommand implement
     @Override
     public CommandResult execute()
     {
-        RuleProviderRegistryCache ruleProviderRegistryCache = getFurnace().getAddonRegistry().getServices(RuleProviderRegistryCache.class).get();
-        printValuesSorted("Available target technologies", ruleProviderRegistryCache.getAvailableTargetTechnologies());
+        printValuesSorted("Available target technologies", getOptionValuesFromHelp(TargetOption.NAME));
         return CommandResult.EXIT;
     }
 

--- a/bootstrap/src/main/java/org/jboss/windup/bootstrap/commands/windup/ListTargetTechnologiesCommand.java
+++ b/bootstrap/src/main/java/org/jboss/windup/bootstrap/commands/windup/ListTargetTechnologiesCommand.java
@@ -1,16 +1,15 @@
 package org.jboss.windup.bootstrap.commands.windup;
 
-import org.jboss.windup.bootstrap.commands.AbstractListCommand;
+import org.jboss.windup.bootstrap.commands.AbstractListCommandWithoutFurnace;
 import org.jboss.windup.bootstrap.commands.Command;
 import org.jboss.windup.bootstrap.commands.CommandPhase;
 import org.jboss.windup.bootstrap.commands.CommandResult;
-import org.jboss.windup.bootstrap.commands.FurnaceDependent;
 import org.jboss.windup.exec.configuration.options.TargetOption;
 
 /**
  * @author <a href="mailto:lincolnbaxter@gmail.com">Lincoln Baxter, III</a>
  */
-public class ListTargetTechnologiesCommand extends AbstractListCommand implements Command, FurnaceDependent
+public class ListTargetTechnologiesCommand extends AbstractListCommandWithoutFurnace implements Command
 {
     @Override
     public CommandResult execute()
@@ -22,7 +21,7 @@ public class ListTargetTechnologiesCommand extends AbstractListCommand implement
     @Override
     public CommandPhase getPhase()
     {
-        return CommandPhase.PRE_EXECUTION;
+        return CommandPhase.PRE_CONFIGURATION;
     }
 
 }


### PR DESCRIPTION
On average, an execution of RHAMT CLI with one of the following flags `--listTags`, `--listSourceTechnologies` or`--listTargetTechnologies` tooks about 5 seconds to execute.
In this 5 seconds, about 1.5-2 seconds are spent in a for loop in [XMLRuleProviderLoader](https://github.com/windup/windup/blob/master/config-xml/addon/src/main/java/org/jboss/windup/config/parser/XMLRuleProviderLoader.java#L120) due to loading of more than 100 rules files, each taking between 15-20 milliseconds.
The remaining 3 seconds are spent for starting and then shutting down Furnace and scanning the classpath for all Java addons.
With the changes in this PR, the sources/targets/tags are not retrieved  from rules anymore but they're read from the `help.xml` file with the result that running every command now take only 3 seconds (sometimes just 2) that is the minimum time for booting Furnace and then turn it off.