### PR TITLE
WINDUP-2544 Fix <filecontent> XML condition

### DIFF
--- a/rules-base/api/src/main/java/org/jboss/windup/rules/files/condition/FileContent.java
+++ b/rules-base/api/src/main/java/org/jboss/windup/rules/files/condition/FileContent.java
@@ -225,8 +225,8 @@ public class FileContent extends ParameterizedGraphCondition implements FileCont
                         if (passed)
                         {
                             evaluationStrategy.modelMatched();
-                            if (parsedFileNamePattern2 == null || (parsedFileNamePattern2.submit(event, context)
-                                        && (contentPattern == null || contentPatternResult.submit(event, context))))
+                            if ((parsedFileNamePattern2 == null || parsedFileNamePattern2.submit(event, context))
+                                        && (contentPattern == null || contentPatternResult.submit(event, context)))
                             {
                                 FileLocationModel fileLocationModel = fileLocationService.create();
                                 fileLocationModel.setFile(fileModel);


### PR DESCRIPTION
https://issues.redhat.com/browse/WINDUP-2544

Added the test with a rule with a parameter `foo` and without a file name pattern condition: without the fix the test fails.