### PR TITLE
WINDUP-1758 WINDUP-1768 CLI  option in list* commands

### DIFF
--- a/bootstrap/src/main/java/org/jboss/windup/bootstrap/Bootstrap.java
+++ b/bootstrap/src/main/java/org/jboss/windup/bootstrap/Bootstrap.java
@@ -409,11 +409,11 @@ public class Bootstrap
             }
             else if ("--listSourceTechnologies".equals(arg))
             {
-                commands.add(new ListSourceTechnologiesCommand());
+                commands.add(new ListSourceTechnologiesCommand(arguments));
             }
             else if ("--listTargetTechnologies".equals(arg))
             {
-                commands.add(new ListTargetTechnologiesCommand());
+                commands.add(new ListTargetTechnologiesCommand(arguments));
             }
             else if ("--generateCompletionData".equals(arg))
             {

--- a/bootstrap/src/main/java/org/jboss/windup/bootstrap/Bootstrap.java
+++ b/bootstrap/src/main/java/org/jboss/windup/bootstrap/Bootstrap.java
@@ -405,7 +405,7 @@ public class Bootstrap
             }
             else if ("--listTags".equals(arg))
             {
-                commands.add(new ListTagsCommand());
+                commands.add(new ListTagsCommand(arguments));
             }
             else if ("--listSourceTechnologies".equals(arg))
             {

--- a/bootstrap/src/main/java/org/jboss/windup/bootstrap/commands/AbstractListCommand.java
+++ b/bootstrap/src/main/java/org/jboss/windup/bootstrap/commands/AbstractListCommand.java
@@ -1,6 +1,15 @@
 package org.jboss.windup.bootstrap.commands;
 
 import org.jboss.forge.furnace.Furnace;
+import org.jboss.windup.exec.configuration.options.UserRulesDirectoryOption;
+import org.jboss.windup.util.PathUtil;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * @author <a href="mailto:lincolnbaxter@gmail.com">Lincoln Baxter, III</a>
@@ -18,5 +27,40 @@ public abstract class AbstractListCommand extends AbstractListCommandWithoutFurn
     public void setFurnace(Furnace furnace)
     {
         this.furnace = furnace;
+    }
+
+    protected List<Path> getUserProvidedPaths(List<String> arguments)
+    {
+        List<Path> userProvidedPaths = new ArrayList<>();
+        boolean foundUserRulesDirectoryOption = false;
+        for (int i = 0; i < arguments.size(); i++)
+        {
+            String argument = arguments.get(i);
+            if (argument.equalsIgnoreCase("--" + UserRulesDirectoryOption.NAME))
+            {
+                foundUserRulesDirectoryOption = true;
+            } else if(foundUserRulesDirectoryOption)
+            {
+                if (argument.startsWith("-"))
+                {
+                    break;
+                } else
+                {
+                    userProvidedPaths.add(Paths.get(argument));
+                }
+            }
+        }
+        Path userRulesDir = PathUtil.getUserRulesDir();
+        try
+        {
+            // do not filter files contained in UserRulesDir to search for "rhamt.xml" or "windup.xml"
+            // as it do not filter in the case of userProvidedPaths.
+            // It just adds the dir to be scanned by RuleProviderRegistryCache
+            if (Files.list(userRulesDir).count() > 0) userProvidedPaths.add(userRulesDir);
+        } catch (IOException ioe)
+        {
+            System.err.println("Warning: Unable to load rules from " + userRulesDir.toString() + " due to " + ioe.getMessage());
+        }
+        return userProvidedPaths;
     }
 }

--- a/bootstrap/src/main/java/org/jboss/windup/bootstrap/commands/windup/ListSourceTechnologiesCommand.java
+++ b/bootstrap/src/main/java/org/jboss/windup/bootstrap/commands/windup/ListSourceTechnologiesCommand.java
@@ -1,26 +1,49 @@
 package org.jboss.windup.bootstrap.commands.windup;
 
-import org.jboss.windup.bootstrap.commands.AbstractListCommandWithoutFurnace;
+import org.jboss.windup.bootstrap.commands.AbstractListCommand;
 import org.jboss.windup.bootstrap.commands.Command;
 import org.jboss.windup.bootstrap.commands.CommandPhase;
 import org.jboss.windup.bootstrap.commands.CommandResult;
+import org.jboss.windup.bootstrap.commands.FurnaceDependent;
+import org.jboss.windup.config.metadata.RuleProviderRegistryCache;
 import org.jboss.windup.exec.configuration.options.SourceOption;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Set;
 
 /**
  * @author <a href="mailto:lincolnbaxter@gmail.com">Lincoln Baxter, III</a>
  */
