### PR TITLE
Setup Oracle Maven repo mirror with https

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,6 +76,26 @@
         </repository>
     </distributionManagement>
 
+    <repositories>
+        <repository>
+            <!--
+                In windup-graph-impl artifact, the janusgraph-berkeleyje dependency defines the 'oracleReleases' repository in order to retrieve
+                artifact com.sleepycat:je:7.4.5 from Oracle Maven repo (http://download.oracle.com/maven/com/sleepycat/je/7.4.5/je-7.4.5.pom)
+                BUT Maven 3.8.1 "Block external HTTP repositories by default" (https://issues.apache.org/jira/browse/MNG-7118) so
+                here the HTTP*S* version of Oracle Maven repo is defined.
+            -->
+            <id>oracleReleases-mirror</id>
+            <name>oracleReleases-mirror</name>
+            <url>https://download.oracle.com/maven/</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
+
     <modules>
         <module>bom</module>
         <module>windup-test-harness</module>


### PR DESCRIPTION
With Maven 3.8.1, the project doesn't build due to:
```
[ERROR] Failed to execute goal on project windup-graph-impl:
Could not resolve dependencies for project org.jboss.windup.graph:windup-graph-impl:jar:5.2.1-SNAPSHOT:
Failed to collect dependencies at org.janusgraph:janusgraph-berkeleyje:jar:0.3.1 -> com.sleepycat:je:jar:7.4.5:
Failed to read artifact descriptor for com.sleepycat:je:jar:7.4.5: Could not transfer artifact com.sleepycat:je:pom:7.4.5 from/to maven-default-http-blocker (http://0.0.0.0/):
Blocked mirror for repositories: [oracleReleases (http://download.oracle.com/maven, default, releases+snapshots), spring-releases (http://repo.spring.io/libs-release-remote/, default, releases)]
```
This PR fixes this issue.