### PR TITLE
change techReport-boxes font-sizes to be more consistent with the other reports

### DIFF
--- a/reporting/impl/src/main/resources/reports/templates/techReport-boxes.ftl
+++ b/reporting/impl/src/main/resources/reports/templates/techReport-boxes.ftl
@@ -52,7 +52,7 @@
         tr.rowSectors > td  > div.box { padding: 8pt 18pt 8pt 12pt; margin-bottom: 10pt; }
         tr.rowSectors > td  > div.box > h4 { font-size: 12pt; font-weight: bold; }
 
-        tr.rowSectors .box h4  { font-size: 12px; font-weight: bold; text-align: right; }
+        tr.rowSectors .box h4  { font-size: 12pt; font-weight: bold; text-align: right; }
         tr.rowSectors .box ul li  { font-size: 12px; }
 
         tr.rowSectors .box .icon {

--- a/reporting/impl/src/main/resources/reports/templates/techReport-boxes.ftl
+++ b/reporting/impl/src/main/resources/reports/templates/techReport-boxes.ftl
@@ -39,13 +39,13 @@
         }
 
         /* Sector headers */
-        tr.sectorsHeaders { font-size: 22pt; font-weight: bold; }
+        tr.sectorsHeaders { font-size: 20pt; font-weight: bold; }
         tr.sectorsHeaders > td { text-align: center; padding: 10pt 20pt 0; } /* Around the sector header box. */
         tr.rowSectors > td { padding: 2ex 2em; }
         tr.sectorsHeaders > td div { text-align: center; padding: 1ex 2em; }
 
         /* Partitions = gray areas */
-        tr.rowHeader { font-size: 18pt; font-weight: bold; }
+        tr.rowHeader { font-size: 14pt; font-weight: bold; }
         tr.rowHeader > td > div { background-color: #D9D9D9; padding: 1ex 20pt 0; margin-top: 18pt; }
         /*tr.rowHeader td,*/
         tr.rowSectors > td { background-color: #D9D9D9; padding: 1ex 2em; vertical-align: top; }

--- a/reporting/impl/src/main/resources/reports/templates/techReport-boxes.ftl
+++ b/reporting/impl/src/main/resources/reports/templates/techReport-boxes.ftl
@@ -52,8 +52,8 @@
         tr.rowSectors > td  > div.box { padding: 8pt 18pt 8pt 12pt; margin-bottom: 10pt; }
         tr.rowSectors > td  > div.box > h4 { font-size: 12pt; font-weight: bold; }
 
-        tr.rowSectors .box h4  { font-size: 12pt; font-weight: bold; text-align: right; }
-        tr.rowSectors .box ul li  { font-size: 12pt; }
+        tr.rowSectors .box h4  { font-size: 12px; font-weight: bold; text-align: right; }
+        tr.rowSectors .box ul li  { font-size: 12px; }
 
         tr.rowSectors .box .icon {
             float: left;


### PR DESCRIPTION
The tech report boxes use a different font size (12pt) than for instance the Issues page (12px).
I kept the headers for the boxes at 12pt.

This led to too early line breaks in the tech boxes (as browser window is maximised with a 15" screen), since the 12pt got rendered on my current test box as 16px - plus it's not really consistent.

While being there I did very minor changes to the font sizes of the JavaEE /Embedded text (they now match the size of e.g. "Migration Mandatory"on the issues page) and the text for the tiers (Connect, Sustain, etc. - they now match the size in the bubble map) - it's not perfect, but it's more consistent now.

Of course, when minimising the browser window, this will happen eventually, but higher consistency plus lesser line breaks on "standard screens" is probably a good thing to have.

before:
<img width="1919" alt="screen shot 2018-06-08 at 20 50 27" src="https://user-images.githubusercontent.com/1665338/41183483-212332ea-6b7b-11e8-8a0b-f5c9cbb31b2b.png">


Note here the cassandra client or the ocpsoft logging utils where you can see the issue.

after:
<img width="1917" alt="screen shot 2018-06-09 at 00 49 01" src="https://user-images.githubusercontent.com/1665338/41184237-54aa6cd8-6b7f-11e8-85bb-23e925483cb1.png">


I tested the changes on Mac (Safari, Chrome, Firefox), Linux (Firefox, Chrome) and Windows (Edge, Chrome, Firefox).
