### PR TITLE
WINDUP-1747 Bootstrap integration tests fails on CI

### DIFF
--- a/bootstrap/src/main/java/org/jboss/windup/bootstrap/Bootstrap.java
+++ b/bootstrap/src/main/java/org/jboss/windup/bootstrap/Bootstrap.java
@@ -52,6 +52,7 @@ import org.jboss.windup.bootstrap.commands.windup.ListTargetTechnologiesCommand;
 import org.jboss.windup.bootstrap.commands.windup.RunWindupCommand;
 import org.jboss.windup.bootstrap.commands.windup.ServerModeCommand;
 import org.jboss.windup.bootstrap.commands.windup.UpdateRulesetsCommand;
+import org.jboss.windup.bootstrap.listener.ContainerStatusListener;
 import org.jboss.windup.bootstrap.listener.GreetingListener;
 import org.jboss.windup.server.WindupServerProvider;
 import org.jboss.windup.util.Util;
@@ -68,6 +69,7 @@ public class Bootstrap
     public static final String WINDUP_HOME = "windup.home";
     private final AtomicBoolean batchMode = new AtomicBoolean(false);
     private Furnace furnace;
+    private final ContainerStatusListener containerStatusListener = new ContainerStatusListener();
 
     public static void main(final String[] args)
     {
@@ -299,6 +301,7 @@ public class Bootstrap
             if (!executePhase(CommandPhase.POST_CONFIGURATION, commands) || commands.isEmpty())
                 return;
 
+            furnace.addContainerLifecycleListener(containerStatusListener);
             try
             {
                 Future<Furnace> future = furnace.startAsync();
@@ -350,6 +353,15 @@ public class Bootstrap
     {
         if (furnace != null && !furnace.getStatus().isStopped())
             furnace.stop();
+        while (!containerStatusListener.getContainerStatus().isStopped())
+        {
+            try {
+                Thread.sleep(10);
+            } catch (InterruptedException e) {
+                System.err.println("Failure waiting for Furnace to shutdown: " + e.getMessage());
+                e.printStackTrace();
+            }
+        }
     }
 
     private List<Command> processArguments(List<String> arguments)

--- a/bootstrap/src/main/java/org/jboss/windup/bootstrap/commands/windup/RunWindupCommand.java
+++ b/bootstrap/src/main/java/org/jboss/windup/bootstrap/commands/windup/RunWindupCommand.java
@@ -109,6 +109,10 @@ public class RunWindupCommand implements Command, FurnaceDependent
             if (option == null)
             {
                 System.err.println("WARNING: Unrecognized command-line argument: " + argument);
+                if (options.size() == 0)
+                {
+                    System.err.println("FATAL: Furnace Addon repository path: " + System.lineSeparator() + furnace.getAddonRegistry().toString());
+                }
                 continue;
             }
 

--- a/bootstrap/src/main/java/org/jboss/windup/bootstrap/listener/ContainerStatusListener.java
+++ b/bootstrap/src/main/java/org/jboss/windup/bootstrap/listener/ContainerStatusListener.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2013 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Eclipse Public License version 1.0, available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.jboss.windup.bootstrap.listener;
+
+import org.jboss.forge.furnace.ContainerStatus;
+import org.jboss.forge.furnace.Furnace;
+import org.jboss.forge.furnace.exception.ContainerException;
+import org.jboss.forge.furnace.spi.ContainerLifecycleListener;
+
+/**
+ * @author <a href="mailto:mrizzi@redhat.com">Marco Rizzi</a>
+ */
+public class ContainerStatusListener implements ContainerLifecycleListener
+{
+    private ContainerStatus containerStatus = ContainerStatus.STOPPED;
+
+    public ContainerStatusListener()
+    {
+    }
+
+    public ContainerStatus getContainerStatus()
+    {
+        return containerStatus;
+    }
+
+    @Override
+    public void beforeStart(Furnace furnace) throws ContainerException
+    {
+        containerStatus = ContainerStatus.STARTING;
+    }
+
+    @Override
+    public void afterStart(Furnace furnace) throws ContainerException
+    {
+        containerStatus = ContainerStatus.STARTED;
+    }
+
+    @Override
+    public void beforeStop(Furnace forge) throws ContainerException
+    {
+        // Do nothing
+    }
+
+    @Override
+    public void afterStop(Furnace forge) throws ContainerException
+    {
+        containerStatus = ContainerStatus.STOPPED;
+    }
+
+    @Override
+    public void beforeConfigurationScan(Furnace forge) throws ContainerException
+    {
+        containerStatus = ContainerStatus.RELOADING;
+    }
+
+    @Override
+    public void afterConfigurationScan(Furnace forge) throws ContainerException
+    {
+        containerStatus = ContainerStatus.STARTED;
+    }
+
+}


### PR DESCRIPTION
The issue is happening on central CI so in order to better investigate it, i add the output of the whole Furnace instance **only** when it happens that input option is unrecognized due to having an empty acceptable options list because of Furnace instance being "wrong" (we're searching what's wrong).

The idea is to merge it and wait for the first failure on central CI to retrieve the information.