### PR TITLE
WIP WINDUP-2241 Change nexus index version to test the release

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -5,7 +5,7 @@
     <properties>
         <version.forge>3.9.2.Final</version.forge>
         <version.furnace>2.28.2.Final</version.furnace>
-        <version.nexus.index>7.0</version.nexus.index>
+        <version.nexus.index>19.1.0.Alpha1</version.nexus.index>
     </properties>
 
     <!-- Does NOT use windup-parent - this is a BOM. -->


### PR DESCRIPTION
DO NOT MERGE
It's just a way to run the build to evaluate that everything works before releasing the version `19.1.0.Final` of the nexus index.