### PR TITLE
WINDUP-2237 Fix the exception during graph generation

### DIFF
--- a/reporting/impl/src/main/java/org/jboss/windup/reporting/freemarker/Sha1HexMethod.java
+++ b/reporting/impl/src/main/java/org/jboss/windup/reporting/freemarker/Sha1HexMethod.java
@@ -1,0 +1,50 @@
+package org.jboss.windup.reporting.freemarker;
+
+import java.util.List;
+
+import freemarker.ext.beans.StringModel;
+import org.apache.commons.codec.digest.DigestUtils;
+import org.jboss.windup.config.GraphRewrite;
+
+import freemarker.template.TemplateModelException;
+import org.jboss.windup.graph.model.resource.FileModel;
+
+/**
+ * Returns the SHA1 Hex hash for the provided {@link FileModel}.<br/>
+ * 
+ * sha1Hex(FileModel):String
+ *
+ */
+public class Sha1HexMethod implements WindupFreeMarkerMethod
+{
+    @Override
+    public String exec(@SuppressWarnings("rawtypes") List arguments) throws TemplateModelException
+    {
+        if (arguments.size() != 1)
+        {
+            throw new TemplateModelException(
+                        "Error, method expects one argument (FileModel)");
+        }
+        StringModel stringModel = (StringModel) arguments.get(0);
+        FileModel fileModel = (FileModel) stringModel.getWrappedObject();
+        return !fileModel.isDirectory() ? fileModel.getSHA1Hash() : DigestUtils.sha1Hex(fileModel.getFileName());
+    }
+
+    @Override
+    public String getMethodName()
+    {
+        return "sha1Hex";
+    }
+
+    @Override
+    public String getDescription()
+    {
+        return "Returns the SHA1 Hex hash for the provided " + FileModel.class.getSimpleName() + ".";
+    }
+
+    @Override
+    public void setContext(GraphRewrite event)
+    {
+
+    }
+}

--- a/reporting/impl/src/main/resources/reports/templates/dependency_graph.ftl
+++ b/reporting/impl/src/main/resources/reports/templates/dependency_graph.ftl
@@ -132,7 +132,7 @@
             </svg>
         <script src="resources/js/app-dependency-graph.js"></script>
         <#if reportModel.projectModel??>
-        <script src="data/${reportModel.projectModel.rootFileModel.SHA1Hash}_app_dependencies_graph.js"></script>
+        <script src="data/${sha1Hex(reportModel.projectModel.rootFileModel)}_app_dependencies_graph.js"></script>
         <#else>
         <script src="data/app_dependencies_graph.js"></script>
         </#if>

--- a/rules-java/api/pom.xml
+++ b/rules-java/api/pom.xml
@@ -123,6 +123,12 @@
             <classifier>forge-addon</classifier>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.jboss.windup.exec</groupId>
+            <artifactId>windup-exec</artifactId>
+            <classifier>forge-addon</classifier>
+            <scope>provided</scope>
+        </dependency>
 
         <!-- Furnace Container -->
         <dependency>

