### PR TITLE
Fix for managing versionRange technology default

### DIFF
--- a/config/api/src/main/java/org/jboss/windup/config/metadata/MetadataBuilder.java
+++ b/config/api/src/main/java/org/jboss/windup/config/metadata/MetadataBuilder.java
@@ -141,7 +141,9 @@ public class MetadataBuilder extends AbstractRulesetMetadata implements RuleProv
             {
                 builder.addTargetTechnology(new TechnologyReference(
                             technology.id(),
-                            Versions.parseVersionRange(technology.versionRange())));
+                            "".equals(technology.versionRange().trim())
+                                    ? new EmptyVersionRange()
+                                    : Versions.parseVersionRange(technology.versionRange())));
             }
         }
 


### PR DESCRIPTION
Fix for handling the [`versionRange` default `""`](https://github.com/windup/windup/blob/4.0.x/config/api/src/main/java/org/jboss/windup/config/metadata/Technology.java#L25) implemented some lines above for [source technologies](https://github.com/windup/windup/blob/4.0.x/config/api/src/main/java/org/jboss/windup/config/metadata/MetadataBuilder.java#L131) to the target technologies.

Ported from https://github.com/windup/windup/pull/1277/files#diff-5b1e5adb9656972a3df7ca157f6b94a1