### PR TITLE
WINDUP-1773 Fix for failing tests on CI

### DIFF
--- a/tests/src/test/java/org/jboss/windup/tests/bootstrap/ListTechnologiesAndTagsCommandsTest.java
+++ b/tests/src/test/java/org/jboss/windup/tests/bootstrap/ListTechnologiesAndTagsCommandsTest.java
@@ -2,10 +2,17 @@ package org.jboss.windup.tests.bootstrap;
 
 import static org.junit.Assert.assertTrue;
 
+import org.junit.Before;
 import org.junit.Test;
 
 public class ListTechnologiesAndTagsCommandsTest extends AbstractBootstrapTestWithRules
 {
+    @Before
+    public void insureHelpCacheIsAvailable()
+    {
+        bootstrap("--generateHelp");
+    }
+
     @Test
     public void sourceTechnologies()
     {


### PR DESCRIPTION
Executing `ListTechnologiesAndTagsCommandsTest` in central CI there was a NPE on [line 33 of `AbstractListCommandWithoutFurnace.getOptionValuesFromHelp`](https://github.com/windup/windup/blob/master/bootstrap/src/main/java/org/jboss/windup/bootstrap/commands/AbstractListCommandWithoutFurnace.java#L33) due to having a `help.xml` cache file w/o the `<available-options>` section for options `target`, `source` and `includeTags`.

This situation was generated by the execution of the [`DisplayHelpCommandTest`](https://github.com/windup/windup/blob/master/tests/src/test/java/org/jboss/windup/tests/bootstrap/DisplayHelpCommandTest.java) that generates `help.xml` file w/o `<available-options>` section for options `target`, `source` and `includeTags` because it extends [`AbstractBootstrapTest`](https://github.com/windup/windup/blob/master/tests/src/test/java/org/jboss/windup/tests/bootstrap/AbstractBootstrapTest.java) that has no rules added so no tags, sources and targets are saved in the cache file.

The fix generates a new `help.xml` file based on the rules in [AbstractBootstrapTestWithRules](https://github.com/windup/windup/blob/master/tests/src/test/java/org/jboss/windup/tests/bootstrap/AbstractBootstrapTestWithRules.java#L16) that `ListTechnologiesAndTagsCommandsTest` extends.