### PR TITLE
WINDUP-1879 Fix XmlFile condition

### DIFF
--- a/rules-xml/api/src/main/java/org/jboss/windup/rules/apps/xml/condition/XmlFile.java
+++ b/rules-xml/api/src/main/java/org/jboss/windup/rules/apps/xml/condition/XmlFile.java
@@ -274,7 +274,7 @@ public class XmlFile extends ParameterizedGraphCondition implements XmlFileDTD, 
             {
                 XmlFileModel xml = getXmlFileModelFromVertex(iterated);
                 if(xmlFilePassRestrictions(event,context,xml)) {
-                    registerAndSubmitResultsFor(xml, finalResults,evaluationStrategy);
+                    registerAndSubmitResultsFor(xml, finalResults,evaluationStrategy, event, context);
                 }
             }
             setResults(event, getOutputVariablesName(), finalResults);
@@ -307,11 +307,16 @@ public class XmlFile extends ParameterizedGraphCondition implements XmlFileDTD, 
         return allXmls;
     }
 
-    private void registerAndSubmitResultsFor(XmlFileModel xml, List<WindupVertexFrame> results, EvaluationStrategy evaluationStrategy)
+    private void registerAndSubmitResultsFor(XmlFileModel xml, List<WindupVertexFrame> results, EvaluationStrategy evaluationStrategy, GraphRewrite event, EvaluationContext context)
     {
         final List<WindupVertexFrame> xpathResults = xpathValidator.getAndClearResultLocations();
         if(xpathResults.isEmpty()) {
             evaluationStrategy.modelMatched();
+            if (fileNameValidator.getFileNamePattern() != null && !fileNameValidator.getFileNamePattern().parse(xml.getFileName()).submit(event, context))
+            {
+                evaluationStrategy.modelSubmissionRejected();
+                return;
+            }
             evaluationStrategy.modelSubmitted(xml);
             results.add(xml);
         } else {

--- a/rules-xml/api/src/main/java/org/jboss/windup/rules/apps/xml/condition/XmlFile.java
+++ b/rules-xml/api/src/main/java/org/jboss/windup/rules/apps/xml/condition/XmlFile.java
@@ -290,6 +290,7 @@ public class XmlFile extends ParameterizedGraphCondition implements XmlFileDTD, 
     private void initValidators(GraphRewrite event, EvaluationContext context, XmlFileEvaluationStrategy evaluationStrategy)
     {
         xpathValidator.setEvaluationStrategy(evaluationStrategy);
+        xpathValidator.setXmlFileNameValidator(fileNameValidator);
         cacheValidator.clear();
     }
 

--- a/rules-xml/api/src/main/java/org/jboss/windup/rules/apps/xml/condition/validators/XmlFileNameValidator.java
+++ b/rules-xml/api/src/main/java/org/jboss/windup/rules/apps/xml/condition/validators/XmlFileNameValidator.java
@@ -30,7 +30,7 @@ public class XmlFileNameValidator implements XmlFileValidator
             {
                 return false;
             }
-            return fileNamePattern.parse(model.getFileName()).submit(event,context);
+            return true;
         }
         return true;
     }

--- a/rules-xml/api/src/main/java/org/jboss/windup/rules/apps/xml/condition/validators/XmlFileXpathValidator.java
+++ b/rules-xml/api/src/main/java/org/jboss/windup/rules/apps/xml/condition/validators/XmlFileXpathValidator.java
@@ -59,6 +59,7 @@ public class XmlFileXpathValidator implements XmlFileValidator
     private String xpathString;
     private static final Logger LOG = Logging.get(XmlFileXpathValidator.class);
     private RegexParameterizedPatternParser xpathPattern;
+    private XmlFileNameValidator fileNameValidator;
 
     public XmlFileXpathValidator()
     {
@@ -80,6 +81,11 @@ public class XmlFileXpathValidator implements XmlFileValidator
         {
             this.xpathPattern = new RegexParameterizedPatternParser(this.xpathString);
         }
+    }
+
+    public void setXmlFileNameValidator(XmlFileNameValidator fileNameValidator)
+    {
+        this.fileNameValidator = fileNameValidator;
     }
 
     @Override
@@ -267,6 +273,12 @@ public class XmlFileXpathValidator implements XmlFileValidator
 
                 evaluationStrategy.modelSubmissionRejected();
                 evaluationStrategy.modelMatched();
+
+                if (fileNameValidator.getFileNamePattern() != null && !fileNameValidator.getFileNamePattern().parse(xml.getFileName()).submit(event, context))
+                {
+                    evaluationStrategy.modelSubmissionRejected();
+                    continue;
+                }
 
                 for (Map.Entry<String, String> entry : paramMatchCache.getVariables().entrySet())
                 {

--- a/rules-xml/tests/src/test/resources/parameterizationtests/file-suffix1.xml
+++ b/rules-xml/tests/src/test/resources/parameterizationtests/file-suffix1.xml
@@ -1,0 +1,1 @@
+<test-file></test-file>

--- a/rules-xml/tests/src/test/resources/parameterizationtests/file-suffix2.xml
+++ b/rules-xml/tests/src/test/resources/parameterizationtests/file-suffix2.xml
@@ -1,0 +1,1 @@
+<test-file></test-file>


### PR DESCRIPTION
The `ParameterizedPatternResult` should be submitted only if the `XMLFile` condition is missing the XPath condition and not every time the file name pattern matches like it happened in [XmlFileNameValidator#isValid](https://github.com/windup/windup/compare/master...mrizzi:WINDUP-1879?expand=1#diff-885e00361e6e936a1a98a6636548f2d7L33) w/o having evaluated if there's also an XPath condition to be checked.
So the `ParameterizedPatternResult` submit has been moved to [XmlFile#registerAndSubmitResultsFor](https://github.com/windup/windup/compare/master...mrizzi:WINDUP-1879?expand=1#diff-3a9eccf2ac145f087bd0f09958ba1655R310) to be better handled.

Thanks to @jsight for the help in the analysis of this issue 👍 
