### PR TITLE
WINDUP-2910 Analyze Applications that have been built with JDK11

### DIFF
--- a/bootstrap/pom.xml
+++ b/bootstrap/pom.xml
@@ -74,7 +74,7 @@
                 </exclusion>
                 <exclusion>
                     <groupId>org.ow2.asm</groupId>
-                    <artifactId>asm-all</artifactId>
+                    <artifactId>asm</artifactId>
                 </exclusion>
                 <exclusion>
                     <groupId>org.jboss.windup.ast</groupId>

--- a/rules-java/api/pom.xml
+++ b/rules-java/api/pom.xml
@@ -31,8 +31,8 @@
         </dependency>
         <dependency>
             <groupId>org.ow2.asm</groupId>
-            <artifactId>asm-all</artifactId>
-            <version>5.0.4</version>
+            <artifactId>asm</artifactId>
+            <version>9.0</version>
         </dependency>
 
         <!-- Local Dependencies -->

--- a/rules-java/api/src/main/java/org/jboss/windup/rules/apps/java/DependencyVisitor.java
+++ b/rules-java/api/src/main/java/org/jboss/windup/rules/apps/java/DependencyVisitor.java
@@ -72,7 +72,7 @@ public class DependencyVisitor extends ClassVisitor
 
     public DependencyVisitor()
     {
-        super(Opcodes.ASM5);
+        super(Opcodes.ASM7);
     }
 
     // ClassVisitor

--- a/rules-xml/api/pom.xml
+++ b/rules-xml/api/pom.xml
@@ -21,8 +21,8 @@
         </dependency>
         <dependency>
             <groupId>org.ow2.asm</groupId>
-            <artifactId>asm-all</artifactId>
-            <version>5.0.4</version>
+            <artifactId>asm</artifactId>
+            <version>9.0</version>
         </dependency>
         <dependency>
             <groupId>net.sf.saxon</groupId>


### PR DESCRIPTION
https://issues.redhat.com/browse/WINDUP-2910

