### PR TITLE
WINDUP-1774 CLI --output option handling

### DIFF
--- a/bootstrap/src/main/java/org/jboss/windup/bootstrap/commands/windup/RunWindupCommand.java
+++ b/bootstrap/src/main/java/org/jboss/windup/bootstrap/commands/windup/RunWindupCommand.java
@@ -153,6 +153,12 @@ public class RunWindupCommand implements Command, FurnaceDependent
             {
                 String valueString = arguments.size() > (i+1) ? arguments.get(++i) : null;
 
+                if (getOptionName(valueString) != null)
+                {
+                    i--;
+                    valueString = "";
+                }
+
                 Object value = convertType(option.getType(), valueString);
                 optionValues.put(option.getName(), value);
             }

--- a/tests/src/test/java/org/jboss/windup/tests/bootstrap/migrate/NoInputOrOutputPathTest.java
+++ b/tests/src/test/java/org/jboss/windup/tests/bootstrap/migrate/NoInputOrOutputPathTest.java
@@ -35,7 +35,7 @@ public class NoInputOrOutputPathTest extends AbstractBootstrapTestWithRules {
     @Test()
     public void InputAndNoOutputPath() {
         bootstrap("--input", TEST_FILE_WAR,
-                "--output", "",
+                "--output",
                 "--target", "eap7");
 
         try


### PR DESCRIPTION
The test didn't cover the right case because `""` was one of the element in the [`args`](https://github.com/windup/windup/blob/master/bootstrap/src/main/java/org/jboss/windup/bootstrap/Bootstrap.java#L72) array while if the command `rhamt-cli --input something --output --target eap` is executed there's no `""` value in the `args` array.