-public class ListSourceTechnologiesCommand extends AbstractListCommandWithoutFurnace implements Command
+public class ListSourceTechnologiesCommand extends AbstractListCommand implements Command, FurnaceDependent
 {
+    private final List<Path> userProvidedPaths;
+
+    public ListSourceTechnologiesCommand(List<String> arguments)
+    {
+        userProvidedPaths = getUserProvidedPaths(arguments);
+    }
+
     @Override
     public CommandResult execute()
     {
-        printValuesSorted("Available source technologies", getOptionValuesFromHelp(SourceOption.NAME));
+        Set<String> result;
+        if (userProvidedPaths.isEmpty())
+        {
+            result = getOptionValuesFromHelp(SourceOption.NAME);
+        } else
+        {
+            RuleProviderRegistryCache ruleProviderRegistryCache = getFurnace().getAddonRegistry().getServices(RuleProviderRegistryCache.class).get();
+            userProvidedPaths.forEach(userProvidedPath -> ruleProviderRegistryCache.addUserRulesPath(userProvidedPath));
+            result = ruleProviderRegistryCache.getAvailableSourceTechnologies();
+        }
+        printValuesSorted("Available source technologies", result);
         return CommandResult.EXIT;
     }
 
     @Override
     public CommandPhase getPhase()
     {
-        return CommandPhase.PRE_CONFIGURATION;
+        return userProvidedPaths.isEmpty() ? CommandPhase.PRE_CONFIGURATION : CommandPhase.PRE_EXECUTION;
     }
 }

--- a/bootstrap/src/main/java/org/jboss/windup/bootstrap/commands/windup/ListTagsCommand.java
+++ b/bootstrap/src/main/java/org/jboss/windup/bootstrap/commands/windup/ListTagsCommand.java
@@ -1,27 +1,70 @@
 package org.jboss.windup.bootstrap.commands.windup;
 
-import org.jboss.windup.bootstrap.commands.AbstractListCommandWithoutFurnace;
+import org.jboss.windup.bootstrap.commands.AbstractListCommand;
 import org.jboss.windup.bootstrap.commands.Command;
 import org.jboss.windup.bootstrap.commands.CommandPhase;
 import org.jboss.windup.bootstrap.commands.CommandResult;
+import org.jboss.windup.bootstrap.commands.FurnaceDependent;
+import org.jboss.windup.config.metadata.RuleProviderRegistryCache;
 import org.jboss.windup.exec.configuration.options.IncludeTagsOption;
+import org.jboss.windup.exec.configuration.options.UserRulesDirectoryOption;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
 
 /**
  * @author <a href="mailto:lincolnbaxter@gmail.com">Lincoln Baxter, III</a>
  */
-public class ListTagsCommand extends AbstractListCommandWithoutFurnace implements Command
+public class ListTagsCommand extends AbstractListCommand implements Command, FurnaceDependent
 {
+    private final List<Path> userProvidedPaths = new ArrayList<>();
+
+    public ListTagsCommand(List<String> arguments)
+    {
+        boolean foundUserRulesDirectoryOption = false;
+        for (int i = 0; i < arguments.size(); i++)
+        {
+            String argument = arguments.get(i);
+            if (argument.equalsIgnoreCase("--" + UserRulesDirectoryOption.NAME))
+            {
+                foundUserRulesDirectoryOption = true;
+            } else if(foundUserRulesDirectoryOption)
+            {
+                if (argument.startsWith("-"))
+                {
+                    break;
+                } else
+                {
+                    userProvidedPaths.add(Paths.get(argument));
+                }
+            }
+        }
+    }
+
     @Override
     public CommandResult execute()
     {
-        printValuesSorted("Available tags", getOptionValuesFromHelp(IncludeTagsOption.NAME));
+        Set<String> result;
+        if (userProvidedPaths.isEmpty())
+        {
+            result = getOptionValuesFromHelp(IncludeTagsOption.NAME);
+        } else
+        {
+            RuleProviderRegistryCache ruleProviderRegistryCache = getFurnace().getAddonRegistry().getServices(RuleProviderRegistryCache.class).get();
+            userProvidedPaths.forEach(userProvidedPath -> ruleProviderRegistryCache.addUserRulesPath(userProvidedPath));
+            result = ruleProviderRegistryCache.getAvailableTags();
+        }
+        printValuesSorted("Available tags", result);
         return CommandResult.EXIT;
     }
 
     @Override
     public CommandPhase getPhase()
     {
-        return CommandPhase.PRE_CONFIGURATION;
+        return userProvidedPaths.isEmpty() ? CommandPhase.PRE_CONFIGURATION : CommandPhase.PRE_EXECUTION;
     }
 
 }

