### PR TITLE
WINDUP-2101 Adding missing classifier to windup-server-provider-spi artifact

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -161,6 +161,7 @@
             <dependency>
                 <groupId>org.jboss.windup</groupId>
                 <artifactId>windup-server-provider-spi</artifactId>
+                <classifier>forge-addon</classifier>
                 <version>${project.version}</version>
             </dependency>
 

--- a/bootstrap/pom.xml
+++ b/bootstrap/pom.xml
@@ -23,6 +23,7 @@
         <dependency>
             <groupId>org.jboss.windup</groupId>
             <artifactId>windup-server-provider-spi</artifactId>
+            <classifier>forge-addon</classifier>
         </dependency>
         <dependency>
             <groupId>org.jboss.windup.config</groupId>


### PR DESCRIPTION
The `<classifier>forge-addon</classifier>` was missing for `windup-server-provider-spi` artifact and adding it should avoid any need for providing the [`windup-server-provider-spi` version](https://github.com/windup/windup-web/blob/master/addons/messaging-executor/addon/pom.xml#L30) during the release process (this causes a failure during automatic release).