### PR TITLE
WINDUP-1915 DiscoverEmbeddedCache*LibraryRuleProvider add cloud-readiness target

### DIFF
--- a/config/api/src/main/java/org/jboss/windup/config/metadata/MetadataBuilder.java
+++ b/config/api/src/main/java/org/jboss/windup/config/metadata/MetadataBuilder.java
@@ -141,7 +141,9 @@ public class MetadataBuilder extends AbstractRulesetMetadata implements RuleProv
             {
                 builder.addTargetTechnology(new TechnologyReference(
                             technology.id(),
-                            Versions.parseVersionRange(technology.versionRange())));
+                            "".equals(technology.versionRange().trim())
+                                    ? new EmptyVersionRange()
+                                    : Versions.parseVersionRange(technology.versionRange())));
             }
         }
 

--- a/rules-java-ee/addon/src/main/java/org/jboss/windup/rules/apps/javaee/rules/cache/DiscoverEmbeddedCacheCoherenceLibraryRuleProvider.java
+++ b/rules-java-ee/addon/src/main/java/org/jboss/windup/rules/apps/javaee/rules/cache/DiscoverEmbeddedCacheCoherenceLibraryRuleProvider.java
@@ -4,6 +4,7 @@ import org.jboss.windup.config.AbstractRuleProvider;
 import org.jboss.windup.config.GraphRewrite;
 import org.jboss.windup.config.loader.RuleLoaderContext;
 import org.jboss.windup.config.metadata.RuleMetadata;
+import org.jboss.windup.config.metadata.Technology;
 import org.jboss.windup.config.operation.iteration.AbstractIterationOperation;
 import org.jboss.windup.config.phase.InitialAnalysisPhase;
 import org.jboss.windup.config.query.Query;
@@ -19,7 +20,8 @@ import org.ocpsoft.rewrite.config.Configuration;
 import org.ocpsoft.rewrite.config.ConfigurationBuilder;
 import org.ocpsoft.rewrite.context.EvaluationContext;
 
