### PR TITLE
WINDUPRULE-378: parameterized rule|project|artifactId bugfix

### DIFF
--- a/rules-java-project/addon/src/main/java/org/jboss/windup/project/condition/Artifact.java
+++ b/rules-java-project/addon/src/main/java/org/jboss/windup/project/condition/Artifact.java
@@ -98,7 +98,7 @@ public class Artifact implements Parameterized
     {
         Set<String> result = new HashSet<>();
         if (groupId != null) result.addAll(groupId.getRequiredParameterNames());
-        result.addAll(artifactId.getRequiredParameterNames());
+        if (artifactId != null) result.addAll(artifactId.getRequiredParameterNames());
         return result;
     }
 

--- a/rules-java-project/addon/src/main/java/org/jboss/windup/project/condition/Artifact.java
+++ b/rules-java-project/addon/src/main/java/org/jboss/windup/project/condition/Artifact.java
@@ -96,7 +96,8 @@ public class Artifact implements Parameterized
     @Override
     public Set<String> getRequiredParameterNames()
     {
-        Set<String> result = new HashSet<>(groupId.getRequiredParameterNames());
+        Set<String> result = new HashSet<>();
+        if (groupId != null) result.addAll(groupId.getRequiredParameterNames());
         result.addAll(artifactId.getRequiredParameterNames());
         return result;
     }

--- a/rules-java-project/addon/src/main/java/org/jboss/windup/project/condition/Artifact.java
+++ b/rules-java-project/addon/src/main/java/org/jboss/windup/project/condition/Artifact.java
@@ -96,7 +96,9 @@ public class Artifact implements Parameterized
     @Override
     public Set<String> getRequiredParameterNames()
     {
-        return new HashSet<>(Arrays.asList("groupId", "artifactId"));
+        Set<String> result = new HashSet<>(groupId.getRequiredParameterNames());
+        result.addAll(artifactId.getRequiredParameterNames());
+        return result;
     }
 
     @Override

--- a/rules-java-project/tests/src/test/java/org/jboss/windup/project/condition/test/ArtifactTest.java
+++ b/rules-java-project/tests/src/test/java/org/jboss/windup/project/condition/test/ArtifactTest.java
@@ -1,0 +1,27 @@
+package org.jboss.windup.project.condition.test;
+
+import org.jboss.windup.project.condition.Artifact;
+import org.jboss.windup.project.condition.Project;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+public class ArtifactTest {
+    /**
+     * Testing that parameterized artifactId sets the right value
+     */
+    @Test
+    public void xmlFileParameterizedIdTest() {
+
+        String artifactIdParam = "artifactId_param";
+        Artifact art = Artifact.withGroupId("group").andArtifactId("{" + artifactIdParam + "}");
+
+        Set<String> parameters = new HashSet<>();
+        Collections.addAll(parameters, artifactIdParam);
+
+        Assert.assertEquals(parameters , art.getRequiredParameterNames());
+    }
+}


### PR DESCRIPTION
A rule with a `when` condition like
```xml
    <when>
        <project>
            <artifact groupId="org.hibernate" artifactId="{type}" />
        </project>
    </when>
```
was not working due to this bug.