### PR TITLE
WINDUP BUBBLE REPORT styles problem

### DIFF
--- a/reporting/impl/src/main/resources/reports/resources/css/tech-report-punchcard.css
+++ b/reporting/impl/src/main/resources/reports/resources/css/tech-report-punchcard.css
@@ -103,7 +103,7 @@ tr.app td.circle.size3:after { content: '\2B24'; font-size: 15pt; vertical-align
 tr.app td.circle.size4:after { content: '\2B24'; font-size: 18pt; vertical-align: middle; }
 tr.app td.circle.size5:after { content: '\2B24'; font-size: 20pt; vertical-align: middle; }
 
-tr.app td.sectorStats.libsCount, tr.app td.sectorStats.storyPoints { padding-right: 20px }
+tr.app td.sectorStats.libsCount, tr.app td.sectorStats.storyPoints { padding-right: 10px }
 
 /********* Styles for scrolling ******************/
 table.technologiesPunchCard thead, table.technologiesPunchCard tbody {

--- a/reporting/impl/src/main/resources/reports/templates/techReport-punchCard.ftl
+++ b/reporting/impl/src/main/resources/reports/templates/techReport-punchCard.ftl
@@ -96,15 +96,15 @@
                             <#list sortedBoxTags as boxTag >
                                 <#if !isTagUnderTag(boxTag, placeTagsParent) >
                                     <#assign techsOrder = techsOrder + [boxTag] />
-                                    <td class="sector sector${sectorTag.title}"><div style="width: 100%">${boxTag.title!}</div></td>
+                                    <td class="sector sector${sectorTag.title}"><div style="width: 100%; padding-left: 10px;">${boxTag.title!}</div></td>
                                 </#if>
                             </#list>
                         </#list>
-                            <td class="sector sectorStats sizeMB"><div>Size (MB)</div></td>
-                            <td class="sector sectorStats libsCount"><div>Libraries</div></td>
-                            <td class="sector sectorStats storyPoints"><div>Mandatory (SP)</div></td>
-                            <td class="sector sectorStats storyPoints"><div>Cloud Mandatory (SP)</div></td>
-                            <td class="sector sectorStats storyPoints"><div>Potential (Count)</div></td>
+                            <td class="sector sectorStats sizeMB"><div style="width: 100%; padding-left: 5px;">Size (MB)</div></td>
+                            <td class="sector sectorStats libsCount"><div style="width: 100%; padding-left: 5px;">Libraries</div></td>
+                            <td class="sector sectorStats storyPoints"><div style="width: 100%; padding-left: 5px;">Mandatory (SP)</div></td>
+                            <td class="sector sectorStats storyPoints"><div style="width: 100%; padding-left: 5px;">Cloud Mandatory (SP)</div></td>
+                            <td class="sector sectorStats storyPoints"><div style="width: 100%; padding-left: 5px;">Potential (Count)</div></td>
                             <#-- this td is needed for scrollbar positioning -->
                             <td class="scrollbar-padding"></td>
                         </tr>


### PR DESCRIPTION
This PR fixes an error on the Bubble report. The error is that the headers are not aligned with the rows. For more info, you can see [WINDUP-2200 Comment](https://issues.jboss.org/browse/WINDUP-2200?focusedCommentId=13725316&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-13725316)