### PR TITLE
Make depencencies minOccurs 0

### DIFF
--- a/config-xml/schema/windup-jboss-ruleset.xsd
+++ b/config-xml/schema/windup-jboss-ruleset.xsd
@@ -32,7 +32,7 @@
                     <xs:complexType>
                         <xs:sequence>
                             <xs:element name="description" type="xs:string" minOccurs="0" maxOccurs="1" />
-                            <xs:element name="dependencies">
+                            <xs:element name="dependencies" minOccurs="0">
                                 <xs:complexType>
                                     <xs:sequence>
                                         <xs:element name="addon" minOccurs="1" maxOccurs="unbounded">


### PR DESCRIPTION
Self-explanatory. The default value for `minOccurs` is 1, and it doesn't seem like that is necessary here. 