### PR TITLE
WINDUP-3307 Exclude '3rd Party Archive' from analysis

### DIFF
--- a/rules-java/api/src/main/java/org/jboss/windup/rules/apps/java/scan/operation/UnzipArchiveToOutputFolder.java
+++ b/rules-java/api/src/main/java/org/jboss/windup/rules/apps/java/scan/operation/UnzipArchiveToOutputFolder.java
@@ -19,6 +19,7 @@ import org.jboss.windup.graph.model.ArchiveModel;
 import org.jboss.windup.graph.model.DuplicateArchiveModel;
 import org.jboss.windup.graph.model.WindupConfigurationModel;
 import org.jboss.windup.graph.model.resource.FileModel;
+import org.jboss.windup.graph.model.resource.IgnoredFileModel;
 import org.jboss.windup.graph.service.FileService;
 import org.jboss.windup.graph.service.GraphService;
 import org.jboss.windup.graph.service.WindupConfigurationService;
@@ -172,7 +173,7 @@ public class UnzipArchiveToOutputFolder extends AbstractIterationOperation<Archi
         boolean isInputApp = inputPaths.stream().anyMatch(inputPath -> inputPath.getFilePath().equals(archiveModel.getFilePath()));
 
         // Do not include libraries found within the artifacts if they are known
-        boolean isKnownLibrary = archiveIdentificationService.getCoordinate(archiveModel.getSHA1Hash()) != null;
+        boolean isKnownLibrary = archiveModel instanceof IgnoredFileModel || archiveIdentificationService.getCoordinate(archiveModel.getSHA1Hash()) != null;
         boolean analyseKnownLibraries = cfg.isAnalyzeKnownLibraries();
         if (isKnownLibrary && !analyseKnownLibraries && !isInputApp) {
             LOG.info(String.format("Library will be ignored: %s", archiveModel.getArchiveName()));


### PR DESCRIPTION
Effort to leverage the `IgnoredFileModel` model (created in [ArchivePackageNameIdentificationGraphChangedListener](https://github.com/windup/windup/blob/81cabeee805314c867bed721a9dfb84f9d60cf6f/rules-java/api/src/main/java/org/jboss/windup/rules/apps/java/scan/operation/packagemapping/ArchivePackageNameIdentificationGraphChangedListener.java#L62)) to skip the analysis of `3rd Party Archive`s.

