### PR TITLE
Enable use of parameters in annotation conditions

### DIFF
--- a/rules-java/api/src/main/java/org/jboss/windup/rules/apps/java/condition/JavaClass.java
+++ b/rules-java/api/src/main/java/org/jboss/windup/rules/apps/java/condition/JavaClass.java
@@ -387,6 +387,15 @@ public class JavaClass extends ParameterizedGraphCondition implements JavaClassB
             result.addAll(typeFilterPattern.getRequiredParameterNames());
         if (lineMatchPattern != null)
             result.addAll(lineMatchPattern.getRequiredParameterNames());
+        if (annotationCondition != null)
+            result.addAll(annotationCondition.getRequiredParameterNames());
+        if (additionalAnnotationConditions != null && !additionalAnnotationConditions.isEmpty())
+        {
+            for (AnnotationCondition condition : additionalAnnotationConditions)
+            {
+                result.addAll(condition.getRequiredParameterNames());
+            }
+        }
         return result;
     }
 

--- a/rules-java/api/src/main/java/org/jboss/windup/rules/apps/java/condition/annotation/AnnotationCondition.java
+++ b/rules-java/api/src/main/java/org/jboss/windup/rules/apps/java/condition/annotation/AnnotationCondition.java
@@ -6,6 +6,8 @@ import org.jboss.windup.config.condition.EvaluationStrategy;
 import org.jboss.windup.rules.apps.java.scan.ast.annotations.JavaAnnotationTypeValueModel;
 import org.ocpsoft.rewrite.context.EvaluationContext;
 
+import java.util.Set;
+
 /**
  * {@link AnnotationCondition} provides support for filtering type references based upon detailed annotation information.
  *
@@ -21,4 +23,10 @@ public abstract class AnnotationCondition
      * false otherwise.
      */
     public abstract boolean evaluate(GraphRewrite event, EvaluationContext context, EvaluationStrategy strategy, JavaAnnotationTypeValueModel value);
+
+    /**
+     * Called by the framework to obtain the list of parameters required by the condition.
+     * @return The parameter names used in the condition.
+     */
+    public abstract Set<String> getRequiredParameterNames();
 }

--- a/rules-java/api/src/main/java/org/jboss/windup/rules/apps/java/condition/annotation/AnnotationListCondition.java
+++ b/rules-java/api/src/main/java/org/jboss/windup/rules/apps/java/condition/annotation/AnnotationListCondition.java
@@ -1,7 +1,9 @@
 package org.jboss.windup.rules.apps.java.condition.annotation;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import org.jboss.windup.config.GraphRewrite;
 import org.jboss.windup.config.condition.EvaluationStrategy;
@@ -135,5 +137,19 @@ public class AnnotationListCondition extends AnnotationCondition
             }
         }
         return selectedValues;
+    }
+
+    @Override
+    public Set<String> getRequiredParameterNames()
+    {
+        Set<String> result = new HashSet<>();
+        if (conditions != null) {
+            for (AnnotationCondition condition : conditions)
+            {
+                result.addAll(condition.getRequiredParameterNames());
+            }
+        }
+
+        return result;
     }
 }

--- a/rules-java/api/src/main/java/org/jboss/windup/rules/apps/java/condition/annotation/AnnotationLiteralCondition.java
+++ b/rules-java/api/src/main/java/org/jboss/windup/rules/apps/java/condition/annotation/AnnotationLiteralCondition.java
@@ -8,6 +8,9 @@ import org.ocpsoft.rewrite.context.EvaluationContext;
 import org.ocpsoft.rewrite.param.ParameterizedPatternResult;
 import org.ocpsoft.rewrite.param.RegexParameterizedPatternParser;
 
