### PR TITLE
WINDUP-2179: summary and detail tech report count discrepancy

### DIFF
--- a/reporting/impl/src/main/java/org/jboss/windup/reporting/rules/generation/techreport/TechReportService.java
+++ b/reporting/impl/src/main/java/org/jboss/windup/reporting/rules/generation/techreport/TechReportService.java
@@ -167,9 +167,9 @@ public class TechReportService
     /**
      * Prepares a precomputed matrix - map of maps of maps: rowTag -> boxTag -> project -> placement label -> TechUsageStatSum.
      *
-     * @param onlyForApplication Sum the statistics only for this project.
+     * @param appBeingSummarized Sum the statistics only for this project.
      */
-    public TechStatsMatrix getTechStatsMap(ProjectModel onlyForApplication)
+    public TechStatsMatrix getTechStatsMap(ProjectModel appBeingSummarized)
     {
 
         Map<String, Map<String, Map<Long, Map<String, TechUsageStatSum>>>> map = new HashMap<>();
@@ -177,11 +177,11 @@ public class TechReportService
         final Iterable<TechnologyUsageStatisticsModel> statModels = graphContext.service(TechnologyUsageStatisticsModel.class).findAll();
         for (TechnologyUsageStatisticsModel stat : statModels)
         {
-            // A shortcut.
-            if (onlyForApplication != null &&
-                    (!stat.getProjectModel().getApplications().contains(onlyForApplication)
+            //If a stat doesn't apply to this project we move on to the next stat without further processing
+            if (appBeingSummarized != null &&
+                    (!stat.getProjectModel().getApplications().contains(appBeingSummarized)
                     || (stat.getProjectModel().getApplications().size() > 1
-                            && !onlyForApplication.getName().toLowerCase().contains("shared"))))
+                            && !appBeingSummarized.getName().toLowerCase().contains("shared"))))
             {
                 LOG.fine("\t\tThis stat is not for this project, skipping.");
                 continue;
@@ -209,7 +209,7 @@ public class TechReportService
             mergeToTheRightCell(map, "", placement.box.getName(), 0L, "", stat, true);
 
             List<Long> appsToCountTowards;
-            if (onlyForApplication == null)
+            if (appBeingSummarized == null)
             {
                 appsToCountTowards = StreamSupport.stream(stat.getProjectModel().getApplications().spliterator(), false)
                             .map(ProjectModel::getElement)
@@ -219,7 +219,7 @@ public class TechReportService
             }
             else
             {
-                appsToCountTowards = Collections.singletonList(onlyForApplication.getId());
+                appsToCountTowards = Collections.singletonList(appBeingSummarized.getId());
             }
 
             boolean isSharedApp = appsToCountTowards.size() > 1;

--- a/reporting/impl/src/main/java/org/jboss/windup/reporting/rules/generation/techreport/TechReportService.java
+++ b/reporting/impl/src/main/java/org/jboss/windup/reporting/rules/generation/techreport/TechReportService.java
@@ -180,7 +180,7 @@ public class TechReportService
         for (TechnologyUsageStatisticsModel stat : statModels)
         {
             // A shortcut.
-            if (applicationProjects != null && !applicationProjects.contains(stat.getProjectModel()))
+            if (onlyForApplication != null && !stat.getProjectModel().getApplications().contains(onlyForApplication))
             {
                 LOG.fine("\t\tThis stat is not for this project, skipping.");
                 continue;

--- a/reporting/impl/src/main/java/org/jboss/windup/reporting/rules/generation/techreport/TechReportService.java
+++ b/reporting/impl/src/main/java/org/jboss/windup/reporting/rules/generation/techreport/TechReportService.java
@@ -178,7 +178,10 @@ public class TechReportService
         for (TechnologyUsageStatisticsModel stat : statModels)
         {
             // A shortcut.
-            if (onlyForApplication != null && !stat.getProjectModel().getApplications().contains(onlyForApplication))
+            if (onlyForApplication != null &&
+                    (!stat.getProjectModel().getApplications().contains(onlyForApplication)
+                    || (stat.getProjectModel().getApplications().size() > 1
+                            && !onlyForApplication.getName().toLowerCase().contains("shared"))))
             {
                 LOG.fine("\t\tThis stat is not for this project, skipping.");
                 continue;
@@ -219,8 +222,20 @@ public class TechReportService
                 appsToCountTowards = Collections.singletonList(onlyForApplication.getId());
             }
 
+            boolean isSharedApp = appsToCountTowards.size() > 1;
+            List<ProjectModel> apps = stat.getProjectModel().getApplications();
+
             for (Long appToCountTowards : appsToCountTowards)
             {
+                if(isSharedApp)
+                {
+                    List<ProjectModel>sharedApps = apps.stream().filter(app -> app.getName().toLowerCase().contains("shared")).collect(toList());
+                    if(!sharedApps.stream().anyMatch(app -> app.getElement().id().equals(appToCountTowards)))
+                    {
+                        continue;
+                    }
+                }
+
                 // For boxes report - show each tech in sector, row, box. For individual projects.
                 mergeToTheRightCell(map, placement.row.getName(), placement.box.getName(), appToCountTowards, stat.getName(), stat, false);
 

--- a/reporting/impl/src/main/java/org/jboss/windup/reporting/rules/generation/techreport/TechReportService.java
+++ b/reporting/impl/src/main/java/org/jboss/windup/reporting/rules/generation/techreport/TechReportService.java
@@ -171,8 +171,6 @@ public class TechReportService
      */
     public TechStatsMatrix getTechStatsMap(ProjectModel onlyForApplication)
     {
-        Set<ProjectModel> applicationProjects = onlyForApplication == null ? null
-                    : new ProjectModelTraversal(onlyForApplication).getAllProjects(true);
 
         Map<String, Map<String, Map<Long, Map<String, TechUsageStatSum>>>> map = new HashMap<>();
 


### PR DESCRIPTION
results map created for techbox report was skipping some of the results, finding that the techstat was not included in the application. This fix amends how that section of the code determines if a stat is to be included in an application's techbox report.