-@RuleMetadata(phase = InitialAnalysisPhase.class, perform = "Discover Coherence libraries embedded")
+@RuleMetadata(phase = InitialAnalysisPhase.class, perform = "Discover Coherence libraries embedded",
+        targetTechnologies = @Technology(id = "cloud-readiness"))
 public class DiscoverEmbeddedCacheCoherenceLibraryRuleProvider extends AbstractRuleProvider
 {
 

--- a/rules-java-ee/addon/src/main/java/org/jboss/windup/rules/apps/javaee/rules/cache/DiscoverEmbeddedCacheCommonsJcsLibraryRuleProvider.java
+++ b/rules-java-ee/addon/src/main/java/org/jboss/windup/rules/apps/javaee/rules/cache/DiscoverEmbeddedCacheCommonsJcsLibraryRuleProvider.java
@@ -4,6 +4,7 @@ import org.jboss.windup.config.AbstractRuleProvider;
 import org.jboss.windup.config.GraphRewrite;
 import org.jboss.windup.config.loader.RuleLoaderContext;
 import org.jboss.windup.config.metadata.RuleMetadata;
+import org.jboss.windup.config.metadata.Technology;
 import org.jboss.windup.config.operation.iteration.AbstractIterationOperation;
 import org.jboss.windup.config.phase.InitialAnalysisPhase;
 import org.jboss.windup.config.query.Query;
@@ -19,7 +20,8 @@ import org.ocpsoft.rewrite.config.Configuration;
 import org.ocpsoft.rewrite.config.ConfigurationBuilder;
 import org.ocpsoft.rewrite.context.EvaluationContext;
 
-@RuleMetadata(phase = InitialAnalysisPhase.class, perform = "Discover Apache Commons JSC libraries embedded")
+@RuleMetadata(phase = InitialAnalysisPhase.class, perform = "Discover Apache Commons JSC libraries embedded",
+        targetTechnologies = @Technology(id = "cloud-readiness"))
 public class DiscoverEmbeddedCacheCommonsJcsLibraryRuleProvider extends AbstractRuleProvider
 {
 

--- a/rules-java-ee/addon/src/main/java/org/jboss/windup/rules/apps/javaee/rules/cache/DiscoverEmbeddedCacheDynacacheLibraryRuleProvider.java
+++ b/rules-java-ee/addon/src/main/java/org/jboss/windup/rules/apps/javaee/rules/cache/DiscoverEmbeddedCacheDynacacheLibraryRuleProvider.java
@@ -4,6 +4,7 @@ import org.jboss.windup.config.AbstractRuleProvider;
 import org.jboss.windup.config.GraphRewrite;
 import org.jboss.windup.config.loader.RuleLoaderContext;
 import org.jboss.windup.config.metadata.RuleMetadata;
+import org.jboss.windup.config.metadata.Technology;
 import org.jboss.windup.config.operation.iteration.AbstractIterationOperation;
 import org.jboss.windup.config.phase.InitialAnalysisPhase;
 import org.jboss.windup.config.query.Query;
@@ -19,7 +20,8 @@ import org.ocpsoft.rewrite.config.Configuration;
 import org.ocpsoft.rewrite.config.ConfigurationBuilder;
 import org.ocpsoft.rewrite.context.EvaluationContext;
 
-@RuleMetadata(phase = InitialAnalysisPhase.class, perform = "Discover Dynacache libraries embedded")
+@RuleMetadata(phase = InitialAnalysisPhase.class, perform = "Discover Dynacache libraries embedded",
+        targetTechnologies = @Technology(id = "cloud-readiness"))
 public class DiscoverEmbeddedCacheDynacacheLibraryRuleProvider extends AbstractRuleProvider
 {
 

--- a/rules-java-ee/addon/src/main/java/org/jboss/windup/rules/apps/javaee/rules/cache/DiscoverEmbeddedCacheEhcacheLibraryRuleProvider.java
+++ b/rules-java-ee/addon/src/main/java/org/jboss/windup/rules/apps/javaee/rules/cache/DiscoverEmbeddedCacheEhcacheLibraryRuleProvider.java
@@ -4,6 +4,7 @@ import org.jboss.windup.config.AbstractRuleProvider;
 import org.jboss.windup.config.GraphRewrite;
 import org.jboss.windup.config.loader.RuleLoaderContext;
 import org.jboss.windup.config.metadata.RuleMetadata;
+import org.jboss.windup.config.metadata.Technology;
 import org.jboss.windup.config.operation.iteration.AbstractIterationOperation;
 import org.jboss.windup.config.phase.InitialAnalysisPhase;
 import org.jboss.windup.config.query.Query;
@@ -19,7 +20,8 @@ import org.ocpsoft.rewrite.config.Configuration;
 import org.ocpsoft.rewrite.config.ConfigurationBuilder;
 import org.ocpsoft.rewrite.context.EvaluationContext;
 
-@RuleMetadata(phase = InitialAnalysisPhase.class, perform = "Discover Ehcache libraries embedded")
+@RuleMetadata(phase = InitialAnalysisPhase.class, perform = "Discover Ehcache libraries embedded",
+        targetTechnologies = @Technology(id = "cloud-readiness"))
 public class DiscoverEmbeddedCacheEhcacheLibraryRuleProvider extends AbstractRuleProvider
 {
 

--- a/rules-java-ee/addon/src/main/java/org/jboss/windup/rules/apps/javaee/rules/cache/DiscoverEmbeddedCacheGlobalLibraryRuleProvider.java
+++ b/rules-java-ee/addon/src/main/java/org/jboss/windup/rules/apps/javaee/rules/cache/DiscoverEmbeddedCacheGlobalLibraryRuleProvider.java
@@ -4,6 +4,7 @@ import org.jboss.windup.config.AbstractRuleProvider;
 import org.jboss.windup.config.GraphRewrite;
 import org.jboss.windup.config.loader.RuleLoaderContext;
 import org.jboss.windup.config.metadata.RuleMetadata;
+import org.jboss.windup.config.metadata.Technology;
 import org.jboss.windup.config.operation.iteration.AbstractIterationOperation;
 import org.jboss.windup.config.phase.InitialAnalysisPhase;
 import org.jboss.windup.config.query.Query;
@@ -19,7 +20,8 @@ import org.ocpsoft.rewrite.config.Configuration;
 import org.ocpsoft.rewrite.config.ConfigurationBuilder;
 import org.ocpsoft.rewrite.context.EvaluationContext;
 
-@RuleMetadata(phase = InitialAnalysisPhase.class, perform = "Discover Cache API libraries embedded")
+@RuleMetadata(phase = InitialAnalysisPhase.class, perform = "Discover Cache API libraries embedded",
+        targetTechnologies = @Technology(id = "cloud-readiness"))
 public class DiscoverEmbeddedCacheGlobalLibraryRuleProvider extends AbstractRuleProvider
 {
 

--- a/rules-java-ee/addon/src/main/java/org/jboss/windup/rules/apps/javaee/rules/cache/DiscoverEmbeddedCacheHazelcastLibraryRuleProvider.java
+++ b/rules-java-ee/addon/src/main/java/org/jboss/windup/rules/apps/javaee/rules/cache/DiscoverEmbeddedCacheHazelcastLibraryRuleProvider.java
@@ -4,6 +4,7 @@ import org.jboss.windup.config.AbstractRuleProvider;
 import org.jboss.windup.config.GraphRewrite;
 import org.jboss.windup.config.loader.RuleLoaderContext;
 import org.jboss.windup.config.metadata.RuleMetadata;
+import org.jboss.windup.config.metadata.Technology;
 import org.jboss.windup.config.operation.iteration.AbstractIterationOperation;
 import org.jboss.windup.config.phase.InitialAnalysisPhase;
 import org.jboss.windup.config.query.Query;
@@ -19,7 +20,8 @@ import org.ocpsoft.rewrite.config.Configuration;
 import org.ocpsoft.rewrite.config.ConfigurationBuilder;
 import org.ocpsoft.rewrite.context.EvaluationContext;
 
-@RuleMetadata(phase = InitialAnalysisPhase.class, perform = "Discover Hazelcast libraries embedded")
+@RuleMetadata(phase = InitialAnalysisPhase.class, perform = "Discover Hazelcast libraries embedded",
+        targetTechnologies = @Technology(id = "cloud-readiness"))
 public class DiscoverEmbeddedCacheHazelcastLibraryRuleProvider extends AbstractRuleProvider
 {
 

--- a/rules-java-ee/addon/src/main/java/org/jboss/windup/rules/apps/javaee/rules/cache/DiscoverEmbeddedCacheIgniteLibraryRuleProvider.java
+++ b/rules-java-ee/addon/src/main/java/org/jboss/windup/rules/apps/javaee/rules/cache/DiscoverEmbeddedCacheIgniteLibraryRuleProvider.java
@@ -4,6 +4,7 @@ import org.jboss.windup.config.AbstractRuleProvider;
 import org.jboss.windup.config.GraphRewrite;
 import org.jboss.windup.config.loader.RuleLoaderContext;
 import org.jboss.windup.config.metadata.RuleMetadata;
+import org.jboss.windup.config.metadata.Technology;
 import org.jboss.windup.config.operation.iteration.AbstractIterationOperation;
 import org.jboss.windup.config.phase.InitialAnalysisPhase;
 import org.jboss.windup.config.query.Query;
@@ -19,7 +20,8 @@ import org.ocpsoft.rewrite.config.Configuration;
 import org.ocpsoft.rewrite.config.ConfigurationBuilder;
 import org.ocpsoft.rewrite.context.EvaluationContext;
 
-@RuleMetadata(phase = InitialAnalysisPhase.class, perform = "Discover Apache Ignite libraries embedded")
+@RuleMetadata(phase = InitialAnalysisPhase.class, perform = "Discover Apache Ignite libraries embedded",
+        targetTechnologies = @Technology(id = "cloud-readiness"))
 public class DiscoverEmbeddedCacheIgniteLibraryRuleProvider extends AbstractRuleProvider
 {
 

--- a/rules-java-ee/addon/src/main/java/org/jboss/windup/rules/apps/javaee/rules/cache/DiscoverEmbeddedCacheInfinispanLibraryRuleProvider.java
+++ b/rules-java-ee/addon/src/main/java/org/jboss/windup/rules/apps/javaee/rules/cache/DiscoverEmbeddedCacheInfinispanLibraryRuleProvider.java
@@ -4,6 +4,7 @@ import org.jboss.windup.config.AbstractRuleProvider;
 import org.jboss.windup.config.GraphRewrite;
 import org.jboss.windup.config.loader.RuleLoaderContext;
 import org.jboss.windup.config.metadata.RuleMetadata;
+import org.jboss.windup.config.metadata.Technology;
 import org.jboss.windup.config.operation.iteration.AbstractIterationOperation;
 import org.jboss.windup.config.phase.InitialAnalysisPhase;
 import org.jboss.windup.config.query.Query;
@@ -19,7 +20,8 @@ import org.ocpsoft.rewrite.config.Configuration;
 import org.ocpsoft.rewrite.config.ConfigurationBuilder;
 import org.ocpsoft.rewrite.context.EvaluationContext;
 
-@RuleMetadata(phase = InitialAnalysisPhase.class, perform = "Discover Infinispan libraries embedded")
+@RuleMetadata(phase = InitialAnalysisPhase.class, perform = "Discover Infinispan libraries embedded",
+        targetTechnologies = @Technology(id = "cloud-readiness"))
 public class DiscoverEmbeddedCacheInfinispanLibraryRuleProvider extends AbstractRuleProvider
 {
 

--- a/rules-java-ee/addon/src/main/java/org/jboss/windup/rules/apps/javaee/rules/cache/DiscoverEmbeddedCacheJBossCacheLibraryRuleProvider.java
+++ b/rules-java-ee/addon/src/main/java/org/jboss/windup/rules/apps/javaee/rules/cache/DiscoverEmbeddedCacheJBossCacheLibraryRuleProvider.java
@@ -4,6 +4,7 @@ import org.jboss.windup.config.AbstractRuleProvider;
 import org.jboss.windup.config.GraphRewrite;
 import org.jboss.windup.config.loader.RuleLoaderContext;
 import org.jboss.windup.config.metadata.RuleMetadata;
+import org.jboss.windup.config.metadata.Technology;
 import org.jboss.windup.config.operation.iteration.AbstractIterationOperation;
 import org.jboss.windup.config.phase.InitialAnalysisPhase;
 import org.jboss.windup.config.query.Query;
@@ -19,7 +20,8 @@ import org.ocpsoft.rewrite.config.Configuration;
 import org.ocpsoft.rewrite.config.ConfigurationBuilder;
 import org.ocpsoft.rewrite.context.EvaluationContext;
 
-@RuleMetadata(phase = InitialAnalysisPhase.class, perform = "Discover JBoss Cache libraries embedded")
+@RuleMetadata(phase = InitialAnalysisPhase.class, perform = "Discover JBoss Cache libraries embedded",
+        targetTechnologies = @Technology(id = "cloud-readiness"))
 public class DiscoverEmbeddedCacheJBossCacheLibraryRuleProvider extends AbstractRuleProvider
 {
 

--- a/rules-java-ee/addon/src/main/java/org/jboss/windup/rules/apps/javaee/rules/cache/DiscoverEmbeddedCacheJcacheLibraryRuleProvider.java
+++ b/rules-java-ee/addon/src/main/java/org/jboss/windup/rules/apps/javaee/rules/cache/DiscoverEmbeddedCacheJcacheLibraryRuleProvider.java
@@ -4,6 +4,7 @@ import org.jboss.windup.config.AbstractRuleProvider;
 import org.jboss.windup.config.GraphRewrite;
 import org.jboss.windup.config.loader.RuleLoaderContext;
 import org.jboss.windup.config.metadata.RuleMetadata;
+import org.jboss.windup.config.metadata.Technology;
 import org.jboss.windup.config.operation.iteration.AbstractIterationOperation;
 import org.jboss.windup.config.phase.InitialAnalysisPhase;
 import org.jboss.windup.config.query.Query;
@@ -19,7 +20,8 @@ import org.ocpsoft.rewrite.config.Configuration;
 import org.ocpsoft.rewrite.config.ConfigurationBuilder;
 import org.ocpsoft.rewrite.context.EvaluationContext;
 
-@RuleMetadata(phase = InitialAnalysisPhase.class, perform = "Discover JCache libraries embedded")
+@RuleMetadata(phase = InitialAnalysisPhase.class, perform = "Discover JCache libraries embedded",
+        targetTechnologies = @Technology(id = "cloud-readiness"))
 public class DiscoverEmbeddedCacheJcacheLibraryRuleProvider extends AbstractRuleProvider
 {
 

--- a/rules-java-ee/addon/src/main/java/org/jboss/windup/rules/apps/javaee/rules/cache/DiscoverEmbeddedCacheMemcachedLibraryRuleProvider.java
+++ b/rules-java-ee/addon/src/main/java/org/jboss/windup/rules/apps/javaee/rules/cache/DiscoverEmbeddedCacheMemcachedLibraryRuleProvider.java
@@ -4,6 +4,7 @@ import org.jboss.windup.config.AbstractRuleProvider;
 import org.jboss.windup.config.GraphRewrite;
 import org.jboss.windup.config.loader.RuleLoaderContext;
 import org.jboss.windup.config.metadata.RuleMetadata;
+import org.jboss.windup.config.metadata.Technology;
 import org.jboss.windup.config.operation.iteration.AbstractIterationOperation;
 import org.jboss.windup.config.phase.InitialAnalysisPhase;
 import org.jboss.windup.config.query.Query;
@@ -19,7 +20,8 @@ import org.ocpsoft.rewrite.config.Configuration;
 import org.ocpsoft.rewrite.config.ConfigurationBuilder;
 import org.ocpsoft.rewrite.context.EvaluationContext;
 
-@RuleMetadata(phase = InitialAnalysisPhase.class, perform = "Discover Memcached client libraries embedded")
+@RuleMetadata(phase = InitialAnalysisPhase.class, perform = "Discover Memcached client libraries embedded",
+        targetTechnologies = @Technology(id = "cloud-readiness"))
 public class DiscoverEmbeddedCacheMemcachedLibraryRuleProvider extends AbstractRuleProvider
 {
     @Override

--- a/rules-java-ee/addon/src/main/java/org/jboss/windup/rules/apps/javaee/rules/cache/DiscoverEmbeddedCacheOscacheLibraryRuleProvider.java
+++ b/rules-java-ee/addon/src/main/java/org/jboss/windup/rules/apps/javaee/rules/cache/DiscoverEmbeddedCacheOscacheLibraryRuleProvider.java
@@ -4,6 +4,7 @@ import org.jboss.windup.config.AbstractRuleProvider;
 import org.jboss.windup.config.GraphRewrite;
 import org.jboss.windup.config.loader.RuleLoaderContext;
 import org.jboss.windup.config.metadata.RuleMetadata;
+import org.jboss.windup.config.metadata.Technology;
 import org.jboss.windup.config.operation.iteration.AbstractIterationOperation;
 import org.jboss.windup.config.phase.InitialAnalysisPhase;
 import org.jboss.windup.config.query.Query;
@@ -19,7 +20,8 @@ import org.ocpsoft.rewrite.config.Configuration;
 import org.ocpsoft.rewrite.config.ConfigurationBuilder;
 import org.ocpsoft.rewrite.context.EvaluationContext;
 
-@RuleMetadata(phase = InitialAnalysisPhase.class, perform = "Discover Oscache libraries embedded")
+@RuleMetadata(phase = InitialAnalysisPhase.class, perform = "Discover Oscache libraries embedded",
+        targetTechnologies = @Technology(id = "cloud-readiness"))
 public class DiscoverEmbeddedCacheOscacheLibraryRuleProvider extends AbstractRuleProvider
 {
 

--- a/rules-java-ee/addon/src/main/java/org/jboss/windup/rules/apps/javaee/rules/cache/DiscoverEmbeddedCacheShiftOneLibraryRuleProvider.java
+++ b/rules-java-ee/addon/src/main/java/org/jboss/windup/rules/apps/javaee/rules/cache/DiscoverEmbeddedCacheShiftOneLibraryRuleProvider.java
@@ -4,6 +4,7 @@ import org.jboss.windup.config.AbstractRuleProvider;
 import org.jboss.windup.config.GraphRewrite;
 import org.jboss.windup.config.loader.RuleLoaderContext;
 import org.jboss.windup.config.metadata.RuleMetadata;
+import org.jboss.windup.config.metadata.Technology;
 import org.jboss.windup.config.operation.iteration.AbstractIterationOperation;
 import org.jboss.windup.config.phase.InitialAnalysisPhase;
 import org.jboss.windup.config.query.Query;
@@ -19,7 +20,8 @@ import org.ocpsoft.rewrite.config.Configuration;
 import org.ocpsoft.rewrite.config.ConfigurationBuilder;
 import org.ocpsoft.rewrite.context.EvaluationContext;
 
-@RuleMetadata(phase = InitialAnalysisPhase.class, perform = "Discover ShiftOne (Java Object Cache) libraries embedded")
+@RuleMetadata(phase = InitialAnalysisPhase.class, perform = "Discover ShiftOne (Java Object Cache) libraries embedded",
+        targetTechnologies = @Technology(id = "cloud-readiness"))
 public class DiscoverEmbeddedCacheShiftOneLibraryRuleProvider extends AbstractRuleProvider
 {
     @Override

--- a/rules-java-ee/addon/src/main/java/org/jboss/windup/rules/apps/javaee/rules/cache/DiscoverEmbeddedCacheSwarmCacheLibraryRuleProvider.java
+++ b/rules-java-ee/addon/src/main/java/org/jboss/windup/rules/apps/javaee/rules/cache/DiscoverEmbeddedCacheSwarmCacheLibraryRuleProvider.java
@@ -4,6 +4,7 @@ import org.jboss.windup.config.AbstractRuleProvider;
 import org.jboss.windup.config.GraphRewrite;
 import org.jboss.windup.config.loader.RuleLoaderContext;
 import org.jboss.windup.config.metadata.RuleMetadata;
+import org.jboss.windup.config.metadata.Technology;
 import org.jboss.windup.config.operation.iteration.AbstractIterationOperation;
 import org.jboss.windup.config.phase.InitialAnalysisPhase;
 import org.jboss.windup.config.query.Query;
@@ -19,7 +20,8 @@ import org.ocpsoft.rewrite.config.Configuration;
 import org.ocpsoft.rewrite.config.ConfigurationBuilder;
 import org.ocpsoft.rewrite.context.EvaluationContext;
 
-@RuleMetadata(phase = InitialAnalysisPhase.class, perform = "Discover SwarmCache libraries embedded")
+@RuleMetadata(phase = InitialAnalysisPhase.class, perform = "Discover SwarmCache libraries embedded",
+        targetTechnologies = @Technology(id = "cloud-readiness"))
 public class DiscoverEmbeddedCacheSwarmCacheLibraryRuleProvider extends AbstractRuleProvider
 {
 


### PR DESCRIPTION
1. changed all the DiscoverEmbeddedCache*LibraryRuleProvider to have the cloud-readiness target so that they will be fire only when cloud-readiness is one of the analysis' targets
2. fixed target versionRange management