+import java.util.HashSet;
+import java.util.Set;
+
 /**
  * Matches a literal value on an annotation element. The value itself is a pattern match and the value is always treated as
  * a string.
@@ -61,5 +64,16 @@ public class AnnotationLiteralCondition extends AnnotationCondition
         }
 
         return true;
+    }
+
+    @Override
+    public Set<String> getRequiredParameterNames()
+    {
+        Set<String> result = new HashSet<>();
+        if (pattern != null) {
+            result.addAll(pattern.getRequiredParameterNames());
+        }
+
+        return result;
     }
 }

--- a/rules-java/api/src/main/java/org/jboss/windup/rules/apps/java/condition/annotation/AnnotationTypeCondition.java
+++ b/rules-java/api/src/main/java/org/jboss/windup/rules/apps/java/condition/annotation/AnnotationTypeCondition.java
@@ -1,6 +1,5 @@
 package org.jboss.windup.rules.apps.java.condition.annotation;
 
-import java.lang.annotation.Annotation;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;

--- a/rules-java/api/src/main/java/org/jboss/windup/rules/apps/java/condition/annotation/AnnotationTypeCondition.java
+++ b/rules-java/api/src/main/java/org/jboss/windup/rules/apps/java/condition/annotation/AnnotationTypeCondition.java
@@ -1,7 +1,10 @@
 package org.jboss.windup.rules.apps.java.condition.annotation;
 
+import java.lang.annotation.Annotation;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 import org.jboss.windup.config.GraphRewrite;
 import org.jboss.windup.config.condition.EvaluationStrategy;
@@ -85,5 +88,22 @@ public class AnnotationTypeCondition extends AnnotationCondition
                 return false;
         }
         return true;
+    }
+
+    @Override
+    public Set<String> getRequiredParameterNames()
+    {
+        Set<String> result = new HashSet<>();
+        if (pattern != null) {
+            result.addAll(pattern.getRequiredParameterNames());
+        }
+        if (conditions != null) {
+            for (AnnotationCondition condition : conditions.values())
+            {
+                result.addAll(condition.getRequiredParameterNames());
+            }
+        }
+
+        return result;
     }
 }

--- a/rules-java/tests/src/test/java/org/jboss/windup/rules/java/JavaClassAnnotationFilteringTest.java
+++ b/rules-java/tests/src/test/java/org/jboss/windup/rules/java/JavaClassAnnotationFilteringTest.java
@@ -8,7 +8,6 @@ import java.util.Collections;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
-import net.bytebuddy.utility.JavaType;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.jboss.arquillian.container.test.api.Deployment;

--- a/rules-java/tests/src/test/java/org/jboss/windup/rules/java/JavaClassAnnotationFilteringTest.java
+++ b/rules-java/tests/src/test/java/org/jboss/windup/rules/java/JavaClassAnnotationFilteringTest.java
@@ -8,6 +8,7 @@ import java.util.Collections;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
+import net.bytebuddy.utility.JavaType;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.jboss.arquillian.container.test.api.Deployment;
@@ -65,6 +66,9 @@ public class JavaClassAnnotationFilteringTest
 
     @Inject
     ComplexAnnotationScanProvider complexProvider;
+
+    @Inject
+    RegexAnnotationScanProvider regexProvider;
 
     @Inject
     private WindupProcessor processor;
@@ -126,6 +130,35 @@ public class JavaClassAnnotationFilteringTest
             Assert.assertEquals(0, complexProvider.nestedAnnotationWrongNameHitCount);
             Assert.assertEquals(1, complexProvider.nestedAnnotationWithNullLiteralShouldMatch);
             Assert.assertEquals(0, complexProvider.nestedAnnotationWithNullLiteralShouldNotMatchNull);
+        }
+    }
+
+    @Test
+    public void testRegexAnnotationFiltering() throws Exception
+    {
+        Path outputPath = getDefaultPath();
+        FileUtils.deleteDirectory(outputPath.toFile());
+        Files.createDirectories(outputPath);
+
+        try (GraphContext context = factory.create(outputPath, true))
+        {
+            final String inputDir = "src/test/resources/org/jboss/windup/rules/annotationtests/regex";
+
+            final WindupConfiguration processorConfig = new WindupConfiguration();
+            processorConfig.setRuleProviderFilter(new RuleProviderWithDependenciesPredicate(RegexAnnotationScanProvider.class));
+            processorConfig.setGraphContext(context);
+            processorConfig.addInputPath(Paths.get(inputDir));
+            processorConfig.setOutputDirectory(outputPath);
+            processorConfig.setOptionValue(ScanPackagesOption.NAME, Collections.singletonList(""));
+            processorConfig.setOptionValue(SourceModeOption.NAME, true);
+
+            processor.execute(processorConfig);
+
+            Assert.assertEquals(3, regexProvider.baseRuleHitCount);
+            Assert.assertEquals(1, regexProvider.withValueFilterHitCount);
+            Assert.assertEquals(0, regexProvider.withIncorrectFilterCount);
+            Assert.assertEquals(1, regexProvider.baseValueRuleHitCount);
+            Assert.assertEquals(1, regexProvider.withRegexFilterHitCount);
         }
     }
 
@@ -294,6 +327,84 @@ public class JavaClassAnnotationFilteringTest
                             nestedAnnotationWithNullLiteralShouldNotMatchNull++;
                         }
                     });
+        }
+        // @formatter:on
+    }
+
+    @Singleton
+    public static class RegexAnnotationScanProvider extends AbstractRuleProvider
+    {
+        private int baseRuleHitCount = 0;
+        private int withValueFilterHitCount = 0;
+        private int withIncorrectFilterCount = 0;
+        private int baseValueRuleHitCount = 0;
+        private int withRegexFilterHitCount = 0;
+
+        public RegexAnnotationScanProvider()
+        {
+            super(MetadataBuilder.forProvider(RegexAnnotationScanProvider.class).setPhase(InitialAnalysisPhase.class)
+                    .addExecuteAfter(AnalyzeJavaFilesRuleProvider.class));
+        }
+
+        // @formatter:off
+        @Override
+        public Configuration getConfiguration(RuleLoaderContext ruleLoaderContext)
+        {
+            return ConfigurationBuilder.begin()
+                    .addRule().when(
+                            JavaClass.references("org.jboss.windup.rules.annotationtests.regex.SimpleTestAnnotation")
+                                    .at(TypeReferenceLocation.ANNOTATION)
+                    ).perform(new AbstractIterationOperation<JavaTypeReferenceModel>()
+                    {
+                        @Override
+                        public void perform(GraphRewrite event, EvaluationContext context, JavaTypeReferenceModel payload)
+                        {
+                            baseRuleHitCount++;
+                        }
+                    })
+                    .addRule().when(
+                            JavaClass.references("org.jboss.windup.rules.annotationtests.regex.SimpleTestAnnotation")
+                                    .at(TypeReferenceLocation.ANNOTATION).annotationMatches("value2", new AnnotationLiteralCondition("value {accepted_value}"))
+                    ).perform(new AbstractIterationOperation<JavaTypeReferenceModel>()
+                    {
+                        @Override
+                        public void perform(GraphRewrite event, EvaluationContext context, JavaTypeReferenceModel payload)
+                        {
+                            withValueFilterHitCount++;
+                        }
+                    }).where("accepted_value").matches("4")
+                    .addRule().when(
+                            JavaClass.references("org.jboss.windup.rules.annotationtests.regex.SimpleTestAnnotation")
+                                    .at(TypeReferenceLocation.ANNOTATION).annotationMatches("value2", new AnnotationLiteralCondition("wrongvalue"))
+                    ).perform(new AbstractIterationOperation<JavaTypeReferenceModel>()
+                    {
+                        @Override
+                        public void perform(GraphRewrite event, EvaluationContext context, JavaTypeReferenceModel payload)
+                        {
+                            withIncorrectFilterCount++;
+                        }
+                    })
+                    .addRule().when(
+                            JavaClass.references("java.lang.String")
+                                    .at(TypeReferenceLocation.FIELD_DECLARATION).annotationMatches(new AnnotationTypeCondition("org.jboss.windup.rules.annotationtests.regex.SimpleTestAnnotation").addCondition("value2", new AnnotationLiteralCondition("member value 2")))
+                    ).perform(new AbstractIterationOperation<JavaTypeReferenceModel>() {
+                        @Override
+                        public void perform(GraphRewrite event, EvaluationContext context, JavaTypeReferenceModel payload) {
+                            baseValueRuleHitCount++;
+                        }
+                    })
+                    .addRule().when(
+                            JavaClass.references("java.lang.String")
+                                    .at(TypeReferenceLocation.FIELD_DECLARATION).annotationMatches(new AnnotationTypeCondition("{annotation_type}").addCondition("value2", new AnnotationLiteralCondition("{annotation_value_2}")))
+                    ).perform(new AbstractIterationOperation<JavaTypeReferenceModel>() {
+                        @Override
+                        public void perform(GraphRewrite event, EvaluationContext context, JavaTypeReferenceModel payload)
+                        {
+                            withRegexFilterHitCount++;
+                        }
+                    }).where("annotation_type").matches("org.jboss.windup.rules.annotationtests.regex.SimpleTestAnnotation")
+                    .where("annotation_value_2").matches(".*2");
+
         }
         // @formatter:on
     }

--- a/rules-java/tests/src/test/resources/org/jboss/windup/rules/annotationtests/regex/SimpleAnnotatedClass.java
+++ b/rules-java/tests/src/test/resources/org/jboss/windup/rules/annotationtests/regex/SimpleAnnotatedClass.java
@@ -1,0 +1,13 @@
+package org.jboss.windup.rules.annotationtests.regex;
+
+@SimpleTestAnnotation(value1 = "value 1", value2 = "value 2")
+@SimpleTestAnnotation(value1 = "value 3", value2 = "value 4")
+@SimpleSingleMemberAnnotation(SimpleAnnotatedClass.SINGLE_MEMBER_VALUE)
+public class SimpleAnnotatedClass
+{
+    public static final String SINGLE_MEMBER_VALUE = "single member value";
+
+    @SimpleTestAnnotation(value1 = "member value 1", value2 = "member value 2")
+    private String testString = "test";
+
+}

--- a/rules-java/tests/src/test/resources/org/jboss/windup/rules/annotationtests/regex/SimpleSingleMemberAnnotation.java
+++ b/rules-java/tests/src/test/resources/org/jboss/windup/rules/annotationtests/regex/SimpleSingleMemberAnnotation.java
@@ -1,0 +1,6 @@
+package org.jboss.windup.rules.annotationtests.regex;
+
+public @interface SimpleSingleMemberAnnotation
+{
+    String value();
+}

--- a/rules-java/tests/src/test/resources/org/jboss/windup/rules/annotationtests/regex/SimpleTestAnnotation.java
+++ b/rules-java/tests/src/test/resources/org/jboss/windup/rules/annotationtests/regex/SimpleTestAnnotation.java
@@ -1,0 +1,12 @@
+package org.jboss.windup.rules.annotationtests.regex;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Target;
+
+@Target(ElementType.TYPE)
+public @interface SimpleTestAnnotation
+{
+    String value1();
+
+    String value2();
+}


### PR DESCRIPTION
Currently, if you try to run a rule like

```xml
<rule id="WOLAMissingClassesRule">
    <when>
        <javaclass references="javax.ejb.RemoteHome">
            <location>ANNOTATION</location>
            <annotation-literal name="value" pattern="{WOLAMissingClassesRule_annotation_fields}" />
        </javaclass>
    </when>
    <perform>
        <hint title="WOLAMissingClassesRule" effort="2">
            <message>Some WebSphere z/OS Optimized Local Adapters APIs are unavailable</message>
        </hint>
    </perform>
    <where param="WOLAMissingClassesRule_annotation_fields">
        <matches pattern="com\.ibm\.websphere\.ola\.ExecuteHome" />
    </where>
</rule>
```

You'll get an error that the parameter WOLAMissingClassesRule_annotation_fields isn't found in the rule and the scan won't run. This is because the code that checks for required parameter names in the javaClass condition doesn't look into any of the annotation conditions for parameters.

I'm proposing to add the parameter names from the annotation conditions into the overall list for the javaclass condition so they are available for where clauses, which enables a rule like the above to successfully run.