Updated [ASM](https://asm.ow2.io/index.html) dependency to let the BeforeDecompileClassesRuleProvider rule to work with JDK 11 built applications.

* ASM depedency upgrade fixed the exception `ASM was unable to parse class file` from `ClassFilePreDecompilationScan` reported in [this comment](https://issues.redhat.com/browse/WINDUP-2910?focusedCommentId=15615130&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-15615130)

* The visitor Opcodes' definition has been changed to `ASM7` to prevent this exception during decompilation:
  ```
  Failed when iterating [v[155672]={w:winduptype: [FileModel, JavaClassFileModel], fileName: Message.class, size: 8274, windupGenerated: false, filePath: /home/mrizzi/Tools/windup/sample/output/sample_quarkus_compiled_202012231645/archives/kafka-clients-quarkus-sample-1.0.0-SNAPSHOT-runner.jar/io/jromanmartin/kafka/schema/avro/Message.class, packageName: io.jromanmartin.kafka.schema.avro, majorVersion: 55, minorVersion: 0, isDirectory: false}], due to: NestMember requires ASM7
          at org.jboss.windup.config.operation.Iteration.perform(Iteration.java:339) [windup-config-api-5.1.1-SNAPSHOT.jar:5.1.1-SNAPSHOT]
          at org.jboss.windup.config.operation.Iteration.perform(Iteration.java:252) [windup-config-api-5.1.1-SNAPSHOT.jar:5.1.1-SNAPSHOT]
          at org.ocpsoft.rewrite.config.RuleBuilder.perform(RuleBuilder.java:168) [rewrite-api-3.0.0.Alpha9-jboss.jar:3.0.0.Alpha9-jboss]
          at org.jboss.windup.config.RuleSubset.perform(RuleSubset.java:290) [windup-config-api-5.1.1-SNAPSHOT.jar:5.1.1-SNAPSHOT]
          at org.jboss.windup.exec.WindupProcessorImpl.execute(WindupProcessorImpl.java:214) [:5.1.1-SNAPSHOT]
          at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) [rt.jar:1.8.0_275]
          at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) [rt.jar:1.8.0_275]
          at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) [rt.jar:1.8.0_275]
          at java.lang.reflect.Method.invoke(Method.java:498) [rt.jar:1.8.0_275]
          at org.jboss.forge.furnace.proxy.ClassLoaderInterceptor$1.call(ClassLoaderInterceptor.java:87) [furnace-proxy-2.28.4.Final.jar:2.28.4.Final]
          at org.jboss.forge.furnace.util.ClassLoaders.executeIn(ClassLoaders.java:42) [furnace-api-2.28.4.Final.jar:2.28.4.Final]
          at org.jboss.forge.furnace.proxy.ClassLoaderInterceptor.invoke(ClassLoaderInterceptor.java:103) [furnace-proxy-2.28.4.Final.jar:2.28.4.Final]
          at org.jboss.windup.exec.WindupProcessorImpl_$$_jvst994_ed.execute(WindupProcessorImpl_$$_jvst994_ed.java) [:5.1.1-SNAPSHOT]
          at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) [rt.jar:1.8.0_275]
          at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) [rt.jar:1.8.0_275]
          at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) [rt.jar:1.8.0_275]
          at java.lang.reflect.Method.invoke(Method.java:498) [rt.jar:1.8.0_275]
          at org.jboss.forge.furnace.proxy.ClassLoaderAdapterCallback$2.call(ClassLoaderAdapterCallback.java:124) [furnace-proxy-2.28.4.Final.jar:2.28.4.Final]
          at org.jboss.forge.furnace.util.ClassLoaders.executeIn(ClassLoaders.java:42) [furnace-api-2.28.4.Final.jar:2.28.4.Final]
          at org.jboss.forge.furnace.proxy.ClassLoaderAdapterCallback.invoke(ClassLoaderAdapterCallback.java:97) [furnace-proxy-2.28.4.Final.jar:2.28.4.Final]
          at org.jboss.windup.exec.WindupProcessor_$$_jvstefb_2b.execute(WindupProcessor_$$_jvstefb_2b.java) [windup-exec-api-5.1.1-SNAPSHOT.jar:5.1.1-SNAPSHOT]
          at org.jboss.windup.bootstrap.commands.windup.RunWindupCommand.runWindup(RunWindupCommand.java:310) [windup-bootstrap-5.1.1-SNAPSHOT.jar:5.1.1-SNAPSHOT]
          at org.jboss.windup.bootstrap.commands.windup.RunWindupCommand.execute(RunWindupCommand.java:67) [windup-bootstrap-5.1.1-SNAPSHOT.jar:5.1.1-SNAPSHOT]
          at org.jboss.windup.bootstrap.Bootstrap.executePhase(Bootstrap.java:532) [windup-bootstrap-5.1.1-SNAPSHOT.jar:5.1.1-SNAPSHOT]
          at org.jboss.windup.bootstrap.Bootstrap.run(Bootstrap.java:352) [windup-bootstrap-5.1.1-SNAPSHOT.jar:5.1.1-SNAPSHOT]
          at org.jboss.windup.bootstrap.Bootstrap.main(Bootstrap.java:113) [windup-bootstrap-5.1.1-SNAPSHOT.jar:5.1.1-SNAPSHOT]
  Caused by: java.lang.UnsupportedOperationException: NestMember requires ASM7
          at org.objectweb.asm.ClassVisitor.visitNestMember(ClassVisitor.java:251) [asm-9.0.jar:9.0]
          at org.objectweb.asm.ClassReader.accept(ClassReader.java:663) [asm-9.0.jar:9.0]
          at org.objectweb.asm.ClassReader.accept(ClassReader.java:394) [asm-9.0.jar:9.0]
          at org.jboss.windup.rules.apps.java.decompiler.ClassFilePreDecompilationScan.filterClassesToDecompile(ClassFilePreDecompilationScan.java:129) [windup-rules-java-api-5.1.1-SNAPSHOT.jar:5.1.1-SNAPSHOT]
          at org.jboss.windup.rules.apps.java.decompiler.ClassFilePreDecompilationScan.perform(ClassFilePreDecompilationScan.java:162) [windup-rules-java-api-5.1.1-SNAPSHOT.jar:5.1.1-SNAPSHOT]
          at org.jboss.windup.rules.apps.java.decompiler.ClassFilePreDecompilationScan.perform(ClassFilePreDecompilationScan.java:34) [windup-rules-java-api-5.1.1-SNAPSHOT.jar:5.1.1-SNAPSHOT]
          at org.jboss.windup.config.operation.iteration.AbstractIterationOperation.perform(AbstractIterationOperation.java:65) [windup-config-api-5.1.1-SNAPSHOT.jar:5.1.1-SNAPSHOT]
          at org.jboss.windup.config.operation.GraphOperation.perform(GraphOperation.java:24) [windup-config-api-5.1.1-SNAPSHOT.jar:5.1.1-SNAPSHOT]
          at org.jboss.windup.config.operation.Iteration.perform(Iteration.java:312) [windup-config-api-5.1.1-SNAPSHOT.jar:5.1.1-SNAPSHOT]
          ... 25 more
  ```