### PR TITLE
Changes cli file and --target value in README example

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -26,7 +26,7 @@ After that, follow the link:https://github.com/windup/windup/wiki/Execute[User G
 
 Windup distribution contains a sample file to try Windup with. Try the following command in a console:
 
-    bin/windup --target eap --input samples/jee-example-app-1.0.0.ear
+    bin/mta-cli --target eap7 --input samples/jee-example-app-1.0.0.ear
 
 This will create a report next to the scanned archive:
 


### PR DESCRIPTION
Changes the example command found in the README file to a currently working one:

    bin/mta-cli --target eap7 --input samples/jee-example-app-1.0.0.ear

- `bin/winup` seems to be an old name for the script
- `--target eap` doesn't work in the current version, it asks for a specific eap version.