### PR TITLE
WINDUP-1767 CLI to describe what parameters are required

### DIFF
--- a/bootstrap/src/main/java/org/jboss/windup/bootstrap/commands/windup/DisplayHelpCommand.java
+++ b/bootstrap/src/main/java/org/jboss/windup/bootstrap/commands/windup/DisplayHelpCommand.java
@@ -22,7 +22,9 @@ public class DisplayHelpCommand implements Command
         for (OptionDescription option : Help.load().getOptions())
         {
             sb.append("--").append(option.getName()).append(System.lineSeparator());
-            sb.append("\t").append(option.getDescription()).append(System.lineSeparator());
+            sb.append("\t");
+            sb.append(option.isRequired() ? "(Required) " : "");
+            sb.append(option.getDescription()).append(System.lineSeparator());
         }
 
         sb.append("--listTags").append(System.lineSeparator());

--- a/bootstrap/src/main/java/org/jboss/windup/bootstrap/commands/windup/DisplayHelpCommand.java
+++ b/bootstrap/src/main/java/org/jboss/windup/bootstrap/commands/windup/DisplayHelpCommand.java
@@ -45,6 +45,9 @@ public class DisplayHelpCommand implements Command
 
         sb.append(System.lineSeparator()).append(" Forge Options:").append(System.lineSeparator());
 
+        sb.append("-b, --batchMode").append(System.lineSeparator());
+        sb.append("\t run Forge in batch mode and does not prompt for confirmation (exits immediately after running) ").append(System.lineSeparator());
+
         sb.append("-i, --install GROUP_ID:ARTIFACT_ID[:VERSION]").append(System.lineSeparator());
         sb.append("\t install the required addons and exit. ex: `"+Util.WINDUP_CLI_NAME+" -i core-addon-x` or `"+Util.WINDUP_CLI_NAME+" -i org.example.addon:example:1.0.0` ").append(System.lineSeparator());
 
@@ -59,9 +62,6 @@ public class DisplayHelpCommand implements Command
 
         sb.append("-m, --immutableAddonDir DIR").append(System.lineSeparator());
         sb.append("\t add the given directory for use as a custom immutable addon repository (read only) ").append(System.lineSeparator());
-
-        sb.append("-b, --batchMode").append(System.lineSeparator());
-        sb.append("\t run Forge in batch mode and does not prompt for confirmation (exits immediately after running) ").append(System.lineSeparator());
 
         sb.append("-d, --debug").append(System.lineSeparator());
         sb.append("\t run Forge in debug mode (wait on port 8000 for a debugger to attach) ").append(System.lineSeparator());

--- a/bootstrap/src/main/java/org/jboss/windup/bootstrap/help/Help.java
+++ b/bootstrap/src/main/java/org/jboss/windup/bootstrap/help/Help.java
@@ -33,6 +33,7 @@ public class Help
     public static final String AVAILABLE_OPTIONS = "available-options";
     public static final String AVAILABLE_OPTION = "option";
     public static final String UI_TYPE = "ui-type";
+    private static final String REQUIRED = "required";
 
     private List<OptionDescription> options = new ArrayList<>();
 
@@ -71,6 +72,7 @@ public class Help
                 String description = optionElement.element(DESCRIPTION).getTextTrim();
                 String type = optionElement.element(TYPE).getTextTrim();
                 String uiType = optionElement.element(UI_TYPE).getTextTrim();
+                boolean required = Boolean.valueOf(optionElement.element(REQUIRED).getTextTrim());
 
                 List<String> availableOptions = null;
 
@@ -83,7 +85,7 @@ public class Help
                     }
                 }
 
-                OptionDescription option = new OptionDescription(name, description, type, uiType, availableOptions);
+                OptionDescription option = new OptionDescription(name, description, type, uiType, availableOptions, required);
                 result.addOption(option);
             }
         }
@@ -130,6 +132,11 @@ public class Help
             }
             if (!availableOptionsElement.elements().isEmpty())
                 optionElement.add(availableOptionsElement);
+
+            // Is it required?
+            Element required = new DOMElement(REQUIRED);
+            required.setText(Boolean.toString(option.isRequired()));
+            optionElement.add(required);
 
             doc.getRootElement().add(optionElement);
         }

--- a/bootstrap/src/main/java/org/jboss/windup/bootstrap/help/OptionDescription.java
+++ b/bootstrap/src/main/java/org/jboss/windup/bootstrap/help/OptionDescription.java
@@ -14,6 +14,7 @@ public class OptionDescription
     private String type;
     private String uiType;
     private List<String> availableOptions;
+    private boolean required;
 
     /**
      * Creates an {@link OptionDescription} with the specified name, description, type, and UI Type (select one, select many, etc).
@@ -32,13 +33,14 @@ public class OptionDescription
     /**
      * Creates an {@link OptionDescription} with the specified name, description, type, UI Type (select one, select many, etc), and available option list.
      */
-    public OptionDescription(String name, String description, String type, String uiType, List<String> availableOptions)
+    public OptionDescription(String name, String description, String type, String uiType, List<String> availableOptions, boolean required)
     {
         this.name = name;
         this.description = description;
         this.type = type;
         this.uiType = uiType;
         this.availableOptions = availableOptions;
+        this.required = required;
     }
 
     /**
@@ -79,5 +81,13 @@ public class OptionDescription
     public List<String> getAvailableOptions()
     {
         return availableOptions;
+    }
+
+    /**
+     * Tells if the option is required.
+     */
+    public boolean isRequired()
+    {
+        return required;
     }
 }

--- a/exec/api/src/main/java/org/jboss/windup/exec/configuration/WindupConfiguration.java
+++ b/exec/api/src/main/java/org/jboss/windup/exec/configuration/WindupConfiguration.java
@@ -170,7 +170,22 @@ public class WindupConfiguration
             @Override
             public int compare(ConfigurationOption o1, ConfigurationOption o2)
             {
-                return o2.getPriority() - o1.getPriority();
+                // if the 1st is required and...
+                if (o1.isRequired())
+                {
+                    // the 2nd isn't, the 1st is "before" than the 2nd
+                    if (!o2.isRequired()) return -1;
+                    // otherwise if also the 2nd is required, then order is priority-based
+                    else return o2.getPriority() - o1.getPriority();
+                }
+                // if the 1st is not required and...
+                else
+                {
+                    // the 2nd is, the 1st is "after" than the 2nd
+                    if (o2.isRequired()) return 1;
+                    // otherwise also the 2nd isn't and order is priority-based
+                    else return o2.getPriority() - o1.getPriority();
+                }
             }
         });
         return results;

--- a/exec/api/src/main/java/org/jboss/windup/exec/configuration/options/OverwriteOption.java
+++ b/exec/api/src/main/java/org/jboss/windup/exec/configuration/options/OverwriteOption.java
@@ -55,4 +55,10 @@ public class OverwriteOption extends AbstractConfigurationOption
     {
         return ValidationResult.SUCCESS;
     }
+
+    @Override
+    public int getPriority()
+    {
+        return 8500;
+    }
 }


### PR DESCRIPTION
[`org.jboss.windup.config.ConfigurationOption#isRequired`](https://github.com/windup/windup/blob/master/config/api/src/main/java/org/jboss/windup/config/ConfigurationOption.java#L43) is now handled in the [`OptionDescription`](https://github.com/windup/windup/blob/master/bootstrap/src/main/java/org/jboss/windup/bootstrap/help/OptionDescription.java) so that it can be displayed in the output of the help command for every option.