--- a/rules-java/api/src/main/java/org/jboss/windup/rules/apps/java/reporting/freemarker/dto/DependencyGraphItem.java
+++ b/rules-java/api/src/main/java/org/jboss/windup/rules/apps/java/reporting/freemarker/dto/DependencyGraphItem.java
@@ -61,7 +61,15 @@ public class DependencyGraphItem
          String projectType;
          if (projectModel.getProjectType() == null)
          {
-            projectType = FilenameUtils.getExtension(projectModel.getRootFileModel().getFileName());
+            if (!projectModel.getRootFileModel().isDirectory())
+            {
+               projectType = FilenameUtils.getExtension(projectModel.getRootFileModel().getFileName());
+            }
+            // if we're analyzing an exploded app we have a directory
+            else
+            {
+               projectType = "war";
+            }
          }
          else
          {

--- a/rules-java/api/src/main/java/org/jboss/windup/rules/apps/java/reporting/rules/CreateDependencyGraphDataRuleProvider.java
+++ b/rules-java/api/src/main/java/org/jboss/windup/rules/apps/java/reporting/rules/CreateDependencyGraphDataRuleProvider.java
@@ -16,6 +16,7 @@ import org.jboss.windup.graph.model.ProjectModel;
 import org.jboss.windup.graph.model.resource.FileModel;
 import org.jboss.windup.graph.service.WindupConfigurationService;
 import org.jboss.windup.reporting.service.ReportService;
+import org.jboss.windup.exec.configuration.options.ExplodedAppInputOption;
 import org.jboss.windup.rules.apps.java.condition.SourceMode;
 import org.jboss.windup.rules.apps.java.dependencyreport.DependenciesReportModel;
 import org.jboss.windup.rules.apps.java.dependencyreport.DependencyReportDependencyGroupModel;
@@ -122,7 +123,7 @@ public class CreateDependencyGraphDataRuleProvider extends AbstractRuleProvider
                {
                   targetFileModel = dependencyReportToArchiveEdgeModel.getArchive().getRootArchiveModel();
                   if (dependencyReportToArchiveEdgeModel.getArchive().equals(targetFileModel) &&
-                           (Boolean) event.getGraphContext().getOptionMap().getOrDefault("explodedApp", Boolean.FALSE)
+                           (Boolean) event.getGraphContext().getOptionMap().getOrDefault(ExplodedAppInputOption.NAME, Boolean.FALSE)
                            && application != null)
                   {
                      targetFileModel = application.getRootFileModel();

--- a/rules-java/api/src/main/java/org/jboss/windup/rules/apps/java/reporting/rules/CreateDependencyGraphDataRuleProvider.java
+++ b/rules-java/api/src/main/java/org/jboss/windup/rules/apps/java/reporting/rules/CreateDependencyGraphDataRuleProvider.java
@@ -72,7 +72,7 @@ public class CreateDependencyGraphDataRuleProvider extends AbstractRuleProvider
       dependenciesReportModels.stream().forEach(dependenciesReportModel -> {
          ProjectModel application = dependenciesReportModel.getProjectModel();
 
-         // in case of shared libraries ("virtual" project) we don not
+         // in case of shared libraries ("virtual" project) we do not
          // generate the dependency graph
          if (application != null && ProjectModel.TYPE_VIRTUAL.equals(application.getProjectType()))
             return;

--- a/tests/src/test/java/org/jboss/windup/tests/application/WindupArchitectureDuplicateTest.java
+++ b/tests/src/test/java/org/jboss/windup/tests/application/WindupArchitectureDuplicateTest.java
@@ -21,7 +21,6 @@ import org.jboss.windup.reporting.rules.CreateApplicationListReportRuleProvider;
 import org.jboss.windup.reporting.service.ReportService;
 import org.jboss.windup.rules.apps.java.dependencyreport.CreateDependencyReportRuleProvider;
 import org.jboss.windup.rules.apps.java.model.JavaApplicationOverviewReportModel;
-import org.jboss.windup.rules.apps.java.reporting.rules.CreateDependencyGraphReportRuleProvider;
 import org.jboss.windup.rules.apps.java.reporting.rules.CreateReportIndexRuleProvider;
 import org.jboss.windup.testutil.html.CheckFailedException;
 import org.jboss.windup.testutil.html.TestApplicationListUtil;
@@ -213,7 +212,7 @@ public class WindupArchitectureDuplicateTest extends WindupArchitectureTest
 
     private void validateJarDependencyGraphReport(GraphContext graphContext)
     {
-        Path dependencyReport = getDependencyGraphReportPath(graphContext);
+        Path dependencyReport = getGlobalDependencyGraphReportPath(graphContext);
         Assert.assertNotNull(dependencyReport);
         TestDependencyGraphReportUtil dependencyGraphReportUtil = new TestDependencyGraphReportUtil();
         dependencyGraphReportUtil.loadPage(dependencyReport);
@@ -303,21 +302,4 @@ public class WindupArchitectureDuplicateTest extends WindupArchitectureTest
         return null;
     }
 
-    private Path getDependencyGraphReportPath(GraphContext graphContext)
-    {
-        Service<ApplicationReportModel> service = graphContext.service(ApplicationReportModel.class);
-        Iterable<ApplicationReportModel> reports = service.findAllByProperty(ReportModel.TEMPLATE_PATH,
-                CreateDependencyGraphReportRuleProvider.TEMPLATE);
-        for (ApplicationReportModel report : reports)
-        {
-            if ("dependency_graph_report_global.html".equals(report.getReportFilename()))
-                return getPathForReport(graphContext, report);
-        }
-        return null;
-    }
-
-    private Path getPathForReport(GraphContext graphContext, ReportModel report)
-    {
-        return new ReportService(graphContext).getReportDirectory().resolve(report.getReportFilename());
-    }
 }

--- a/tests/src/test/java/org/jboss/windup/tests/application/WindupArchitectureExplodedAppTest.java
+++ b/tests/src/test/java/org/jboss/windup/tests/application/WindupArchitectureExplodedAppTest.java
@@ -57,7 +57,7 @@ public class WindupArchitectureExplodedAppTest extends WindupArchitectureTest
     {
         tmp.create();
         final File explodedAppDir = tmp.newFolder(EXPLODED_APP_DIR);
-        ZipUtil.unzipToFolder(new File("../test-files/Windup1x-javaee-example-tiny.war"), explodedAppDir);
+        ZipUtil.unzipToFolder(new File("../test-files/spring-small-example.war"), explodedAppDir);
 
         final Path outputPath = getDefaultPath();
         try (GraphContext context = createGraphContext(outputPath))
@@ -80,6 +80,11 @@ public class WindupArchitectureExplodedAppTest extends WindupArchitectureTest
         Assert.assertNotNull(dependencyReport);
         TestDependencyGraphReportUtil dependencyGraphReportUtil = new TestDependencyGraphReportUtil();
         dependencyGraphReportUtil.loadPage(dependencyReport);
+        Assert.assertEquals(21, dependencyGraphReportUtil.getNumberOfArchivesInTheGraph());
         Assert.assertEquals(1, dependencyGraphReportUtil.getNumberOfArchivesInTheGraphByName(EXPLODED_APP_DIR));
+        Assert.assertEquals(1, dependencyGraphReportUtil.getNumberOfArchivesInTheGraphByName("commons-logging-1.1.1.jar"));
+        Assert.assertEquals(1, dependencyGraphReportUtil.getNumberOfArchivesInTheGraphByName("standard-1.1.2.jar"));
+        Assert.assertEquals(15, dependencyGraphReportUtil.getNumberOfRelationsInTheGraph());
+
     }
 }

--- a/tests/src/test/java/org/jboss/windup/tests/application/WindupArchitectureExplodedAppTest.java
+++ b/tests/src/test/java/org/jboss/windup/tests/application/WindupArchitectureExplodedAppTest.java
@@ -1,0 +1,85 @@
+package org.jboss.windup.tests.application;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.forge.arquillian.AddonDependencies;
+import org.jboss.forge.arquillian.AddonDependency;
+import org.jboss.forge.arquillian.archive.AddonArchive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.windup.exec.configuration.options.ExplodedAppInputOption;
+import org.jboss.windup.graph.GraphContext;
+import org.jboss.windup.testutil.html.TestDependencyGraphReportUtil;
+import org.jboss.windup.util.ZipUtil;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+
+/**
+ * @author <a href="mailto:marcorizzi82@gmail.com">Marco Rizzi</a>
+ */
+@RunWith(Arquillian.class)
+public class WindupArchitectureExplodedAppTest extends WindupArchitectureTest
+{
+
+    final TemporaryFolder tmp = new TemporaryFolder();
+    private static final String EXPLODED_APP_DIR = "exploded-app-directory";
+
+    @Deployment
+    @AddonDependencies({
+                @AddonDependency(name = "org.jboss.windup.graph:windup-graph"),
+                @AddonDependency(name = "org.jboss.windup.reporting:windup-reporting"),
+                @AddonDependency(name = "org.jboss.windup.exec:windup-exec"),
+                @AddonDependency(name = "org.jboss.windup.rules.apps:windup-rules-java"),
+                @AddonDependency(name = "org.jboss.windup.rules.apps:windup-rules-java-ee"),
+                @AddonDependency(name = "org.jboss.windup.rules.apps:windup-rules-tattletale"),
+                @AddonDependency(name = "org.jboss.windup.utils:windup-utils"),
+                @AddonDependency(name = "org.jboss.windup.tests:test-util"),
+                @AddonDependency(name = "org.jboss.windup.config:windup-config-groovy"),
+                @AddonDependency(name = "org.jboss.forge.furnace.container:cdi"),
+    })
+    public static AddonArchive getDeployment()
+    {
+        return ShrinkWrap.create(AddonArchive.class)
+                    .addBeansXML()
+                    .addClass(WindupArchitectureTest.class)
+                    .addAsResource(new File("src/test/groovy/GroovyExampleRule.windup.groovy"));
+    }
+
+    @Test
+    public void testRunWindupExplodedApp() throws Exception
+    {
+        tmp.create();
+        final File explodedAppDir = tmp.newFolder(EXPLODED_APP_DIR);
+        ZipUtil.unzipToFolder(new File("../test-files/Windup1x-javaee-example-tiny.war"), explodedAppDir);
+
+        final Path outputPath = getDefaultPath();
+        try (GraphContext context = createGraphContext(outputPath))
+        {
+            Map<String, Object> explodedAppOption = new HashMap<>();
+            explodedAppOption.put(ExplodedAppInputOption.NAME, true);
+            super.runTest(context, Collections.singletonList(explodedAppDir.toString()), null, false, Collections.emptyList(),
+                        Collections.emptyList(), explodedAppOption);
+            validateJarDependencyGraphReport(context);
+        }
+        finally
+        {
+            tmp.delete();
+        }
+    }
+
+    private void validateJarDependencyGraphReport(GraphContext graphContext)
+    {
+        Path dependencyReport = getApplicationDependencyGraphReportPath(graphContext);
+        Assert.assertNotNull(dependencyReport);
+        TestDependencyGraphReportUtil dependencyGraphReportUtil = new TestDependencyGraphReportUtil();
+        dependencyGraphReportUtil.loadPage(dependencyReport);
+        Assert.assertEquals(1, dependencyGraphReportUtil.getNumberOfArchivesInTheGraphByName(EXPLODED_APP_DIR));
+    }
+}

--- a/tests/src/test/java/org/jboss/windup/tests/application/WindupArchitectureTest.java
+++ b/tests/src/test/java/org/jboss/windup/tests/application/WindupArchitectureTest.java
@@ -24,6 +24,7 @@ import org.jboss.windup.graph.GraphContext;
 import org.jboss.windup.graph.GraphContextFactory;
 import org.jboss.windup.graph.model.ProjectModel;
 import org.jboss.windup.graph.service.GraphService;
+import org.jboss.windup.graph.service.Service;
 import org.jboss.windup.reporting.model.ApplicationReportModel;
 import org.jboss.windup.reporting.model.MigrationIssuesReportModel;
 import org.jboss.windup.reporting.model.ReportModel;
@@ -34,6 +35,7 @@ import org.jboss.windup.rules.apps.java.config.SourceModeOption;
 import org.jboss.windup.rules.apps.java.dependencyreport.CreateDependencyReportRuleProvider;
 import org.jboss.windup.rules.apps.java.model.JavaApplicationOverviewReportModel;
 import org.jboss.windup.rules.apps.java.model.JavaClassFileModel;
+import org.jboss.windup.rules.apps.java.reporting.rules.CreateDependencyGraphReportRuleProvider;
 import org.jboss.windup.rules.apps.java.reporting.rules.CreateJavaApplicationOverviewReportRuleProvider;
 import org.jboss.windup.rules.apps.java.reporting.rules.EnableCompatibleFilesReportOption;
 import org.jboss.windup.rules.apps.tattletale.DisableTattletaleReportOption;
@@ -299,7 +301,33 @@ public abstract class WindupArchitectureTest
 
     }
 
+    Path getPathForReport(GraphContext graphContext, ReportModel report)
+    {
+        return new ReportService(graphContext).getReportDirectory().resolve(report.getReportFilename());
+    }
 
+    Path getGlobalDependencyGraphReportPath(GraphContext graphContext)
+    {
+        return getDependencyGraphReportPath (graphContext,"dependency_graph_report_global.html");
+    }
+
+    Path getApplicationDependencyGraphReportPath(GraphContext graphContext)
+    {
+        return getDependencyGraphReportPath (graphContext,"dependency_graph_report.html");
+    }
+
+    private Path getDependencyGraphReportPath(GraphContext graphContext, String reportFilename)
+    {
+        Service<ApplicationReportModel> service = graphContext.service(ApplicationReportModel.class);
+        Iterable<ApplicationReportModel> reports = service.findAllByProperty(ReportModel.TEMPLATE_PATH,
+                CreateDependencyGraphReportRuleProvider.TEMPLATE);
+        for (ApplicationReportModel report : reports)
+        {
+            if (reportFilename.equals(report.getReportFilename()))
+                return getPathForReport(graphContext, report);
+        }
+        return null;
+    }
 
     /**
      * Stores the info about incoming calls which the tests can review.


### PR DESCRIPTION
https://issues.jboss.org/browse/WINDUP-2237
- fixes the exception during the dependency graph report generation
- adds a node in the graph for the exploded application (considered as a WAR archive)
- adds the test for the dependency graph generation for the  `--explodedApp` use case
