### PR TITLE
WINDUP-961: Create a link to the source report for unparsable files, …

### DIFF
--- a/rules-java/api/src/main/resources/reports/templates/unparsable_files.ftl
+++ b/rules-java/api/src/main/resources/reports/templates/unparsable_files.ftl
@@ -12,9 +12,20 @@
         </div>
         <table class="table unparsableFiles">
             <#items as file>
+            <#assign sourceReportModel = fileModelToSourceReport(file)!>
             <tr>
                 <td>
-                    <div><strong>${file.fileName!}</strong> <span>${file.filePath!}</span></div>
+                    <div>
+                        <#if sourceReportModel.reportFilename?? >
+                            <a href="${sourceReportModel.reportFilename}?project=${reportModel.projectModel.getElement().id()?c}">
+                                <strong>${file.fileName!}</strong>
+                                <span>${file.filePath!}</span>
+                            </a>
+                        <#else>
+                            <strong>${file.fileName!}</strong>
+                            <span>${file.filePath!}</span>
+                        </#if>
+                    </div>
                     <#if file.expectedFormat?has_content>
                     <div><strong>Expected format:</strong> ${file.expectedFormat!}</div>
                     </#if>


### PR DESCRIPTION
…if a report was generated. When there is no report, the file will likely no longer exist on disk.

https://issues.jboss.org/browse/WINDUP-961
