### PR TITLE
WINDUPRULE-403 Added 'windup-config-groovy' dependency to use 'windup-rules-java-ee' in Groovy rules

### DIFF
--- a/rules-java-ee/addon/pom.xml
+++ b/rules-java-ee/addon/pom.xml
@@ -49,6 +49,16 @@
             <classifier>forge-addon</classifier>
             <scope>provided</scope>
         </dependency>
+        <!--
+            This dependency has to be added in order to have org.jboss.windup.ext.groovy.GroovyWindupRuleProviderLoader.getCompositeClassloader
+            to install this "windup-rules-java-ee" addon installed when executing Groovy rules like singleton-sessionbean-groovy-00001
+        -->
+        <dependency>
+            <groupId>org.jboss.windup.config</groupId>
+            <artifactId>windup-config-groovy</artifactId>
+            <classifier>forge-addon</classifier>
+            <scope>provided</scope>
+        </dependency>
         <dependency>
             <groupId>org.jboss.windup.reporting</groupId>
             <artifactId>windup-reporting</artifactId>


### PR DESCRIPTION
https://issues.redhat.com/browse/WINDUPRULE-403

This dependency has to be added in order to have [`org.jboss.windup.ext.groovy.GroovyWindupRuleProviderLoader.getCompositeClassloader`](https://github.com/windup/windup/blob/master/config-groovy/addon/src/main/java/org/jboss/windup/ext/groovy/GroovyWindupRuleProviderLoader.java#L159) to install this `windup-rules-java-ee` addon when executing Groovy rules like `singleton-sessionbean-groovy-00001` in https://github.com/windup/windup-rulesets/pull/392