### PR TITLE
add mapping for Logging to tech report boxes on UI

### DIFF
--- a/reporting/impl/src/main/resources/org/jboss/windup/reporting/rules/generation/techreport/techReport-hierarchy.tags.xml
+++ b/reporting/impl/src/main/resources/org/jboss/windup/reporting/rules/generation/techreport/techReport-hierarchy.tags.xml
@@ -171,6 +171,7 @@
             <tag pseudo="true" name="place:Integration" title="Integration" parents="techBox:Integration"/>
             <tag pseudo="true" name="place:Inversion of Control" title="Inversion of Control" parents="techBox:ioc"/>
             <tag pseudo="true" name="place:JSON-P" title="JSON-P" parents="techBox:Processing"/> <!-- Not a box? WINDUPRULE-296 -->
+            <tag pseudo="true" name="place:Logging" title="Logging" parents="techBox:Logging"/>
             <tag pseudo="true" name="place:Markup" title="Markup" parents="techBox:Markup"/>
             <tag pseudo="true" name="place:Messaging" title="Messaging" parents="techBox:Messaging"/>
             <tag pseudo="true" name="place:MVC" title="MVC" parents="techBox:mvc"/>


### PR DESCRIPTION
This fixes the missing mapping for logging which results, without the fix, in non-rendering reports if a rule for logging is added.
Attached are the screenshots from my local test on that branch.
![report_2](https://user-images.githubusercontent.com/1665338/39548080-c1f7a7e4-4e59-11e8-8a14-86ee09a59615.png)
![report_1](https://user-images.githubusercontent.com/1665338/39548081-c21efbc8-4e59-11e8-9db2-d60500713368.png)