--- a/bootstrap/src/main/java/org/jboss/windup/bootstrap/commands/windup/ListTagsCommand.java
+++ b/bootstrap/src/main/java/org/jboss/windup/bootstrap/commands/windup/ListTagsCommand.java
@@ -7,11 +7,8 @@ import org.jboss.windup.bootstrap.commands.CommandResult;
 import org.jboss.windup.bootstrap.commands.FurnaceDependent;
 import org.jboss.windup.config.metadata.RuleProviderRegistryCache;
 import org.jboss.windup.exec.configuration.options.IncludeTagsOption;
-import org.jboss.windup.exec.configuration.options.UserRulesDirectoryOption;
 
 import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
@@ -20,28 +17,11 @@ import java.util.Set;
  */
 public class ListTagsCommand extends AbstractListCommand implements Command, FurnaceDependent
 {
-    private final List<Path> userProvidedPaths = new ArrayList<>();
+    private final List<Path> userProvidedPaths;
 
     public ListTagsCommand(List<String> arguments)
     {
-        boolean foundUserRulesDirectoryOption = false;
-        for (int i = 0; i < arguments.size(); i++)
-        {
-            String argument = arguments.get(i);
-            if (argument.equalsIgnoreCase("--" + UserRulesDirectoryOption.NAME))
-            {
-                foundUserRulesDirectoryOption = true;
-            } else if(foundUserRulesDirectoryOption)
-            {
-                if (argument.startsWith("-"))
-                {
-                    break;
-                } else
-                {
-                    userProvidedPaths.add(Paths.get(argument));
-                }
-            }
-        }
+        userProvidedPaths = getUserProvidedPaths(arguments);
     }
 
     @Override

--- a/bootstrap/src/main/java/org/jboss/windup/bootstrap/commands/windup/ListTargetTechnologiesCommand.java
+++ b/bootstrap/src/main/java/org/jboss/windup/bootstrap/commands/windup/ListTargetTechnologiesCommand.java
@@ -1,27 +1,50 @@
 package org.jboss.windup.bootstrap.commands.windup;
 
-import org.jboss.windup.bootstrap.commands.AbstractListCommandWithoutFurnace;
+import org.jboss.windup.bootstrap.commands.AbstractListCommand;
 import org.jboss.windup.bootstrap.commands.Command;
 import org.jboss.windup.bootstrap.commands.CommandPhase;
 import org.jboss.windup.bootstrap.commands.CommandResult;
+import org.jboss.windup.bootstrap.commands.FurnaceDependent;
+import org.jboss.windup.config.metadata.RuleProviderRegistryCache;
 import org.jboss.windup.exec.configuration.options.TargetOption;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Set;
 
 /**
  * @author <a href="mailto:lincolnbaxter@gmail.com">Lincoln Baxter, III</a>
  */
-public class ListTargetTechnologiesCommand extends AbstractListCommandWithoutFurnace implements Command
+public class ListTargetTechnologiesCommand extends AbstractListCommand implements Command, FurnaceDependent
 {
+    private final List<Path> userProvidedPaths;
+
+    public ListTargetTechnologiesCommand(List<String> arguments)
+    {
+        userProvidedPaths = getUserProvidedPaths(arguments);
+    }
+
     @Override
     public CommandResult execute()
     {
-        printValuesSorted("Available target technologies", getOptionValuesFromHelp(TargetOption.NAME));
+        Set<String> result;
+        if (userProvidedPaths.isEmpty())
+        {
+            result = getOptionValuesFromHelp(TargetOption.NAME);
+        } else
+        {
+            RuleProviderRegistryCache ruleProviderRegistryCache = getFurnace().getAddonRegistry().getServices(RuleProviderRegistryCache.class).get();
+            userProvidedPaths.forEach(userProvidedPath -> ruleProviderRegistryCache.addUserRulesPath(userProvidedPath));
+            result = ruleProviderRegistryCache.getAvailableTargetTechnologies();
+        }
+        printValuesSorted("Available target technologies", result);
         return CommandResult.EXIT;
     }
 
     @Override
     public CommandPhase getPhase()
     {
-        return CommandPhase.PRE_CONFIGURATION;
+        return userProvidedPaths.isEmpty() ? CommandPhase.PRE_CONFIGURATION : CommandPhase.PRE_EXECUTION;
     }
 
 }


### PR DESCRIPTION
The first commit has only the changes for `ListTagsCommand`.
If these changes are good, then i'll apply the same to `ListSourceTechnologiesCommand` and `ListTargetTechnologiesCommand`.

With these changes:

- executing CLI only with `--listTags` option still executes directly w/o any delay
- executing CLI with `--listTags` and `--userRulesDirectory /path/` options takes 5 seconds because it needs a `RuleProviderRegistryCache` from Furnace to get all the available tags from all the rules available