### PR TITLE
Fixed a case where the fileservice doesn't behave well if a filemodel…

### DIFF
--- a/graph/api/src/main/java/org/jboss/windup/graph/service/FileService.java
+++ b/graph/api/src/main/java/org/jboss/windup/graph/service/FileService.java
@@ -12,7 +12,6 @@ import org.jboss.windup.graph.GraphContext;
 import org.jboss.windup.graph.TitanUtil;
 import org.jboss.windup.graph.frames.FramedVertexIterable;
 import org.jboss.windup.graph.model.WindupFrame;
-import org.jboss.windup.graph.model.WindupVertexFrame;
 import org.jboss.windup.graph.model.resource.FileModel;
 import org.jboss.windup.util.ExecutionStatistics;
 
@@ -39,6 +38,12 @@ public class FileService extends GraphService<FileModel>
         {
             entry = this.create();
             entry.setFilePath(absolutePath);
+            entry.setParentFile(parentFile);
+        }
+
+        if (entry.getParentFile() == null && parentFile != null)
+        {
+            // Deal with an odd corner case, that probably only happens in my test environment.
             entry.setParentFile(parentFile);
         }
 


### PR DESCRIPTION
… entry was precreated.

This really only occurs in odd ege cases. For example, if you were to analyze a source directory which contained a user rules directory. The configuration would create FileModels
for the rules directory, which would later be reused, but their parents wouldn't be setup correctly.