### PR TITLE
Ci intermittent failures

### DIFF
--- a/config/tests/src/test/java/org/jboss/windup/config/QueryConditionTest.java
+++ b/config/tests/src/test/java/org/jboss/windup/config/QueryConditionTest.java
@@ -95,7 +95,7 @@ public class QueryConditionTest
     public void testInitialQueryAsGremlin() throws Exception
     {
         final Path folder = OperatingSystemUtils.createTempDir().toPath();
-        try (final GraphContext context = factory.create(folder))
+        try (final GraphContext context = factory.create(folder, true))
         {
             GraphRewrite event = new GraphRewrite(context);
             DefaultEvaluationContext evaluationContext = createEvalContext(event);
@@ -133,7 +133,7 @@ public class QueryConditionTest
     public void testSingletonSelection() throws Exception
     {
         final Path folder = OperatingSystemUtils.createTempDir().toPath();
-        try (final GraphContext context = factory.create(folder))
+        try (final GraphContext context = factory.create(folder, true))
         {
 
             GraphRewrite event = new GraphRewrite(context);
@@ -185,7 +185,7 @@ public class QueryConditionTest
     public void testJavaMethodModel() throws Exception
     {
         final Path folder = OperatingSystemUtils.createTempDir().toPath();
-        try (final GraphContext context = factory.create(folder))
+        try (final GraphContext context = factory.create(folder, true))
         {
 
             GraphRewrite event = new GraphRewrite(context);
@@ -223,7 +223,7 @@ public class QueryConditionTest
     {
         // build the initial graph
         final Path folder = OperatingSystemUtils.createTempDir().toPath();
-        try (final GraphContext context = factory.create(folder))
+        try (final GraphContext context = factory.create(folder, true))
         {
 
             fillData(context);
@@ -247,7 +247,7 @@ public class QueryConditionTest
     {
         // build the initial graph
         final Path folder = OperatingSystemUtils.createTempDir().toPath();
-        try (final GraphContext context = factory.create(folder))
+        try (final GraphContext context = factory.create(folder, true))
         {
 
             fillData(context);
@@ -279,7 +279,7 @@ public class QueryConditionTest
     {
         // build the initial graph
         final Path folder = OperatingSystemUtils.createTempDir().toPath();
-        try (final GraphContext context = factory.create(folder))
+        try (final GraphContext context = factory.create(folder, true))
         {
 
             fillData(context);
@@ -304,7 +304,7 @@ public class QueryConditionTest
     {
         // build the initial graph
         final Path folder = OperatingSystemUtils.createTempDir().toPath();
-        try (final GraphContext context = factory.create(folder))
+        try (final GraphContext context = factory.create(folder, true))
         {
             fillData(context);
             context.commit();
@@ -327,7 +327,7 @@ public class QueryConditionTest
     @Test
     public void testExcludeTypeFilter() throws Exception
     {
-        try (final GraphContext context = factory.create())
+        try (final GraphContext context = factory.create(true))
         {
             GraphRewrite event = new GraphRewrite(context);
             DefaultEvaluationContext evaluationContext = createEvalContext(event);
@@ -372,7 +372,7 @@ public class QueryConditionTest
     @Test
     public void testIncludeTypeFilter() throws Exception
     {
-        try (final GraphContext context = factory.create())
+        try (final GraphContext context = factory.create(true))
         {
             GraphRewrite event = new GraphRewrite(context);
             DefaultEvaluationContext evaluationContext = createEvalContext(event);

--- a/config/tests/src/test/java/org/jboss/windup/config/ReadXMLConfigurationTest.java
+++ b/config/tests/src/test/java/org/jboss/windup/config/ReadXMLConfigurationTest.java
@@ -43,7 +43,7 @@ public class ReadXMLConfigurationTest
     public void testRunWindup() throws Exception
     {
         final Path folder = File.createTempFile("windupGraph", "").toPath();
-        try (final GraphContext context = factory.create(folder))
+        try (final GraphContext context = factory.create(folder, true))
         {
             RuleLoaderContext ruleLoaderContext = new RuleLoaderContext();
             final ConfigurationLoader loader = ConfigurationLoader.create(ruleLoaderContext);

--- a/config/tests/src/test/java/org/jboss/windup/config/RuleLoaderTest.java
+++ b/config/tests/src/test/java/org/jboss/windup/config/RuleLoaderTest.java
@@ -54,7 +54,7 @@ public class RuleLoaderTest
     @Test
     public void testRuleProviderWithFilter() throws IOException
     {
-        try (GraphContext context = factory.create())
+        try (GraphContext context = factory.create(true))
         {
             Predicate<RuleProvider> predicate = (provider) -> {
                     return provider.getMetadata().getPhase() == MigrationRulesPhase.class;

--- a/config/tests/src/test/java/org/jboss/windup/config/RuleProviderDisabledTest.java
+++ b/config/tests/src/test/java/org/jboss/windup/config/RuleProviderDisabledTest.java
@@ -75,7 +75,7 @@ public class RuleProviderDisabledTest
     public void testDisabledFeature() throws Exception
     {
         final Path folder = OperatingSystemUtils.createTempDir().toPath();
-        try (final GraphContext context = factory.create(folder))
+        try (final GraphContext context = factory.create(folder, true))
         {
             GraphRewrite event = new GraphRewrite(context);
             DefaultEvaluationContext evaluationContext = createEvalContext(event);

--- a/config/tests/src/test/java/org/jboss/windup/config/iteration/IterationAutomicCommitTest.java
+++ b/config/tests/src/test/java/org/jboss/windup/config/iteration/IterationAutomicCommitTest.java
@@ -79,7 +79,7 @@ public class IterationAutomicCommitTest
     public void testAutomaticPeriodicCommit() throws Exception
     {
         final Path folder = OperatingSystemUtils.createTempDir().toPath();
-        try (final GraphContext baseContext = factory.create(folder))
+        try (final GraphContext baseContext = factory.create(folder, true))
         {
             CommitInterceptingGraphContext context = new CommitInterceptingGraphContext(baseContext);
 

--- a/config/tests/src/test/java/org/jboss/windup/config/iteration/IterationAutomicCommitTest.java
+++ b/config/tests/src/test/java/org/jboss/windup/config/iteration/IterationAutomicCommitTest.java
@@ -163,9 +163,9 @@ public class IterationAutomicCommitTest
         }
 
         @Override
-        public GraphContext create()
+        public GraphContext create(boolean enableListeners)
         {
-            return delegate.create();
+            return delegate.create(enableListeners);
         }
 
         @Override

--- a/config/tests/src/test/java/org/jboss/windup/config/iteration/RuleIterationOverAllSpecifiedTest.java
+++ b/config/tests/src/test/java/org/jboss/windup/config/iteration/RuleIterationOverAllSpecifiedTest.java
@@ -71,7 +71,7 @@ public class RuleIterationOverAllSpecifiedTest
     public void testTypeSelection() throws Exception
     {
         final Path folder = OperatingSystemUtils.createTempDir().toPath();
-        try (final GraphContext context = factory.create(folder))
+        try (final GraphContext context = factory.create(folder, true))
         {
 
             TestSimple1Model vertex = context.getFramed().addFramedVertex(TestSimple1Model.class);
@@ -105,7 +105,7 @@ public class RuleIterationOverAllSpecifiedTest
     public void testTypeSelectionWithException() throws Exception
     {
         final Path folder = OperatingSystemUtils.createTempDir().toPath();
-        try (final GraphContext context = factory.create(folder))
+        try (final GraphContext context = factory.create(folder, true))
         {
 
             TestSimple1Model vertex = context.getFramed().addFramedVertex(TestSimple1Model.class);

--- a/config/tests/src/test/java/org/jboss/windup/config/iteration/RuleIterationOverDefaultListVariableTest.java
+++ b/config/tests/src/test/java/org/jboss/windup/config/iteration/RuleIterationOverDefaultListVariableTest.java
@@ -78,7 +78,7 @@ public class RuleIterationOverDefaultListVariableTest
     public void testTypeSelection() throws Exception
     {
         final Path folder = OperatingSystemUtils.createTempDir().toPath();
-        try (final GraphContext context = factory.create(folder))
+        try (final GraphContext context = factory.create(folder, true))
         {
 
             TestSimple1Model vertex = context.getFramed().addFramedVertex(TestSimple1Model.class);

--- a/config/tests/src/test/java/org/jboss/windup/config/iteration/RuleIterationOverDefaultSingleVariableTest.java
+++ b/config/tests/src/test/java/org/jboss/windup/config/iteration/RuleIterationOverDefaultSingleVariableTest.java
@@ -80,7 +80,7 @@ public class RuleIterationOverDefaultSingleVariableTest
     public void testTypeSelection() throws Exception
     {
         final Path folder = OperatingSystemUtils.createTempDir().toPath();
-        try (final GraphContext context = factory.create(folder))
+        try (final GraphContext context = factory.create(folder, true))
         {
 
             TestSimple1Model vertex = context.getFramed().addFramedVertex(TestSimple1Model.class);
@@ -118,7 +118,7 @@ public class RuleIterationOverDefaultSingleVariableTest
     public void testTypeSelectionWithException() throws Exception
     {
         final Path folder = OperatingSystemUtils.createTempDir().toPath();
-        try (final GraphContext context = factory.create(folder))
+        try (final GraphContext context = factory.create(folder, true))
         {
 
             TestSimple1Model vertex = context.getFramed().addFramedVertex(TestSimple1Model.class);

--- a/config/tests/src/test/java/org/jboss/windup/config/iteration/RuleIterationOverTypesTest.java
+++ b/config/tests/src/test/java/org/jboss/windup/config/iteration/RuleIterationOverTypesTest.java
@@ -79,7 +79,7 @@ public class RuleIterationOverTypesTest
     public void testTypeSelection() throws Exception
     {
         final Path folder = OperatingSystemUtils.createTempDir().toPath();
-        try (final GraphContext context = factory.create(folder))
+        try (final GraphContext context = factory.create(folder, true))
         {
 
             TestSimple1Model vertex = context.getFramed().addFramedVertex(TestSimple1Model.class);
@@ -113,7 +113,7 @@ public class RuleIterationOverTypesTest
     public void testTypeSelectionWithException() throws Exception
     {
         final Path folder = OperatingSystemUtils.createTempDir().toPath();
-        try (final GraphContext context = factory.create(folder))
+        try (final GraphContext context = factory.create(folder, true))
         {
 
             TestSimple1Model vertex = context.getFramed().addFramedVertex(TestSimple1Model.class);

--- a/config/tests/src/test/java/org/jboss/windup/config/iteration/payload/IterationPayLoadPassTest.java
+++ b/config/tests/src/test/java/org/jboss/windup/config/iteration/payload/IterationPayLoadPassTest.java
@@ -75,7 +75,7 @@ public class IterationPayLoadPassTest
     public void testPayloadPass() throws Exception
     {
         final Path folder = OperatingSystemUtils.createTempDir().toPath();
-        try (final GraphContext context = factory.create(folder))
+        try (final GraphContext context = factory.create(folder, true))
         {
             context.getFramed().addFramedVertex(TestPayloadModel.class);
             context.getFramed().addFramedVertex(TestPayloadModel.class);
@@ -102,7 +102,7 @@ public class IterationPayLoadPassTest
     public void testPayloadNotPass() throws Exception
     {
         final Path folder = OperatingSystemUtils.createTempDir().toPath();
-        try (final GraphContext context = factory.create(folder))
+        try (final GraphContext context = factory.create(folder, true))
         {
             context.getFramed().addFramedVertex(TestSimple1Model.class);
             context.getFramed().addFramedVertex(TestSimple2Model.class);

--- a/config/tests/src/test/java/org/jboss/windup/config/iteration/payload/when/RuleIterationWhenTest.java
+++ b/config/tests/src/test/java/org/jboss/windup/config/iteration/payload/when/RuleIterationWhenTest.java
@@ -74,7 +74,7 @@ public class RuleIterationWhenTest
     public void testTypeSelection() throws Exception
     {
         final Path folder = OperatingSystemUtils.createTempDir().toPath();
-        try (final GraphContext context = factory.create(folder))
+        try (final GraphContext context = factory.create(folder, true))
         {
 
             TestWhenModel vertex = context.getFramed().addFramedVertex(TestWhenModel.class);

--- a/config/tests/src/test/java/org/jboss/windup/config/metadata/RuleProviderMetadataTest.java
+++ b/config/tests/src/test/java/org/jboss/windup/config/metadata/RuleProviderMetadataTest.java
@@ -53,7 +53,7 @@ public class RuleProviderMetadataTest
     @Test
     public void testMetadataPickedUp() throws Exception
     {
-        try (GraphContext context = contextFactory.create())
+        try (GraphContext context = contextFactory.create(true))
         {
             WindupConfiguration windupConfig = new WindupConfiguration();
             windupConfig.setGraphContext(context);

--- a/config/tests/src/test/java/org/jboss/windup/config/metadata/RulesetMetadataTest.java
+++ b/config/tests/src/test/java/org/jboss/windup/config/metadata/RulesetMetadataTest.java
@@ -55,7 +55,7 @@ public class RulesetMetadataTest
     @Test
     public void testMetadataPickedUp() throws Exception
     {
-        try (GraphContext context = contextFactory.create())
+        try (GraphContext context = contextFactory.create(true))
         {
             WindupConfiguration windupConfig = new WindupConfiguration();
             windupConfig.setGraphContext(context);

--- a/config/tests/src/test/java/org/jboss/windup/config/parameters/ParameterWiringTest.java
+++ b/config/tests/src/test/java/org/jboss/windup/config/parameters/ParameterWiringTest.java
@@ -61,7 +61,7 @@ public class ParameterWiringTest
     public void testIterationVariableResolving() throws Exception
     {
         final Path folder = OperatingSystemUtils.createTempDir().toPath();
-        try (final GraphContext context = factory.create(folder))
+        try (final GraphContext context = factory.create(folder, true))
         {
 
             GraphRewrite event = new GraphRewrite(context);
@@ -160,7 +160,7 @@ public class ParameterWiringTest
     public void testIterationVariableResolving2() throws Exception
     {
         final Path folder = OperatingSystemUtils.createTempDir().toPath();
-        try (final GraphContext context = factory.create(folder))
+        try (final GraphContext context = factory.create(folder, true))
         {
 
             GraphRewrite event = new GraphRewrite(context);
@@ -288,7 +288,7 @@ public class ParameterWiringTest
     public void testIterationVariableResolving3() throws Exception
     {
         final Path folder = OperatingSystemUtils.createTempDir().toPath();
-        try (final GraphContext context = factory.create(folder))
+        try (final GraphContext context = factory.create(folder, true))
         {
 
             GraphRewrite event = new GraphRewrite(context);
@@ -411,7 +411,7 @@ public class ParameterWiringTest
     public void testIterationVariableResolving4() throws Exception
     {
         final Path folder = OperatingSystemUtils.createTempDir().toPath();
-        try (final GraphContext context = factory.create(folder))
+        try (final GraphContext context = factory.create(folder, true))
         {
 
             GraphRewrite event = new GraphRewrite(context);

--- a/config/tests/src/test/java/org/jboss/windup/config/selectables/IterationPayloadTest.java
+++ b/config/tests/src/test/java/org/jboss/windup/config/selectables/IterationPayloadTest.java
@@ -68,7 +68,7 @@ public class IterationPayloadTest
     public void testIterationVariableResolving() throws Exception
     {
         final Path folder = OperatingSystemUtils.createTempDir().toPath();
-        try (final GraphContext context = factory.create(folder))
+        try (final GraphContext context = factory.create(folder, true))
         {
 
             GraphRewrite event = new GraphRewrite(context);
@@ -91,7 +91,7 @@ public class IterationPayloadTest
     public void testNestedIteration() throws Exception
     {
         final Path folder = OperatingSystemUtils.createTempDir().toPath();
-        try (final GraphContext context = factory.create(folder))
+        try (final GraphContext context = factory.create(folder, true))
         {
 
             GraphRewrite event = new GraphRewrite(context);

--- a/config/tests/src/test/java/org/jboss/windup/config/selectables/VariablesTest.java
+++ b/config/tests/src/test/java/org/jboss/windup/config/selectables/VariablesTest.java
@@ -55,7 +55,7 @@ public class VariablesTest
     public void testMultipleFramesSameName() throws Exception
     {
         final Path folder = OperatingSystemUtils.createTempDir().toPath();
-        try (final GraphContext context = factory.create(folder))
+        try (final GraphContext context = factory.create(folder, true))
         {
             GraphRewrite event = new GraphRewrite(context);
             final DefaultEvaluationContext evaluationContext = new DefaultEvaluationContext();
@@ -92,7 +92,7 @@ public class VariablesTest
     public void testInvalidTypeGet() throws Exception
     {
         final Path folder = OperatingSystemUtils.createTempDir().toPath();
-        try (final GraphContext context = factory.create(folder))
+        try (final GraphContext context = factory.create(folder, true))
         {
             GraphRewrite event = new GraphRewrite(context);
             final DefaultEvaluationContext evaluationContext = new DefaultEvaluationContext();
@@ -127,7 +127,7 @@ public class VariablesTest
     public void testUnTypedGet() throws Exception
     {
         final Path folder = OperatingSystemUtils.createTempDir().toPath();
-        try (final GraphContext context = factory.create(folder))
+        try (final GraphContext context = factory.create(folder, true))
         {
             GraphRewrite event = new GraphRewrite(context);
             final DefaultEvaluationContext evaluationContext = new DefaultEvaluationContext();
@@ -151,7 +151,7 @@ public class VariablesTest
     public void testInvalidCountGet() throws Exception
     {
         final Path folder = OperatingSystemUtils.createTempDir().toPath();
-        try (final GraphContext context = factory.create(folder))
+        try (final GraphContext context = factory.create(folder, true))
         {
             GraphRewrite event = new GraphRewrite(context);
             final DefaultEvaluationContext evaluationContext = new DefaultEvaluationContext();

--- a/config/tests/src/test/java/org/jboss/windup/config/tags/TagsRulesTest.java
+++ b/config/tests/src/test/java/org/jboss/windup/config/tags/TagsRulesTest.java
@@ -61,7 +61,7 @@ public class TagsRulesTest
     {
 
         final Path folder = OperatingSystemUtils.createTempDir().toPath();
-        try (final GraphContext context = factory.create(folder))
+        try (final GraphContext context = factory.create(folder, true))
         {
 
             GraphRewrite event = new GraphRewrite(context);

--- a/exec/impl/src/main/java/org/jboss/windup/exec/WindupProcessorImpl.java
+++ b/exec/impl/src/main/java/org/jboss/windup/exec/WindupProcessorImpl.java
@@ -102,7 +102,7 @@ public class WindupProcessorImpl implements WindupProcessor
             // Since we created it, we should clean it up
             autoCloseGraph = true;
             Path graphPath = configuration.getOutputDirectory().resolve(GraphContextFactory.DEFAULT_GRAPH_SUBDIRECTORY);
-            GraphContext graphContext = this.graphContextFactory.create(graphPath);
+            GraphContext graphContext = this.graphContextFactory.create(graphPath, true);
             configuration.setGraphContext(graphContext);
         }
 

--- a/exec/tests/src/test/java/org/jboss/windup/exec/test/SkippingReportsRenderingTest.java
+++ b/exec/tests/src/test/java/org/jboss/windup/exec/test/SkippingReportsRenderingTest.java
@@ -146,7 +146,7 @@ public class SkippingReportsRenderingTest
 
     private void executeTest(List<Class<? extends RuleProvider>> rules)
     {
-        try (GraphContext context = contextFactory.create())
+        try (GraphContext context = contextFactory.create(true))
         {
             runRules(context, rules);
         }

--- a/exec/tests/src/test/java/org/jboss/windup/exec/test/TagsIncludeExcludeTest.java
+++ b/exec/tests/src/test/java/org/jboss/windup/exec/test/TagsIncludeExcludeTest.java
@@ -170,7 +170,7 @@ public class TagsIncludeExcludeTest
         if (excludeTags != null)
             excluded = new HashSet<>(Arrays.asList(StringUtils.split(excludeTags)));
 
-        try (GraphContext context = contextFactory.create())
+        try (GraphContext context = contextFactory.create(true))
         {
             runRules(context, included, excluded, rules);
         }

--- a/graph/api/src/main/java/org/jboss/windup/graph/GraphContext.java
+++ b/graph/api/src/main/java/org/jboss/windup/graph/GraphContext.java
@@ -33,8 +33,11 @@ public interface GraphContext extends Closeable
 
     /**
      * Creates new graph using the configuration. In case there was already a graph located in the specified path, it will be deleted.
+     *
+     * If the enableListeners flag is false, then this will not enable GraphMutation listeners. These are not
+     * necessary for processes that only read from the graph and are only used for graphs that are used as part of an analysis.
      */
-    GraphContext create();
+    GraphContext create(boolean enableListeners);
 
     /**
      * Loads the graph using the configuration.

--- a/graph/api/src/main/java/org/jboss/windup/graph/GraphContextFactory.java
+++ b/graph/api/src/main/java/org/jboss/windup/graph/GraphContextFactory.java
@@ -28,4 +28,6 @@ public interface GraphContextFactory
      */
     GraphContext load(Path dir);
 
+    void closeAll();
+
 }

--- a/graph/api/src/main/java/org/jboss/windup/graph/GraphContextFactory.java
+++ b/graph/api/src/main/java/org/jboss/windup/graph/GraphContextFactory.java
@@ -15,19 +15,28 @@ public interface GraphContextFactory
      * Create a new {@link GraphContext} using the given {@link Path} as a file storage location. The {@link Path} will
      * be created if it does not already exist. (<b>**WARNING**: This will potentially delete all data in the given
      * directory.</b>)
+     *
+     * The enableListeners flag indicates whether or not mutation listeners should be enabled. Only a single open graph can have
+     * those at a time, and these should only be used for analysis runs.
      */
-    GraphContext create(Path dir);
+    GraphContext create(Path dir, boolean enableListeners);
 
     /**
      * Create a new {@link GraphContext} using a temporary file storage location.
+     *
+     * The enableListeners flag indicates whether or not mutation listeners should be enabled. Only a single open graph can have
+     * those at a time, and these should only be used for analysis runs.
      */
-    GraphContext create();
-    
+    GraphContext create(boolean enableListeners);
+
     /**
      * Loads a {@link GraphContext} using the given {@link Path} as a file storage location. 
      */
     GraphContext load(Path dir);
 
+    /**
+     * Close all of the graphs that have been opened by this factory. This can be useful as a final
+     * cleanup to insure that all resources have been successfully destroyed.
+     */
     void closeAll();
-
 }

--- a/graph/api/src/main/java/org/jboss/windup/graph/GraphTypeManager.java
+++ b/graph/api/src/main/java/org/jboss/windup/graph/GraphTypeManager.java
@@ -21,6 +21,7 @@ import org.apache.tinkerpop.gremlin.structure.Edge;
 import org.apache.tinkerpop.gremlin.structure.Element;
 import org.apache.tinkerpop.gremlin.structure.Property;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
+import org.apache.tinkerpop.gremlin.structure.VertexProperty;
 import org.janusgraph.core.JanusGraphEdge;
 import org.jboss.forge.furnace.Furnace;
 import org.jboss.forge.furnace.container.simple.lifecycle.SimpleContainer;
@@ -212,6 +213,8 @@ public class GraphTypeManager implements TypeResolver
             }
         }
         element.properties(WindupFrame.TYPE_PROP).forEachRemaining(Property::remove);
+
+        LOG.info("Setting types for: " + element.id() + " to: " + newTypes);
         for (String newType : newTypes)
             addProperty(element, WindupFrame.TYPE_PROP, newType);
 
@@ -222,25 +225,14 @@ public class GraphTypeManager implements TypeResolver
     {
         // This uses the direct Titan API which is indexed. See GraphContextImpl.
         if (abstractElement instanceof Vertex)
-            ((Vertex) abstractElement).property(propertyName, propertyValue);
+            ((Vertex) abstractElement).property(VertexProperty.Cardinality.list, propertyName, propertyValue);
         // StandardEdge doesn't have addProperty().
         else if (abstractElement instanceof Edge)
             addTokenProperty(abstractElement, propertyName, propertyValue);
         // For all others, we resort to storing a list
         else
         {
-            Property<List<String>> property = abstractElement.property(propertyName);
-            if (property == null)
-            {
-                abstractElement.property(propertyName, Collections.singletonList(propertyValue));
-            }
-            else
-            {
-                List<String> existingList = property.value();
-                List<String> newList = new ArrayList<>(existingList);
-                newList.add(propertyValue);
-                abstractElement.property(propertyName, newList);
-            }
+            throw new UnsupportedOperationException("Unrecognized type; " + abstractElement.getClass().getName());
         }
     }
 
@@ -275,6 +267,7 @@ public class GraphTypeManager implements TypeResolver
                 return;
             }
         }
+        LOG.info("Setting types for: " + element.id() + " to: " + typeValue);
 
         addProperty(element, WindupFrame.TYPE_PROP, typeValue);
         addSuperclassType(kind, element);

--- a/graph/impl/src/main/java/org/jboss/windup/graph/GraphContextFactoryImpl.java
+++ b/graph/impl/src/main/java/org/jboss/windup/graph/GraphContextFactoryImpl.java
@@ -2,7 +2,6 @@ package org.jboss.windup.graph;
 
 import java.io.File;
 import java.nio.file.Path;
-import java.util.Set;
 import java.util.WeakHashMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -48,14 +47,14 @@ public class GraphContextFactoryImpl implements GraphContextFactory
     }
 
     @Override
-    public GraphContext create()
+    public GraphContext create(boolean enableListeners)
     {
         return ExecutionStatistics.performBenchmarked(GraphContextFactory.class.getName() + ".create(Path)", () -> {
             GraphContext graphContext = new GraphContextImpl(
                     getFurnace(),
                     getGraphTypeManager(),
                     getGraphApiCompositeClassLoaderProvider(),
-                    getTempGraphDirectory()).create(false);
+                    getTempGraphDirectory()).create(enableListeners);
             graphMap.put(graphContext.getGraphDirectory().toString(), graphContext);
             return graphContext;
     }
@@ -63,14 +62,14 @@ public class GraphContextFactoryImpl implements GraphContextFactory
     }
 
     @Override
-    public GraphContext create(Path graphDir)
+    public GraphContext create(Path graphDir, boolean enableListeners)
     {
         return ExecutionStatistics.performBenchmarked(GraphContextFactory.class.getName() + ".create(Path)", () -> {
             GraphContext graphContext = new GraphContextImpl(
                     getFurnace(),
                     getGraphTypeManager(),
                     getGraphApiCompositeClassLoaderProvider(),
-                    graphDir).create(true);
+                    graphDir).create(enableListeners);
             graphMap.put(graphContext.getGraphDirectory().toString(), graphContext);
             return graphContext;
         });

--- a/graph/impl/src/main/java/org/jboss/windup/graph/GraphContextImpl.java
+++ b/graph/impl/src/main/java/org/jboss/windup/graph/GraphContextImpl.java
@@ -377,8 +377,6 @@ public class GraphContextImpl implements GraphContext
 
             graphStrategies.addStrategies(EventStrategy.build().addListener(mutationListener).create());
             TraversalStrategies.GlobalCache.registerStrategies(StandardJanusGraph.class, graphStrategies);
-            LOG.info("Setting graph to: " + this + " for listener: " + mutationListener);
-            new Exception().printStackTrace();
             mutationListener.setGraph(this);
         }
         return janusGraph;
@@ -605,7 +603,6 @@ public class GraphContextImpl implements GraphContext
         public void vertexPropertyChanged(Vertex vertex, org.apache.tinkerpop.gremlin.structure.Property oldValue, Object setValue,
                     Object... vertexPropertyKeyValues)
         {
-            LOG.info("Vertex property changed with graph: " + getGraphContext() + " and this: " + this);
             GraphContextImpl graphContext = getGraphContext();
             if (graphContext == null || graphContext.graphListeners == null)
                 return;

--- a/graph/tests/src/test/java/org/jboss/windup/graph/ProjectModelTraversalTest.java
+++ b/graph/tests/src/test/java/org/jboss/windup/graph/ProjectModelTraversalTest.java
@@ -65,7 +65,7 @@ public class ProjectModelTraversalTest
 
     private GraphContext createGraphContext(Path temporaryDirectory)
     {
-        return factory.create(temporaryDirectory.resolve("output"));
+        return factory.create(temporaryDirectory.resolve("output"), true);
     }
 
     @Test

--- a/graph/tests/src/test/java/org/jboss/windup/graph/duplicate/typevalue/DuplicateTypeValueTest.java
+++ b/graph/tests/src/test/java/org/jboss/windup/graph/duplicate/typevalue/DuplicateTypeValueTest.java
@@ -35,7 +35,7 @@ public class DuplicateTypeValueTest
     @Test(expected = Exception.class)
     public void testDuplicateTypeValue() throws Exception
     {
-        try (GraphContext context = factory.create())
+        try (GraphContext context = factory.create(true))
         {
             Assert.assertNotNull(context);
             context.getFramed().addFramedVertex(TestSimpleModel.class);

--- a/graph/tests/src/test/java/org/jboss/windup/graph/iterable/FramesIterableSetTest.java
+++ b/graph/tests/src/test/java/org/jboss/windup/graph/iterable/FramesIterableSetTest.java
@@ -48,7 +48,7 @@ public class FramesIterableSetTest
     @Test
     public void testIterableSetEmpty() throws IOException
     {
-        try (GraphContext context = factory.create())
+        try (GraphContext context = factory.create(true))
         {
             List<WindupVertexFrame> models = fillInTestDataAndReturn(context);
             FramesSetIterable iterable = new FramesSetIterable(new ArrayList<>());
@@ -60,7 +60,7 @@ public class FramesIterableSetTest
     @Test
     public void testIterableSetWithoutDuplicates() throws IOException
     {
-        try (GraphContext context = factory.create())
+        try (GraphContext context = factory.create(true))
         {
             List<WindupVertexFrame> models = fillInTestDataAndReturn(context);
             FramesSetIterable iterable = new FramesSetIterable(models);
@@ -72,7 +72,7 @@ public class FramesIterableSetTest
     @Test
     public void testIterableSetWithDuplicates() throws IOException
     {
-        try (GraphContext context = factory.create())
+        try (GraphContext context = factory.create(true))
         {
             List<WindupVertexFrame> models = fillInTestDataAndReturn(context);
             models.add(models.get(0));

--- a/graph/tests/src/test/java/org/jboss/windup/graph/service/RuleProviderExecutionStatisticsServiceTest.java
+++ b/graph/tests/src/test/java/org/jboss/windup/graph/service/RuleProviderExecutionStatisticsServiceTest.java
@@ -41,7 +41,7 @@ public class RuleProviderExecutionStatisticsServiceTest
     @Test
     public void testFindAllOrderedByIndex() throws Exception
     {
-        try (GraphContext context = factory.create())
+        try (GraphContext context = factory.create(true))
         {
             RuleProviderExecutionStatisticsService service = new RuleProviderExecutionStatisticsService(context);
             RuleProviderExecutionStatisticsModel m1 = service.create();

--- a/graph/tests/src/test/java/org/jboss/windup/graph/test/DefaultValueTest.java
+++ b/graph/tests/src/test/java/org/jboss/windup/graph/test/DefaultValueTest.java
@@ -37,7 +37,7 @@ public class DefaultValueTest
     @Test
     public void testDefaultValue() throws Exception
     {
-        try (GraphContext context = factory.create())
+        try (GraphContext context = factory.create(true))
         {
             Assert.assertNotNull(context);
             DefaultValueTestModel initialModelType = context.getFramed().addFramedVertex(DefaultValueTestModel.class);

--- a/graph/tests/src/test/java/org/jboss/windup/graph/test/EventGraphTest.java
+++ b/graph/tests/src/test/java/org/jboss/windup/graph/test/EventGraphTest.java
@@ -38,7 +38,7 @@ public class EventGraphTest
     @Test
     public void testEventGraph() throws Exception
     {
-        try (GraphContext context = factory.create())
+        try (GraphContext context = factory.create(true))
         {
             Assert.assertNotNull(context);
 

--- a/graph/tests/src/test/java/org/jboss/windup/graph/typedgraph/JavaHandlerSubclassSpecializationTest.java
+++ b/graph/tests/src/test/java/org/jboss/windup/graph/typedgraph/JavaHandlerSubclassSpecializationTest.java
@@ -45,7 +45,7 @@ public class JavaHandlerSubclassSpecializationTest
     @Test
     public void testSubclassMethodHandling() throws Exception
     {
-        try (GraphContext context = factory.create())
+        try (GraphContext context = factory.create(true))
         {
             Assert.assertNotNull(context);
 

--- a/graph/tests/src/test/java/org/jboss/windup/graph/typedgraph/WindupPropertyMethodHandlerTest.java
+++ b/graph/tests/src/test/java/org/jboss/windup/graph/typedgraph/WindupPropertyMethodHandlerTest.java
@@ -43,7 +43,7 @@ public class WindupPropertyMethodHandlerTest
     @Test
     public void testPropertyHandler() throws Exception
     {
-        try (GraphContext context = factory.create())
+        try (GraphContext context = factory.create(true))
         {
             Assert.assertNotNull(context);
 

--- a/graph/tests/src/test/java/org/jboss/windup/graph/typedgraph/graphservice/GraphServiceTest.java
+++ b/graph/tests/src/test/java/org/jboss/windup/graph/typedgraph/graphservice/GraphServiceTest.java
@@ -56,7 +56,7 @@ public class GraphServiceTest
     @Test
     public void testGraphTypeHandling() throws Exception
     {
-        try (GraphContext context = factory.create())
+        try (GraphContext context = factory.create(true))
         {
             Assert.assertNotNull(context);
             TestFooModel initialModelType = context.getFramed().addFramedVertex(TestFooModel.class);
@@ -90,7 +90,7 @@ public class GraphServiceTest
     @Test
     public void testGraphSearchWithoutCommit() throws Exception
     {
-        try (GraphContext context = factory.create())
+        try (GraphContext context = factory.create(true))
         {
             Assert.assertNotNull(context);
 
@@ -131,7 +131,7 @@ public class GraphServiceTest
     @Test
     public void testModelCreation() throws Exception
     {
-        try (GraphContext context = factory.create())
+        try (GraphContext context = factory.create(true))
         {
             Assert.assertNotNull(context);
 
@@ -176,7 +176,7 @@ public class GraphServiceTest
     @Test
     public void testEdgeFrames() throws Exception
     {
-        try (GraphContext graphContext = factory.create())
+        try (GraphContext graphContext = factory.create(true))
         {
             // Connect two vertexes with an edge,
             TestIncidenceAaaModel aaa = graphContext.create(TestIncidenceAaaModel.class);
@@ -226,7 +226,7 @@ public class GraphServiceTest
     @Test
     public void testServiceDeletagesInGraphContext() throws Exception
     {
-        try (GraphContext context = factory.create())
+        try (GraphContext context = factory.create(true))
         {
             TestFooModel created = context.create(TestFooSubModel.class);
 

--- a/graph/tests/src/test/java/org/jboss/windup/graph/typedgraph/map/FrameMapHandlerTest.java
+++ b/graph/tests/src/test/java/org/jboss/windup/graph/typedgraph/map/FrameMapHandlerTest.java
@@ -43,7 +43,7 @@ public class FrameMapHandlerTest
     @Test
     public void testMapHandling() throws Exception
     {
-        try (GraphContext context = factory.create())
+        try (GraphContext context = factory.create(true))
         {
             Assert.assertNotNull(context);
 

--- a/graph/tests/src/test/java/org/jboss/windup/graph/typedgraph/mapinadjprops/MapInAdjacentPropertiesTest.java
+++ b/graph/tests/src/test/java/org/jboss/windup/graph/typedgraph/mapinadjprops/MapInAdjacentPropertiesTest.java
@@ -47,7 +47,7 @@ public class MapInAdjacentPropertiesTest
     {
         Assert.assertNotNull(contextFactory);
 
-        try (GraphContext context = contextFactory.create())
+        try (GraphContext context = contextFactory.create(true))
         {
             MapMainModel mainModel = context.getFramed().addFramedVertex(MapMainModel.class);
 

--- a/graph/tests/src/test/java/org/jboss/windup/graph/typedgraph/mapinprops/MapInPropertiesTest.java
+++ b/graph/tests/src/test/java/org/jboss/windup/graph/typedgraph/mapinprops/MapInPropertiesTest.java
@@ -43,7 +43,7 @@ public class MapInPropertiesTest
     @Test
     public void testMapHandling() throws Exception
     {
-        try (GraphContext context = contextFactory.create())
+        try (GraphContext context = contextFactory.create(true))
         {
             Assert.assertNotNull(context);
             prepareFrame(context, TestMapPrefixModel.class);
@@ -59,7 +59,7 @@ public class MapInPropertiesTest
     @Test
     public void testMapWithBlankPrefixHandling() throws Exception
     {
-        try (GraphContext context = contextFactory.create())
+        try (GraphContext context = contextFactory.create(true))
         {
             TestMapBlankSubModel frame = prepareFrame(context, TestMapBlankSubModel.class);
             System.out.println("    Frame class: " + frame.getClass());
@@ -85,7 +85,7 @@ public class MapInPropertiesTest
     @Test
     public void testMapWithBlankPrefixHandling2() throws Exception
     {
-        try (GraphContext context = contextFactory.create())
+        try (GraphContext context = contextFactory.create(true))
         {
             TestMapBlankModel frame = context.getFramed().addFramedVertex(TestMapBlankModel.class);
             Map<String, String> map = prepareMap();

--- a/graph/tests/src/test/java/org/jboss/windup/graph/typedgraph/setinprops/SetInPropertiesTest.java
+++ b/graph/tests/src/test/java/org/jboss/windup/graph/typedgraph/setinprops/SetInPropertiesTest.java
@@ -41,7 +41,7 @@ public class SetInPropertiesTest
     @Test
     public void testSetHandling() throws Exception
     {
-        try (GraphContext context = contextFactory.create())
+        try (GraphContext context = contextFactory.create(true))
         {
             Assert.assertNotNull(context);
             prepareFrame(context, TestSetPrefixModel.class);
@@ -58,7 +58,7 @@ public class SetInPropertiesTest
     @Test
     public void testSetWithBlankPrefixHandling() throws Exception
     {
-        try (GraphContext context = contextFactory.create())
+        try (GraphContext context = contextFactory.create(true))
         {
             TestSetBlankSubModel frame = prepareFrame(context, TestSetBlankSubModel.class);
             System.out.println("    Frame class: " + frame.getClass());
@@ -84,7 +84,7 @@ public class SetInPropertiesTest
     @Test
     public void testSetWithBlankPrefixHandling2() throws Exception
     {
-        try (GraphContext context = contextFactory.create())
+        try (GraphContext context = contextFactory.create(true))
         {
             TestSetBlankModel frame = context.getFramed().addFramedVertex(TestSetBlankModel.class);
             Set<String> set = prepareSet();

--- a/reporting/tests/src/test/java/org/jboss/windup/reporting/ApplicationReportIndexModelServiceTest.java
+++ b/reporting/tests/src/test/java/org/jboss/windup/reporting/ApplicationReportIndexModelServiceTest.java
@@ -48,7 +48,7 @@ public class ApplicationReportIndexModelServiceTest
     @Test
     public void testGetApplicationReportsForProjectModelSortedByPriority() throws IOException
     {
-        try (GraphContext context = factory.create())
+        try (GraphContext context = factory.create(true))
         {
             ProjectModel projectModel = new ProjectService(context).create();
             ApplicationReportService applicationReportService = new ApplicationReportService(context);

--- a/reporting/tests/src/test/java/org/jboss/windup/reporting/CSVExportingTest.java
+++ b/reporting/tests/src/test/java/org/jboss/windup/reporting/CSVExportingTest.java
@@ -82,7 +82,7 @@ public class CSVExportingTest
                     "windup_" + RandomStringUtils.randomAlphanumeric(6));
 
         outputPath.toFile().mkdirs();
-        try (GraphContext context = factory.create())
+        try (GraphContext context = factory.create(true))
         {
             fillData(context);
             String inputPath = "src/test/resources";

--- a/reporting/tests/src/test/java/org/jboss/windup/reporting/ClassificationServiceTest.java
+++ b/reporting/tests/src/test/java/org/jboss/windup/reporting/ClassificationServiceTest.java
@@ -51,7 +51,7 @@ public class ClassificationServiceTest
     @Test
     public void testClassificationEffort() throws Exception
     {
-        try (GraphContext context = factory.create())
+        try (GraphContext context = factory.create(true))
         {
             ClassificationService classificationService = new ClassificationService(context);
 
@@ -94,7 +94,7 @@ public class ClassificationServiceTest
     @Test
     public void testClassificationAcrossProjectBoundaries() throws Exception
     {
-        try (GraphContext context = factory.create())
+        try (GraphContext context = factory.create(true))
         {
             ClassificationService classificationService = new ClassificationService(context);
 
@@ -115,7 +115,7 @@ public class ClassificationServiceTest
     @Test
     public void testClassificationAlreadyAttached() throws Exception
     {
-        try (GraphContext context = factory.create())
+        try (GraphContext context = factory.create(true))
         {
             GraphRewrite event = new GraphRewrite(context);
             ClassificationService classificationService = new ClassificationService(context);

--- a/reporting/tests/src/test/java/org/jboss/windup/reporting/FreeMarkerIterationOperationTest.java
+++ b/reporting/tests/src/test/java/org/jboss/windup/reporting/FreeMarkerIterationOperationTest.java
@@ -58,7 +58,7 @@ public class FreeMarkerIterationOperationTest
     @Test
     public void testApplicationReportFreemarker() throws Exception
     {
-        try (GraphContext context = factory.create())
+        try (GraphContext context = factory.create(true))
         {
             GraphRewrite event = new GraphRewrite(context);
             DefaultEvaluationContext evaluationContext = ReportingTestUtil.createEvalContext(event);

--- a/reporting/tests/src/test/java/org/jboss/windup/reporting/InlineHintServiceTest.java
+++ b/reporting/tests/src/test/java/org/jboss/windup/reporting/InlineHintServiceTest.java
@@ -54,7 +54,7 @@ public class InlineHintServiceTest
     public void testHintEffort() throws Exception
     {
 
-        try (GraphContext context = factory.create())
+        try (GraphContext context = factory.create(true))
         {
             InlineHintService inlineHintService = new InlineHintService(context);
 
@@ -92,7 +92,7 @@ public class InlineHintServiceTest
     @Test
     public void testFindHintsForProject() throws Exception
     {
-        try (GraphContext context = factory.create())
+        try (GraphContext context = factory.create(true))
         {
             FileService fileService = new FileService(context);
             InlineHintService hintService = new InlineHintService(context);

--- a/reporting/tests/src/test/java/org/jboss/windup/reporting/LoadIssueCategoriesRuleProviderTest.java
+++ b/reporting/tests/src/test/java/org/jboss/windup/reporting/LoadIssueCategoriesRuleProviderTest.java
@@ -58,7 +58,7 @@ public class LoadIssueCategoriesRuleProviderTest
     @Test
     public void testLoadIssueCategories() throws Exception
     {
-        try (GraphContext context = factory.create())
+        try (GraphContext context = factory.create(true))
         {
             GraphRewrite event = new GraphRewrite(context);
             DefaultEvaluationContext evaluationContext = ReportingTestUtil.createEvalContext(event);

--- a/reporting/tests/src/test/java/org/jboss/windup/reporting/service/TechnologyTagServiceTest.java
+++ b/reporting/tests/src/test/java/org/jboss/windup/reporting/service/TechnologyTagServiceTest.java
@@ -48,7 +48,7 @@ public class TechnologyTagServiceTest
     @Test
     public void testFindTechnologyTagsByProject() throws Exception
     {
-        try (GraphContext context = factory.create())
+        try (GraphContext context = factory.create(true))
         {
             ProjectService projectService = new ProjectService(context);
             TechnologyTagService techTagService = new TechnologyTagService(context);

--- a/rules-base/tests/src/test/java/org/jboss/windup/rules/apps/condition/FileContentTest.java
+++ b/rules-base/tests/src/test/java/org/jboss/windup/rules/apps/condition/FileContentTest.java
@@ -87,7 +87,7 @@ public class FileContentTest
     @Test
     public void testFileContentScan() throws Exception
     {
-        try (GraphContext context = factory.create())
+        try (GraphContext context = factory.create(true))
         {
             Path inputPath = Paths.get("src/test/resources/");
 

--- a/rules-base/tests/src/test/java/org/jboss/windup/rules/apps/condition/FileTest.java
+++ b/rules-base/tests/src/test/java/org/jboss/windup/rules/apps/condition/FileTest.java
@@ -82,7 +82,7 @@ public class FileTest
     @Test
     public void testFileScan() throws Exception
     {
-        try (GraphContext context = factory.create())
+        try (GraphContext context = factory.create(true))
         {
             Path inputPath = Paths.get("src/test/resources/");
 

--- a/rules-base/tests/src/test/java/org/jboss/windup/rules/apps/condition/IterableFilterTest.java
+++ b/rules-base/tests/src/test/java/org/jboss/windup/rules/apps/condition/IterableFilterTest.java
@@ -86,7 +86,7 @@ public class IterableFilterTest
     }
 
     private void runWindupWithPredicate()  throws Exception{
-        try (GraphContext context = factory.create())
+        try (GraphContext context = factory.create(true))
         {
             Path inputPath = Paths.get("src/test/resources/");
 

--- a/rules-base/tests/src/test/java/org/jboss/windup/rules/apps/condition/ToFileModelTest.java
+++ b/rules-base/tests/src/test/java/org/jboss/windup/rules/apps/condition/ToFileModelTest.java
@@ -76,7 +76,7 @@ public class ToFileModelTest
     @Test
     public void testToFileModelTransformation() throws Exception
     {
-        try (GraphContext context = factory.create())
+        try (GraphContext context = factory.create(true))
         {
             Path inputPath = Paths.get("src/test/resources/");
 

--- a/rules-java-archives/tests/src/test/java/org/jboss/windup/rules/apps/java/archives/IdentifyArchivesRulesetTest.java
+++ b/rules-java-archives/tests/src/test/java/org/jboss/windup/rules/apps/java/archives/IdentifyArchivesRulesetTest.java
@@ -80,7 +80,7 @@ public class IdentifyArchivesRulesetTest
     @Test
     public void testJarsAreIdentified() throws Exception
     {
-        try (GraphContext graphContext = contextFactory.create())
+        try (GraphContext graphContext = contextFactory.create(true))
         {
             FileUtils.deleteDirectory(OUTPUT_PATH.toFile());
 

--- a/rules-java-archives/tests/src/test/java/org/jboss/windup/rules/apps/java/archives/IgnoreArchivesRulesetTest.java
+++ b/rules-java-archives/tests/src/test/java/org/jboss/windup/rules/apps/java/archives/IgnoreArchivesRulesetTest.java
@@ -77,7 +77,7 @@ public class IgnoreArchivesRulesetTest
     @Test
     public void testSkippedArchivesFound() throws Exception
     {
-        try (GraphContext graphContext = contextFactory.create())
+        try (GraphContext graphContext = contextFactory.create(true))
         {
             FileUtils.deleteDirectory(OUTPUT_PATH.toFile());
 

--- a/rules-java-ee/tests/src/test/java/org/jboss/windup/rules/apps/javaee/service/EjbRemoteServiceModelServiceTest.java
+++ b/rules-java-ee/tests/src/test/java/org/jboss/windup/rules/apps/javaee/service/EjbRemoteServiceModelServiceTest.java
@@ -44,7 +44,7 @@ public class EjbRemoteServiceModelServiceTest extends AbstractTest
     public void setUp() throws Exception
     {
         this.graphPath = getDefaultPath();
-        this.context = this.factory.create(graphPath);
+        this.context = this.factory.create(graphPath, true);
         this.javaClassService = new JavaClassService(this.context);
         this.serviceModelService = new EjbRemoteServiceModelService(this.context);
     }

--- a/rules-java-ee/tests/src/test/java/org/jboss/windup/rules/apps/javaee/service/HibernateConfigurationFileServiceTest.java
+++ b/rules-java-ee/tests/src/test/java/org/jboss/windup/rules/apps/javaee/service/HibernateConfigurationFileServiceTest.java
@@ -27,7 +27,7 @@ public class HibernateConfigurationFileServiceTest extends AbstractTest
     @Test
     public void testHibernateConfigurationFindByProject() throws Exception
     {
-        try (GraphContext context = factory.create())
+        try (GraphContext context = factory.create(true))
         {
             ProjectService projectService = new ProjectService(context);
             ProjectModel app1 = projectService.create();

--- a/rules-java-ee/tests/src/test/java/org/jboss/windup/rules/apps/javaee/service/HibernateEntityServiceTest.java
+++ b/rules-java-ee/tests/src/test/java/org/jboss/windup/rules/apps/javaee/service/HibernateEntityServiceTest.java
@@ -27,7 +27,7 @@ public class HibernateEntityServiceTest extends AbstractTest
     @Test
     public void testHibernateEntityFindByProject() throws Exception
     {
-        try (GraphContext context = factory.create())
+        try (GraphContext context = factory.create(true))
         {
             ProjectService projectService = new ProjectService(context);
             ProjectModel app1 = projectService.create();

--- a/rules-java-ee/tests/src/test/java/org/jboss/windup/rules/apps/javaee/service/JaxRSWebServiceModelServiceTest.java
+++ b/rules-java-ee/tests/src/test/java/org/jboss/windup/rules/apps/javaee/service/JaxRSWebServiceModelServiceTest.java
@@ -44,7 +44,7 @@ public class JaxRSWebServiceModelServiceTest extends AbstractTest
     public void setUp() throws Exception
     {
         this.graphPath = getDefaultPath();
-        this.context = this.factory.create(graphPath);
+        this.context = this.factory.create(graphPath, true);
         this.javaClassService = new JavaClassService(this.context);
         this.serviceModelService = new JaxRSWebServiceModelService(this.context);
     }

--- a/rules-java-ee/tests/src/test/java/org/jboss/windup/rules/apps/javaee/service/JaxWSWebServiceModelServiceTest.java
+++ b/rules-java-ee/tests/src/test/java/org/jboss/windup/rules/apps/javaee/service/JaxWSWebServiceModelServiceTest.java
@@ -43,7 +43,7 @@ public class JaxWSWebServiceModelServiceTest extends AbstractTest
     public void setUp() throws Exception
     {
         this.graphPath = getDefaultPath();
-        this.context = this.factory.create(graphPath);
+        this.context = this.factory.create(graphPath, true);
         this.javaClassService = new JavaClassService(this.context);
         this.serviceModelService = new JaxWSWebServiceModelService(this.context);
     }

--- a/rules-java-ee/tests/src/test/java/org/jboss/windup/rules/apps/javaee/service/RMIServiceModelServiceTest.java
+++ b/rules-java-ee/tests/src/test/java/org/jboss/windup/rules/apps/javaee/service/RMIServiceModelServiceTest.java
@@ -43,7 +43,7 @@ public class RMIServiceModelServiceTest extends AbstractTest
     public void setUp() throws Exception
     {
         this.graphPath = getDefaultPath();
-        this.context = this.factory.create(graphPath);
+        this.context = this.factory.create(graphPath, true);
         this.javaClassService = new JavaClassService(this.context);
         this.rmiService = new RMIServiceModelService(this.context);
     }

--- a/rules-java-ee/tests/src/test/java/org/jboss/windup/rules/apps/javaee/service/SpringBeanServiceTest.java
+++ b/rules-java-ee/tests/src/test/java/org/jboss/windup/rules/apps/javaee/service/SpringBeanServiceTest.java
@@ -29,7 +29,7 @@ public class SpringBeanServiceTest extends AbstractTest
     @Test
     public void testSpringFindByProject() throws Exception
     {
-        try (GraphContext context = factory.create())
+        try (GraphContext context = factory.create(true))
         {
             ProjectService projectService = new ProjectService(context);
             ProjectModel app1 = projectService.create();

--- a/rules-java-ee/tests/src/test/java/org/jboss/windup/rules/apps/javaee/tests/DiscoverDataSourceAnnotationRuleProviderTest.java
+++ b/rules-java-ee/tests/src/test/java/org/jboss/windup/rules/apps/javaee/tests/DiscoverDataSourceAnnotationRuleProviderTest.java
@@ -43,7 +43,7 @@ public class DiscoverDataSourceAnnotationRuleProviderTest extends AbstractTest
         FileUtils.deleteDirectory(outputPath.toFile());
         Files.createDirectories(outputPath);
 
-        try (GraphContext context = factory.create(outputPath))
+        try (GraphContext context = factory.create(outputPath, true))
         {
             ProjectModel pm = context.getFramed().addFramedVertex(ProjectModel.class);
             pm.setName("Main Project");

--- a/rules-java-ee/tests/src/test/java/org/jboss/windup/rules/apps/javaee/tests/DiscoverEjbConfigurationTest.java
+++ b/rules-java-ee/tests/src/test/java/org/jboss/windup/rules/apps/javaee/tests/DiscoverEjbConfigurationTest.java
@@ -34,7 +34,7 @@ public class DiscoverEjbConfigurationTest extends AbstractTest
     @Test
     public void testEJBMetadataExtraction() throws Exception
     {
-        try (GraphContext context = factory.create())
+        try (GraphContext context = factory.create(true))
         {
             ProjectModel pm = context.getFramed().addFramedVertex(ProjectModel.class);
             pm.setName("Main Project");

--- a/rules-java-ee/tests/src/test/java/org/jboss/windup/rules/apps/javaee/tests/DiscoverWebXmlTest.java
+++ b/rules-java-ee/tests/src/test/java/org/jboss/windup/rules/apps/javaee/tests/DiscoverWebXmlTest.java
@@ -1,25 +1,16 @@
 package org.jboss.windup.rules.apps.javaee.tests;
 
-import com.google.common.collect.Iterables;
 import org.apache.commons.io.FileUtils;
 import org.jboss.arquillian.junit.Arquillian;
-import org.jboss.forge.furnace.util.OperatingSystemUtils;
 import org.jboss.windup.exec.WindupProcessor;
 import org.jboss.windup.exec.configuration.WindupConfiguration;
 import org.jboss.windup.graph.GraphContext;
 import org.jboss.windup.graph.GraphContextFactory;
-import org.jboss.windup.graph.model.LinkModel;
 import org.jboss.windup.graph.model.ProjectModel;
-import org.jboss.windup.graph.model.WindupConfigurationModel;
 import org.jboss.windup.graph.model.resource.FileModel;
 import org.jboss.windup.graph.service.GraphService;
 import org.jboss.windup.rules.apps.javaee.AbstractTest;
-import org.jboss.windup.rules.apps.javaee.model.EjbMessageDrivenModel;
 import org.jboss.windup.rules.apps.javaee.model.WebXmlModel;
-import org.jboss.windup.rules.apps.javaee.rules.DiscoverWebXmlRuleProvider;
-import org.jboss.windup.rules.apps.javaee.rules.jboss.GenerateJBossWebDescriptorRuleProvider;
-import org.jboss.windup.rules.apps.xml.model.XmlFileModel;
-import org.jboss.windup.testutil.basics.WindupTestUtilMethods;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -28,7 +19,6 @@ import javax.inject.Inject;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.UUID;
 
@@ -44,7 +34,7 @@ public class DiscoverWebXmlTest extends AbstractTest
     @Test
     public void testWebXmlMetadataExtraction() throws Exception
     {
-        try (GraphContext context = factory.create())
+        try (GraphContext context = factory.create(true))
         {
             ProjectModel pm = context.getFramed().addFramedVertex(ProjectModel.class);
             pm.setName("Main Project");

--- a/rules-java-ee/tests/src/test/java/org/jboss/windup/rules/apps/javaee/tests/EjbXmlParsingTest.java
+++ b/rules-java-ee/tests/src/test/java/org/jboss/windup/rules/apps/javaee/tests/EjbXmlParsingTest.java
@@ -53,7 +53,7 @@ public class EjbXmlParsingTest extends AbstractTest
     @Test
     public void testEJBWebLogic() throws Exception
     {
-        try (GraphContext context = factory.create())
+        try (GraphContext context = factory.create(true))
         {
             startWindup(WEBLOGIC_TEST_EJB_XMLS, context);
             EnvironmentReferenceService envRefService = new EnvironmentReferenceService(context);
@@ -104,7 +104,7 @@ public class EjbXmlParsingTest extends AbstractTest
     @Test
     public void testEJBWebSphere() throws Exception
     {
-        try (GraphContext context = factory.create())
+        try (GraphContext context = factory.create(true))
         {
             startWindup(WEBSPHERE_TEST_EJB_XMLS, context);
             EnvironmentReferenceService envRefService = new EnvironmentReferenceService(context);
@@ -119,7 +119,7 @@ public class EjbXmlParsingTest extends AbstractTest
     @Test
     public void testEJBOrion() throws Exception
     {
-        try (GraphContext context = factory.create())
+        try (GraphContext context = factory.create(true))
         {
             startWindup(ORION_TEST_EJB_XMLS, context);
             GraphService<EjbSessionBeanModel> ejbSessionBeanService = new GraphService<>(context, EjbSessionBeanModel.class);
@@ -150,7 +150,7 @@ public class EjbXmlParsingTest extends AbstractTest
     @Test
     public void testEJBJBoss() throws Exception
     {
-        try (GraphContext context = factory.create())
+        try (GraphContext context = factory.create(true))
         {
             startWindup(JBOSS_TEST_EJB_XMLS, context);
             GraphService<EjbSessionBeanModel> ejbSessionBeanService = new GraphService<>(context, EjbSessionBeanModel.class);

--- a/rules-java-ee/tests/src/test/java/org/jboss/windup/rules/apps/javaee/tests/GenerateJBossEjbDescriptorTest.java
+++ b/rules-java-ee/tests/src/test/java/org/jboss/windup/rules/apps/javaee/tests/GenerateJBossEjbDescriptorTest.java
@@ -36,7 +36,7 @@ public class GenerateJBossEjbDescriptorTest extends AbstractTest
     public void testRuleProviders() throws Exception
     {
         final Path folder = OperatingSystemUtils.createTempDir().toPath();
-        try (final GraphContext context = factory.create(folder))
+        try (final GraphContext context = factory.create(folder, true))
         {
             initData(context);
             WindupTestUtilMethods.runOnlyRuleProviders(Collections.singletonList(new GenerateJBossEjbDescriptorRuleProvider()), context);

--- a/rules-java-ee/tests/src/test/java/org/jboss/windup/rules/apps/javaee/tests/GenerateJbossWebDescriptorTest.java
+++ b/rules-java-ee/tests/src/test/java/org/jboss/windup/rules/apps/javaee/tests/GenerateJbossWebDescriptorTest.java
@@ -34,7 +34,7 @@ public class GenerateJbossWebDescriptorTest extends AbstractTest
     public void testRuleProviders() throws Exception
     {
         final Path folder = OperatingSystemUtils.createTempDir().toPath();
-        try (final GraphContext context = factory.create(folder))
+        try (final GraphContext context = factory.create(folder, true))
         {
             initData(context);
             WindupTestUtilMethods.runOnlyRuleProviders(Collections.singletonList(new GenerateJBossWebDescriptorRuleProvider()), context);

--- a/rules-java-ee/tests/src/test/java/org/jboss/windup/rules/apps/javaee/tests/ResolveJBossLegacyEjbXmlRuleProviderTest.java
+++ b/rules-java-ee/tests/src/test/java/org/jboss/windup/rules/apps/javaee/tests/ResolveJBossLegacyEjbXmlRuleProviderTest.java
@@ -58,7 +58,7 @@ public class ResolveJBossLegacyEjbXmlRuleProviderTest extends AbstractTest
             FileUtils.deleteDirectory(outputPath.toFile());
             Files.createDirectories(outputPath);
 
-        try (GraphContext context = factory.create(outputPath))
+        try (GraphContext context = factory.create(outputPath, true))
         {
             ProjectModel pm = context.getFramed().addFramedVertex(ProjectModel.class);
             pm.setName("Main Project");

--- a/rules-java-ee/tests/src/test/java/org/jboss/windup/rules/apps/javaee/tests/SpringDataSourceExtractionTest.java
+++ b/rules-java-ee/tests/src/test/java/org/jboss/windup/rules/apps/javaee/tests/SpringDataSourceExtractionTest.java
@@ -44,7 +44,7 @@ public class SpringDataSourceExtractionTest extends AbstractTest
     @Test
     public void testSpringBeans() throws Exception
     {
-        try (GraphContext context = factory.create())
+        try (GraphContext context = factory.create(true))
         {
             startWindup(SPRING_XMLS, context);
             GraphService<DataSourceModel> dataSourceService = new GraphService<>(context, DataSourceModel.class);

--- a/rules-java-ee/tests/src/test/java/org/jboss/windup/rules/apps/javaee/tests/TechnologyIdentifiedTest.java
+++ b/rules-java-ee/tests/src/test/java/org/jboss/windup/rules/apps/javaee/tests/TechnologyIdentifiedTest.java
@@ -79,7 +79,7 @@ public class TechnologyIdentifiedTest
     @Test
     public void testTechnologyIdentified() throws IOException, InstantiationException, IllegalAccessException
     {
-        try (GraphContext context = factory.create(WindupTestUtilMethods.getTempDirectoryForGraph()))
+        try (GraphContext context = factory.create(WindupTestUtilMethods.getTempDirectoryForGraph(), true))
         {
             final String inputDir = "src/test/java";
 
@@ -126,7 +126,7 @@ public class TechnologyIdentifiedTest
         Path graphPath = baseOutputPath.resolve("graph");
         Path reportPath = baseOutputPath.resolve("reports");
 
-        try (GraphContext context = factory.create(graphPath))
+        try (GraphContext context = factory.create(graphPath, true))
         {
             final String basePath = "../../test-files/duplicate/duplicate-ear-test-";
             final String[] inputPaths = new String[]{

--- a/rules-java-project/tests/src/test/java/org/jboss/windup/project/operation/test/OverviewReportLineTest.java
+++ b/rules-java-project/tests/src/test/java/org/jboss/windup/project/operation/test/OverviewReportLineTest.java
@@ -77,7 +77,7 @@ public class OverviewReportLineTest
     @Test
     public void testOverviewReportLine() throws IOException
     {
-        try (GraphContext context = factory.create())
+        try (GraphContext context = factory.create(true))
         {
             ProjectModel pm = context.getFramed().addFramedVertex(ProjectModel.class);
             pm.setName("Main Project");

--- a/rules-java-project/tests/src/test/java/org/jboss/windup/project/operation/test/ProjectWithHintTest.java
+++ b/rules-java-project/tests/src/test/java/org/jboss/windup/project/operation/test/ProjectWithHintTest.java
@@ -76,7 +76,7 @@ public class ProjectWithHintTest
     @Test
     public void testProjectWithHint() throws IOException
     {
-        try (GraphContext context = factory.create())
+        try (GraphContext context = factory.create(true))
         {
             ProjectModel pm = context.getFramed().addFramedVertex(ProjectModel.class);
             pm.setName("Main Project");

--- a/rules-java/api/src/main/java/org/jboss/windup/rules/apps/java/scan/operation/packagemapping/PackageNameMappingRegistry.java
+++ b/rules-java/api/src/main/java/org/jboss/windup/rules/apps/java/scan/operation/packagemapping/PackageNameMappingRegistry.java
@@ -49,7 +49,7 @@ public class PackageNameMappingRegistry
 
     public void loadPackageMappings(Path rulesPath)
     {
-        try (GraphContext graphContext = graphContextFactory.create())
+        try (GraphContext graphContext = graphContextFactory.create(false))
         {
             WindupConfigurationModel configurationModel = WindupConfigurationService.getConfigurationModel(graphContext);
             FileModel windupRulesPath = new FileService(graphContext).createByFilePath(rulesPath.toString());

--- a/rules-java/tests/src/test/java/org/jboss/windup/rule/groovy/GroovyExtensionJavaRulesTest.java
+++ b/rules-java/tests/src/test/java/org/jboss/windup/rule/groovy/GroovyExtensionJavaRulesTest.java
@@ -87,7 +87,7 @@ public class GroovyExtensionJavaRulesTest
         FileUtils.deleteDirectory(outputPath.toFile());
         Files.createDirectories(outputPath);
 
-        try (GraphContext context = factory.create(outputPath.resolve("graph")))
+        try (GraphContext context = factory.create(outputPath.resolve("graph"), true))
         {
             String inputPath = "src/test/resources/org/jboss/windup/rules/java";
 

--- a/rules-java/tests/src/test/java/org/jboss/windup/rules/apps/java/ClassMetadataTest.java
+++ b/rules-java/tests/src/test/java/org/jboss/windup/rules/apps/java/ClassMetadataTest.java
@@ -75,7 +75,7 @@ public class ClassMetadataTest
 
     private void runTest(String inputPath) throws Exception
     {
-        try (GraphContext context = factory.create(getDefaultPath()))
+        try (GraphContext context = factory.create(getDefaultPath(), true))
         {
             final Path outputPath = Paths.get(FileUtils.getTempDirectory().toString(),
                         "windup_" + RandomStringUtils.randomAlphanumeric(6));

--- a/rules-java/tests/src/test/java/org/jboss/windup/rules/apps/java/DiscoverAdditionalProjectDetailsTest.java
+++ b/rules-java/tests/src/test/java/org/jboss/windup/rules/apps/java/DiscoverAdditionalProjectDetailsTest.java
@@ -71,7 +71,7 @@ public class DiscoverAdditionalProjectDetailsTest
         final Path outputPath = getDefaultPath();
         FileUtils.deleteDirectory(outputPath.toFile());
         Files.createDirectories(outputPath);
-        try (GraphContext context = factory.create(outputPath))
+        try (GraphContext context = factory.create(outputPath, true))
         {
             final WindupConfiguration processorConfig = new WindupConfiguration();
             processorConfig.setOptionValue(SourceModeOption.NAME, true);

--- a/rules-java/tests/src/test/java/org/jboss/windup/rules/apps/java/NonNamespacedMavenDiscoveryTest.java
+++ b/rules-java/tests/src/test/java/org/jboss/windup/rules/apps/java/NonNamespacedMavenDiscoveryTest.java
@@ -67,7 +67,7 @@ public class NonNamespacedMavenDiscoveryTest
         final Path outputPath = getDefaultPath();
         FileUtils.deleteDirectory(outputPath.toFile());
         Files.createDirectories(outputPath);
-        try (GraphContext context = factory.create(outputPath))
+        try (GraphContext context = factory.create(outputPath, true))
         {
             final WindupConfiguration processorConfig = new WindupConfiguration();
             processorConfig.setOptionValue(SourceModeOption.NAME, true);

--- a/rules-java/tests/src/test/java/org/jboss/windup/rules/apps/java/scan/ast/ASTProcessorIntegrationTest.java
+++ b/rules-java/tests/src/test/java/org/jboss/windup/rules/apps/java/scan/ast/ASTProcessorIntegrationTest.java
@@ -69,7 +69,7 @@ public class ASTProcessorIntegrationTest
     @Test
     public void testJavaSourceScanning() throws IOException, InstantiationException, IllegalAccessException
     {
-        try (GraphContext context = factory.create(getDefaultPath()))
+        try (GraphContext context = factory.create(getDefaultPath(), true))
         {
             final String inputDir = "src/test/resources/simple";
 

--- a/rules-java/tests/src/test/java/org/jboss/windup/rules/apps/java/service/TypeReferenceServiceTest.java
+++ b/rules-java/tests/src/test/java/org/jboss/windup/rules/apps/java/service/TypeReferenceServiceTest.java
@@ -49,7 +49,7 @@ public class TypeReferenceServiceTest
     @Test
     public void testGetPackageUseFrequencies() throws Exception
     {
-        try (GraphContext context = factory.create())
+        try (GraphContext context = factory.create(true))
         {
             Assert.assertNotNull(context);
 

--- a/rules-java/tests/src/test/java/org/jboss/windup/rules/apps/mavenize/MavenizeRuleProviderTest.java
+++ b/rules-java/tests/src/test/java/org/jboss/windup/rules/apps/mavenize/MavenizeRuleProviderTest.java
@@ -98,7 +98,7 @@ public class MavenizeRuleProviderTest
     @Test
     public void testMavenizeRuleProvider() throws IOException, InstantiationException, IllegalAccessException
     {
-        try (GraphContext graphContext = factory.create(WindupTestUtilMethods.getTempDirectoryForGraph()))
+        try (GraphContext graphContext = factory.create(WindupTestUtilMethods.getTempDirectoryForGraph(), true))
         {
             final String inputDir = "../../test-files/jee-example-app-1.0.0.ear"; // rules-java/api
             final Class<MavenizeRuleProvider> ruleToRunUpTo = MavenizeRuleProvider.class;

--- a/rules-java/tests/src/test/java/org/jboss/windup/rules/java/CacheFileModelPrettyPathRuleProviderTest.java
+++ b/rules-java/tests/src/test/java/org/jboss/windup/rules/java/CacheFileModelPrettyPathRuleProviderTest.java
@@ -65,7 +65,7 @@ public class CacheFileModelPrettyPathRuleProviderTest
     @Test
     public void testCachedPrettyPath() throws IOException, InstantiationException, IllegalAccessException
     {
-        try (GraphContext context = factory.create(WindupTestUtilMethods.getTempDirectoryForGraph()))
+        try (GraphContext context = factory.create(WindupTestUtilMethods.getTempDirectoryForGraph(), true))
         {
             final String inputDir = "src/test/resources/org/jboss/windup/rules/java";
 

--- a/rules-java/tests/src/test/java/org/jboss/windup/rules/java/GatherIgnoredFilesTest.java
+++ b/rules-java/tests/src/test/java/org/jboss/windup/rules/java/GatherIgnoredFilesTest.java
@@ -59,7 +59,7 @@ public class GatherIgnoredFilesTest
     @Test
     public void testJavaClassCondition() throws IOException, InstantiationException, IllegalAccessException
     {
-        try (GraphContext context = factory.create())
+        try (GraphContext context = factory.create(true))
         {
             ProjectModel pm = context.getFramed().addFramedVertex(ProjectModel.class);
             pm.setName("Main Project");

--- a/rules-java/tests/src/test/java/org/jboss/windup/rules/java/InlineHintModelQueryTest.java
+++ b/rules-java/tests/src/test/java/org/jboss/windup/rules/java/InlineHintModelQueryTest.java
@@ -61,7 +61,7 @@ public class InlineHintModelQueryTest
     @Before
     public void beforeTest() throws Exception
     {
-        context = factory.create();
+        context = factory.create(true);
     }
 
     @After

--- a/rules-java/tests/src/test/java/org/jboss/windup/rules/java/JavaClassAnnotationFilteringTest.java
+++ b/rules-java/tests/src/test/java/org/jboss/windup/rules/java/JavaClassAnnotationFilteringTest.java
@@ -78,7 +78,7 @@ public class JavaClassAnnotationFilteringTest
         Path outputPath = getDefaultPath();
         FileUtils.deleteDirectory(outputPath.toFile());
         Files.createDirectories(outputPath);
-        try (GraphContext context = factory.create(outputPath))
+        try (GraphContext context = factory.create(outputPath, true))
         {
             final String inputDir = "src/test/resources/org/jboss/windup/rules/annotationtests/basic";
 
@@ -106,7 +106,7 @@ public class JavaClassAnnotationFilteringTest
         FileUtils.deleteDirectory(outputPath.toFile());
         Files.createDirectories(outputPath);
 
-        try (GraphContext context = factory.create(outputPath))
+        try (GraphContext context = factory.create(outputPath, true))
         {
             final String inputDir = "src/test/resources/org/jboss/windup/rules/annotationtests/complex";
 

--- a/rules-java/tests/src/test/java/org/jboss/windup/rules/java/JavaClassBindingStatusTest.java
+++ b/rules-java/tests/src/test/java/org/jboss/windup/rules/java/JavaClassBindingStatusTest.java
@@ -87,7 +87,7 @@ public class JavaClassBindingStatusTest
     @Test
     public void testResolutionStatus() throws IOException, InstantiationException, IllegalAccessException
     {
-        try (GraphContext context = factory.create(getDefaultPath()))
+        try (GraphContext context = factory.create(getDefaultPath(), true))
         {
             final String inputDir = "src/test/resources/org/jboss/windup/rules/java";
 

--- a/rules-java/tests/src/test/java/org/jboss/windup/rules/java/JavaClassCompositeTest.java
+++ b/rules-java/tests/src/test/java/org/jboss/windup/rules/java/JavaClassCompositeTest.java
@@ -71,7 +71,7 @@ public class JavaClassCompositeTest
     @Test
     public void testJavaClassCondition() throws IOException, InstantiationException, IllegalAccessException
     {
-        try (GraphContext context = factory.create(getDefaultPath()))
+        try (GraphContext context = factory.create(getDefaultPath(), true))
         {
             final String inputDir = "src/test/resources/org/jboss/windup/rules/java";
 

--- a/rules-java/tests/src/test/java/org/jboss/windup/rules/java/JavaClassSourceMatchTest.java
+++ b/rules-java/tests/src/test/java/org/jboss/windup/rules/java/JavaClassSourceMatchTest.java
@@ -74,7 +74,7 @@ public class JavaClassSourceMatchTest
         final Path outputPath = getDefaultPath();
         FileUtils.deleteDirectory(outputPath.toFile());
         Files.createDirectories(outputPath);
-        try (GraphContext context = factory.create(outputPath))
+        try (GraphContext context = factory.create(outputPath, true))
         {
             final String inputDir = "src/test/resources/org/jboss/windup/rules/java";
 

--- a/rules-java/tests/src/test/java/org/jboss/windup/rules/java/JavaClassTest.java
+++ b/rules-java/tests/src/test/java/org/jboss/windup/rules/java/JavaClassTest.java
@@ -78,7 +78,7 @@ public class JavaClassTest
     @Test
     public void testJavaClassCondition() throws IOException, InstantiationException, IllegalAccessException
     {
-        try (GraphContext context = factory.create(WindupTestUtilMethods.getTempDirectoryForGraph()))
+        try (GraphContext context = factory.create(WindupTestUtilMethods.getTempDirectoryForGraph(), true))
         {
             final String inputDir = "src/test/resources/org/jboss/windup/rules/java";
 

--- a/rules-java/tests/src/test/java/org/jboss/windup/rules/java/JavaClassWithEnumConstOnClasspathTest.java
+++ b/rules-java/tests/src/test/java/org/jboss/windup/rules/java/JavaClassWithEnumConstOnClasspathTest.java
@@ -79,7 +79,7 @@ public class JavaClassWithEnumConstOnClasspathTest
     @Test
     public void testJavaClassEnumCondition() throws IOException, InstantiationException, IllegalAccessException
     {
-        try (GraphContext context = factory.create(WindupTestUtilMethods.getTempDirectoryForGraph()))
+        try (GraphContext context = factory.create(WindupTestUtilMethods.getTempDirectoryForGraph(), true))
         {
             final String inputDir = "src/test/resources/org/jboss/windup/rules/enum";
 

--- a/rules-java/tests/src/test/java/org/jboss/windup/rules/java/JavaClassWithoutClassificationTest.java
+++ b/rules-java/tests/src/test/java/org/jboss/windup/rules/java/JavaClassWithoutClassificationTest.java
@@ -55,7 +55,7 @@ public class JavaClassWithoutClassificationTest
     @Test
     public void testJavaClassCondition() throws IOException, InstantiationException, IllegalAccessException
     {
-        try (GraphContext context = factory.create(getDefaultPath()))
+        try (GraphContext context = factory.create(getDefaultPath(), true))
         {
             final String inputDir = "src/test/resources/org/jboss/windup/rules/java";
 

--- a/rules-java/tests/src/test/java/org/jboss/windup/rules/java/JavaClassWithoutHintTest.java
+++ b/rules-java/tests/src/test/java/org/jboss/windup/rules/java/JavaClassWithoutHintTest.java
@@ -60,7 +60,7 @@ public class JavaClassWithoutHintTest
         FileUtils.deleteDirectory(outputPath.toFile());
         Files.createDirectories(outputPath);
 
-        try (GraphContext context = factory.create(outputPath))
+        try (GraphContext context = factory.create(outputPath, true))
         {
             final String inputDir = "src/test/resources/org/jboss/windup/rules/java";
 

--- a/rules-java/tests/src/test/java/org/jboss/windup/rules/java/JavaClassXmlRulesTest.java
+++ b/rules-java/tests/src/test/java/org/jboss/windup/rules/java/JavaClassXmlRulesTest.java
@@ -59,7 +59,7 @@ public class JavaClassXmlRulesTest
     @Test
     public void testJavaClassCondition() throws IOException, InstantiationException, IllegalAccessException
     {
-        try (GraphContext context = factory.create(getDefaultPath()))
+        try (GraphContext context = factory.create(getDefaultPath(), true))
         {
             final String inputDir = "src/test/resources/org/jboss/windup/rules/java";
 

--- a/rules-java/tests/src/test/java/org/jboss/windup/rules/java/JavaHintsClassificationsTest.java
+++ b/rules-java/tests/src/test/java/org/jboss/windup/rules/java/JavaHintsClassificationsTest.java
@@ -89,7 +89,7 @@ public class JavaHintsClassificationsTest
     public void testHintAndClassificationInvalidTitle() throws Exception
     {
         Path outputPath = null;
-        try (GraphContext context = factory.create())
+        try (GraphContext context = factory.create(true))
         {
             outputPath = runWindup(context);
 
@@ -124,7 +124,7 @@ public class JavaHintsClassificationsTest
     @Test
     public void testHintsAndClassificationOperation() throws Exception
     {
-        try (GraphContext context = factory.create())
+        try (GraphContext context = factory.create(true))
         {
             Path outputPath = null;
             try

--- a/rules-java/tests/src/test/java/org/jboss/windup/rules/java/SourceModeTest.java
+++ b/rules-java/tests/src/test/java/org/jboss/windup/rules/java/SourceModeTest.java
@@ -67,7 +67,7 @@ public class SourceModeTest
         final Path outputPath = Paths.get(FileUtils.getTempDirectory().toString(),
                     "windup_" + RandomStringUtils.randomAlphanumeric(6));
 
-        try (GraphContext context = factory.create(getDefaultPath()))
+        try (GraphContext context = factory.create(getDefaultPath(), true))
         {
             final WindupConfiguration processorConfig = new WindupConfiguration();
             processorConfig.setRuleProviderFilter(new RuleProviderWithDependenciesPredicate(
@@ -91,7 +91,7 @@ public class SourceModeTest
         final Path outputPath = Paths.get(FileUtils.getTempDirectory().toString(),
                     "windup_" + RandomStringUtils.randomAlphanumeric(6));
 
-        try (GraphContext context = factory.create(getDefaultPath()))
+        try (GraphContext context = factory.create(getDefaultPath(), true))
         {
             final WindupConfiguration processorConfig = new WindupConfiguration();
             processorConfig.setRuleProviderFilter(new RuleProviderWithDependenciesPredicate(
@@ -115,7 +115,7 @@ public class SourceModeTest
         final Path outputPath = Paths.get(FileUtils.getTempDirectory().toString(),
                     "windup_" + RandomStringUtils.randomAlphanumeric(6));
 
-        try (GraphContext context = factory.create(getDefaultPath()))
+        try (GraphContext context = factory.create(getDefaultPath(), true))
         {
             final WindupConfiguration processorConfig = new WindupConfiguration();
             processorConfig.setRuleProviderFilter(new RuleProviderWithDependenciesPredicate(

--- a/rules-java/tests/src/test/java/org/jboss/windup/rules/java/handlers/XMLTechnologyMetadataLoaderTest.java
+++ b/rules-java/tests/src/test/java/org/jboss/windup/rules/java/handlers/XMLTechnologyMetadataLoaderTest.java
@@ -66,7 +66,7 @@ public class XMLTechnologyMetadataLoaderTest
     @Test
     public void testMetadataLoad() throws Exception
     {
-        try (GraphContext context = graphContextFactory.create())
+        try (GraphContext context = graphContextFactory.create(true))
         {
             WindupConfigurationModel cfg = WindupConfigurationService.getConfigurationModel(context);
 

--- a/rules-java/tests/src/test/java/org/jboss/windup/rules/java/ignore/JavaIgnoreRegexesTest.java
+++ b/rules-java/tests/src/test/java/org/jboss/windup/rules/java/ignore/JavaIgnoreRegexesTest.java
@@ -88,7 +88,7 @@ public class JavaIgnoreRegexesTest
     @Test
     public void testHintsAndClassificationOperation() throws Exception
     {
-        try (GraphContext context = factory.create())
+        try (GraphContext context = factory.create(true))
         {
 
             Assert.assertNotNull(context);

--- a/rules-java/tests/src/test/java/org/jboss/windup/rules/java/ip/DiscoverHardcodedIPAddressTest.java
+++ b/rules-java/tests/src/test/java/org/jboss/windup/rules/java/ip/DiscoverHardcodedIPAddressTest.java
@@ -64,7 +64,7 @@ public class DiscoverHardcodedIPAddressTest
     @Test
     public void testStaticIPScanner() throws IOException, InstantiationException, IllegalAccessException
     {
-        try (GraphContext context = factory.create())
+        try (GraphContext context = factory.create(true))
         {
             Path inputPath = Paths.get("src/test/resources/staticip");
 

--- a/rules-xml/tests/src/test/java/org/jboss/windup/rules/apps/xml/groovy/GroovyExtensionXmlRulesTest.java
+++ b/rules-xml/tests/src/test/java/org/jboss/windup/rules/apps/xml/groovy/GroovyExtensionXmlRulesTest.java
@@ -71,7 +71,7 @@ public class GroovyExtensionXmlRulesTest
     @Test
     public void testHintsAndClassificationOperation() throws Exception
     {
-        try (GraphContext context = factory.create())
+        try (GraphContext context = factory.create(true))
         {
             ProjectModel pm = context.getFramed().addFramedVertex(ProjectModel.class);
             pm.setName("Main Project");

--- a/rules-xml/tests/src/test/java/org/jboss/windup/rules/apps/xml/operation/xslt/XSLTTransformationHandlerTest.java
+++ b/rules-xml/tests/src/test/java/org/jboss/windup/rules/apps/xml/operation/xslt/XSLTTransformationHandlerTest.java
@@ -132,7 +132,7 @@ public class XSLTTransformationHandlerTest
         Path outputPath = Paths.get(FileUtils.getTempDirectory().toString(), "Windup", "windup_"
                 + UUID.randomUUID().toString());
 
-        try (GraphContext context = factory.create())
+        try (GraphContext context = factory.create(true))
         {
             FileUtils.deleteDirectory(outputPath.toFile());
             Files.createDirectories(outputPath);

--- a/rules-xml/tests/src/test/java/org/jboss/windup/rules/apps/xml/rules/ValidateXmlFilesRuleProviderWithInternetTest.java
+++ b/rules-xml/tests/src/test/java/org/jboss/windup/rules/apps/xml/rules/ValidateXmlFilesRuleProviderWithInternetTest.java
@@ -69,7 +69,7 @@ public class ValidateXmlFilesRuleProviderWithInternetTest extends AbstractXsdVal
     @Test
     public void testNotValidXml() throws Exception
     {
-        try (GraphContext context = factory.create())
+        try (GraphContext context = factory.create(true))
         {
             initOnlineWindupConfiguration(context);
             addFileModel(context, NOT_VALID_XML);
@@ -94,7 +94,7 @@ public class ValidateXmlFilesRuleProviderWithInternetTest extends AbstractXsdVal
     @Test
     public void testNotValidXsdUrlAttribute() throws Exception
     {
-        try (GraphContext context = factory.create())
+        try (GraphContext context = factory.create(true))
         {
             initOnlineWindupConfiguration(context);
             addFileModel(context, NOT_VALID_XSD_SCHEMA_URL);
@@ -131,7 +131,7 @@ public class ValidateXmlFilesRuleProviderWithInternetTest extends AbstractXsdVal
     @Test
     public void testWithoutXsdUrlAttribute() throws Exception
     {
-        try (GraphContext context = factory.create())
+        try (GraphContext context = factory.create(true))
         {
             addFileModel(context, NO_XSD_SCHEMA_URL);
             initOnlineWindupConfiguration(context);
@@ -150,7 +150,7 @@ public class ValidateXmlFilesRuleProviderWithInternetTest extends AbstractXsdVal
     @Ignore // Ignoring for now as we are not currently running validation in offline mode
     public void testNotValidXmlInOfflineMode() throws Exception
     {
-        try (GraphContext context = factory.create())
+        try (GraphContext context = factory.create(true))
         {
             initOfflineWindupConfiguration(context);
             addFileModel(context, NOT_VALID_XML);
@@ -168,7 +168,7 @@ public class ValidateXmlFilesRuleProviderWithInternetTest extends AbstractXsdVal
     @Test
     public void testUnparsableUrl() throws Exception
     {
-        try (GraphContext context = factory.create())
+        try (GraphContext context = factory.create(true))
         {
             initOnlineWindupConfiguration(context);
             addFileModel(context, URL_NOT_PARSABLE);
@@ -201,7 +201,7 @@ public class ValidateXmlFilesRuleProviderWithInternetTest extends AbstractXsdVal
     @Test
     public void testMultipleSchemas() throws Exception
     {
-        try (GraphContext context = factory.create())
+        try (GraphContext context = factory.create(true))
         {
             initOnlineWindupConfiguration(context);
             addFileModel(context, URL_MULTIPLE_SCHEMAS);

--- a/rules-xml/tests/src/test/java/org/jboss/windup/rules/xml/XMLFileNestedConditionTest.java
+++ b/rules-xml/tests/src/test/java/org/jboss/windup/rules/xml/XMLFileNestedConditionTest.java
@@ -80,7 +80,7 @@ public class XMLFileNestedConditionTest
     @Test
     public void testNestedCondition() throws IOException
     {
-        try (GraphContext context = factory.create())
+        try (GraphContext context = factory.create(true))
         {
             ProjectModel pm = context.getFramed().addFramedVertex(ProjectModel.class);
             pm.setName("Main Project");

--- a/rules-xml/tests/src/test/java/org/jboss/windup/rules/xml/XMLFileWithoutClassification1Test.java
+++ b/rules-xml/tests/src/test/java/org/jboss/windup/rules/xml/XMLFileWithoutClassification1Test.java
@@ -59,7 +59,7 @@ public class XMLFileWithoutClassification1Test
     @Test
     public void testXSLTTransformation() throws IOException
     {
-        try (GraphContext context = factory.create())
+        try (GraphContext context = factory.create(true))
         {
             Path inputPath = Paths.get("src/test/resources/");
 

--- a/rules-xml/tests/src/test/java/org/jboss/windup/rules/xml/XMLFileWithoutClassification2Test.java
+++ b/rules-xml/tests/src/test/java/org/jboss/windup/rules/xml/XMLFileWithoutClassification2Test.java
@@ -59,7 +59,7 @@ public class XMLFileWithoutClassification2Test
     @Test
     public void testXmlFileWithoutClassification() throws IOException
     {
-        try (GraphContext context = factory.create())
+        try (GraphContext context = factory.create(true))
         {
             Path inputPath = Paths.get("src/test/resources/");
 

--- a/rules-xml/tests/src/test/java/org/jboss/windup/rules/xml/XMLHintsClassificationsTest.java
+++ b/rules-xml/tests/src/test/java/org/jboss/windup/rules/xml/XMLHintsClassificationsTest.java
@@ -81,7 +81,7 @@ public class XMLHintsClassificationsTest
     @Test
     public void testHintAndClassificationOperation() throws IOException
     {
-        try (GraphContext context = factory.create())
+        try (GraphContext context = factory.create(true))
         {
             ProjectModel pm = context.getFramed().addFramedVertex(ProjectModel.class);
             pm.setName("Main Project");

--- a/rules-xml/tests/src/test/java/org/jboss/windup/rules/xml/XMLTransformationTest.java
+++ b/rules-xml/tests/src/test/java/org/jboss/windup/rules/xml/XMLTransformationTest.java
@@ -80,7 +80,7 @@ public class XMLTransformationTest
     @Test
     public void testXSLTTransformation() throws IOException
     {
-        try (GraphContext context = factory.create())
+        try (GraphContext context = factory.create(true))
         {
             ProjectModel pm = context.getFramed().addFramedVertex(ProjectModel.class);
             pm.setName("Main Project");

--- a/rules-xml/tests/src/test/java/org/jboss/windup/rules/xml/XMLTransformationXMLRulesTest.java
+++ b/rules-xml/tests/src/test/java/org/jboss/windup/rules/xml/XMLTransformationXMLRulesTest.java
@@ -69,7 +69,7 @@ public class XMLTransformationXMLRulesTest
     @Test
     public void testXSLTTransformation() throws IOException
     {
-        try (GraphContext context = factory.create())
+        try (GraphContext context = factory.create(true))
         {
             ProjectModel pm = context.getFramed().addFramedVertex(ProjectModel.class);
             pm.setName("Main Project");

--- a/rules-xml/tests/src/test/java/org/jboss/windup/rules/xml/XmlAndJavaParameterizedTest.java
+++ b/rules-xml/tests/src/test/java/org/jboss/windup/rules/xml/XmlAndJavaParameterizedTest.java
@@ -83,7 +83,7 @@ public class XmlAndJavaParameterizedTest
     @Test
     public void testXmlAndJavaSearchParams() throws IOException
     {
-        try (GraphContext context = factory.create())
+        try (GraphContext context = factory.create(true))
         {
             ProjectModel pm = context.getFramed().addFramedVertex(ProjectModel.class);
             pm.setName("Main Project");

--- a/rules-xml/tests/src/test/java/org/jboss/windup/rules/xml/XmlFileDtdNamespaceTest.java
+++ b/rules-xml/tests/src/test/java/org/jboss/windup/rules/xml/XmlFileDtdNamespaceTest.java
@@ -67,7 +67,7 @@ public class XmlFileDtdNamespaceTest
     public void testRuleProviders() throws Exception
     {
         final Path folder = OperatingSystemUtils.createTempDir().toPath();
-        try (final GraphContext context = factory.create(folder))
+        try (final GraphContext context = factory.create(folder, true))
         {
             initData(context);
             List<RuleProvider> providers = new ArrayList<>();

--- a/rules-xml/tests/src/test/java/org/jboss/windup/rules/xml/XmlFileLongXpathTest.java
+++ b/rules-xml/tests/src/test/java/org/jboss/windup/rules/xml/XmlFileLongXpathTest.java
@@ -74,7 +74,7 @@ public class XmlFileLongXpathTest
     @Test
     public void test() throws IOException
     {
-        try (GraphContext context = factory.create())
+        try (GraphContext context = factory.create(true))
         {
             ProjectModel pm = context.getFramed().addFramedVertex(ProjectModel.class);
             pm.setName("Main Project");

--- a/rules-xml/tests/src/test/java/org/jboss/windup/rules/xml/XmlFileMultipleConditionTest.java
+++ b/rules-xml/tests/src/test/java/org/jboss/windup/rules/xml/XmlFileMultipleConditionTest.java
@@ -75,7 +75,7 @@ public class XmlFileMultipleConditionTest
     @Test
     public void testNestedCondition() throws IOException
     {
-        try (GraphContext context = factory.create())
+        try (GraphContext context = factory.create(true))
         {
             ProjectModel pm = context.getFramed().addFramedVertex(ProjectModel.class);
             pm.setName("Main Project");

--- a/rules-xml/tests/src/test/java/org/jboss/windup/rules/xml/XmlFileParameterizedTest.java
+++ b/rules-xml/tests/src/test/java/org/jboss/windup/rules/xml/XmlFileParameterizedTest.java
@@ -214,7 +214,7 @@ public class XmlFileParameterizedTest
 
     public void _doTestXmlParams(ResultValidator validator) throws IOException
     {
-        try (GraphContext context = factory.create())
+        try (GraphContext context = factory.create(true))
         {
             ProjectModel pm = context.getFramed().addFramedVertex(ProjectModel.class);
             pm.setName("Main Project");

--- a/tests/src/test/java/org/jboss/windup/tests/application/GraphServiceLookupTest.java
+++ b/tests/src/test/java/org/jboss/windup/tests/application/GraphServiceLookupTest.java
@@ -45,7 +45,7 @@ public class GraphServiceLookupTest
     @Test
     public void testServiceLookup() throws Exception
     {
-        try (GraphContext graphContext = factory.create())
+        try (GraphContext graphContext = factory.create(true))
         {
             Assert.assertNotNull(graphContext);
 

--- a/tests/src/test/java/org/jboss/windup/tests/application/WindupArchitectureTest.java
+++ b/tests/src/test/java/org/jboss/windup/tests/application/WindupArchitectureTest.java
@@ -77,7 +77,7 @@ public abstract class WindupArchitectureTest
 
     GraphContext createGraphContext(Path path)
     {
-        return factory.create(path);
+        return factory.create(path, true);
     }
 
     protected void runTest(String inputPath, boolean sourceMode) throws Exception

--- a/tooling/impl/src/main/java/org/jboss/windup/tooling/ExecutionBuilderImpl.java
+++ b/tooling/impl/src/main/java/org/jboss/windup/tooling/ExecutionBuilderImpl.java
@@ -251,7 +251,7 @@ public class ExecutionBuilderImpl implements ExecutionBuilder
             globalLogger.addHandler(loggingHandler);
         }
 
-        try (final GraphContext graphContext = graphContextFactory.create(graphPath))
+        try (final GraphContext graphContext = graphContextFactory.create(graphPath, true))
         {
 
             GraphService<IgnoredFileRegexModel> graphService = new GraphService<>(graphContext, IgnoredFileRegexModel.class);

--- a/ui/addon/src/main/java/org/jboss/windup/ui/WindupCommand.java
+++ b/ui/addon/src/main/java/org/jboss/windup/ui/WindupCommand.java
@@ -236,7 +236,7 @@ public class WindupCommand implements UICommand
 
         FileUtils.deleteQuietly(windupConfiguration.getOutputDirectory().toFile());
         Path graphPath = windupConfiguration.getOutputDirectory().resolve("graph");
-        try (GraphContext graphContext = graphContextFactory.create(graphPath))
+        try (GraphContext graphContext = graphContextFactory.create(graphPath, true))
         {
             context.getUIContext().getAttributeMap().put(GraphContext.class, graphContext);
             UIProgressMonitor uiProgressMonitor = context.getProgressMonitor();


### PR DESCRIPTION
Despite this PR appearing massive, it really only does a couple of things:
 - enable graphcontextfactory to track all graphs that it has opened and to closeAll for any open graphs
- Make GraphContextFactory clients explicitly specify whether they want graph listeners. At the moment, only one graph at a time can have these, but we also only use them on analysis graphs during analysis. So everything else should say "false".