### PR TITLE
No longer reload from the graph on GraphService.refresh. This method …

### DIFF
--- a/graph/api/src/main/java/org/jboss/windup/graph/service/GraphService.java
+++ b/graph/api/src/main/java/org/jboss/windup/graph/service/GraphService.java
@@ -39,8 +39,8 @@ public class GraphService<T extends WindupVertexFrame> implements Service<T>
     @SuppressWarnings("unchecked")
     public static <T extends WindupVertexFrame> T refresh(GraphContext context, T frame)
     {
-        Vertex v = context.getGraph().traversal().V((Long)frame.getId()).next();
-        return (T) context.getFramed().frameElement(v, WindupVertexFrame.class);
+        //Vertex v = context.getGraph().traversal().V((Long)frame.getId()).next();
+        return (T) context.getFramed().frameElement(frame.getElement(), WindupVertexFrame.class);
     }
 
     @Override


### PR DESCRIPTION
…is only intended to reload the frame itself, as that was the behavior before the TP2 port. Fixing this improves performance