### PR TITLE
WINDUPRULE-275 Rule 'Hard-coded IP addresses' too many matches

### DIFF
--- a/rules-java/api/src/main/java/org/jboss/windup/rules/apps/java/ip/DiscoverHardcodedIPAddressRuleProvider.java
+++ b/rules-java/api/src/main/java/org/jboss/windup/rules/apps/java/ip/DiscoverHardcodedIPAddressRuleProvider.java
@@ -42,7 +42,7 @@ import org.w3c.dom.Element;
 @RuleMetadata(phase = MigrationRulesPhase.class, tags = {"cloud-readiness"})
 public class DiscoverHardcodedIPAddressRuleProvider extends AbstractRuleProvider
 {
-    private static final String IP_PATTERN = "(?<![\\w.])\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}(?![\\w.])";
+    private static final String IP_PATTERN = "(?<![\\w./-])\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}(?![\\w.-])";
     private static final Logger LOG = Logger.getLogger(DiscoverHardcodedIPAddressRuleProvider.class.getName());
 
     @Override

--- a/rules-java/tests/src/test/resources/staticip/other.xml
+++ b/rules-java/tests/src/test/resources/staticip/other.xml
@@ -1,4 +1,6 @@
 <?xml version="1.0"?>
 <test>
     <ip>192.168.0.13</ip>
+    <some>optional/castor-0.9.5.1-xml.jar</some>
+    <device user_agent="CDM-8400/505 UP.Browser/5.0.5.4 (GUI)" fall_back="cdm_8400_ver1" id="cdm_8400_ver1_sub5054"/>
 </test>

--- a/rules-java/tests/src/test/resources/staticip/staticips.properties
+++ b/rules-java/tests/src/test/resources/staticip/staticips.properties
@@ -7,3 +7,4 @@ mixedwithcontent. 192.168.0.6morecontent
 mixedwithcontent. 192.168.0.7 morecontent
 mixedwithcontent. 192.168.270.8 morecontent
 mixedwithnumbers 192.168.0.9.3.4 more content
+BUILDINFO=JBoss Inc. [jhalli] (Linux 2.6.27.21-170.2.56.fc10.x86_64)


### PR DESCRIPTION
This PR fixes these three (adding also test cases) false positives for `Hard-coded IP addresses` rule :

- `<td>optional/castor-0.9.5.1-xml.jar</td>`
- `<device user_agent="AUDIOVOX-CDM9500/111.030 UP.Browser/5.0.4.1 (GUI)" fall_back="audiovox_cdm9500_ver1" id="audiovox_cdm9500_ver1_sub111030"/>`
- `BUILDINFO=JBoss Inc. [jhalli] (Linux 2.6.27.21-170.2.56.fc10.x86_64)`