### PR TITLE
[WINDUP-3388] Fix Dependencies report when --analyzeKnownLibraries is false

### DIFF
--- a/graph/api/src/main/java/org/jboss/windup/graph/model/IgnoredArchiveModel.java
+++ b/graph/api/src/main/java/org/jboss/windup/graph/model/IgnoredArchiveModel.java
@@ -1,7 +1,5 @@
-package org.jboss.windup.rules.apps.java.archives.model;
+package org.jboss.windup.graph.model;
 
-import org.jboss.windup.graph.model.ArchiveModel;
-import org.jboss.windup.graph.model.TypeValue;
 import org.jboss.windup.graph.model.resource.IgnoredFileModel;
 
 /**

--- a/rules-java-archives/addon/src/main/java/org/jboss/windup/rules/apps/java/archives/listener/ArchiveIdentificationGraphChangedListener.java
+++ b/rules-java-archives/addon/src/main/java/org/jboss/windup/rules/apps/java/archives/listener/ArchiveIdentificationGraphChangedListener.java
@@ -2,7 +2,6 @@ package org.jboss.windup.rules.apps.java.archives.listener;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.Optional;
 import java.util.logging.Logger;
 
 import org.apache.commons.codec.digest.DigestUtils;
@@ -21,8 +20,7 @@ import org.jboss.windup.graph.service.WindupConfigurationService;
 import org.jboss.windup.rules.apps.java.archives.identify.ArchiveIdentificationService;
 import org.jboss.windup.rules.apps.java.archives.model.ArchiveCoordinateModel;
 import org.jboss.windup.rules.apps.java.archives.model.IdentifiedArchiveModel;
-import org.jboss.windup.rules.apps.java.archives.model.IgnoredArchiveModel;
-import org.jboss.windup.config.AnalyzeKnownLibrariesOption;
+import org.jboss.windup.graph.model.IgnoredArchiveModel;
 import org.jboss.windup.util.Logging;
 import org.jboss.windup.util.exception.WindupException;
 

--- a/rules-java-archives/tests/src/test/java/org/jboss/windup/rules/apps/java/archives/IgnoreArchivesRulesetTest.java
+++ b/rules-java-archives/tests/src/test/java/org/jboss/windup/rules/apps/java/archives/IgnoreArchivesRulesetTest.java
@@ -26,7 +26,7 @@ import org.jboss.windup.rules.apps.java.archives.identify.InMemoryArchiveIdentif
 import org.jboss.windup.rules.apps.java.archives.ignore.SkippedArchives;
 import org.jboss.windup.rules.apps.java.archives.model.ArchiveCoordinateModel;
 import org.jboss.windup.rules.apps.java.archives.model.IdentifiedArchiveModel;
-import org.jboss.windup.rules.apps.java.archives.model.IgnoredArchiveModel;
+import org.jboss.windup.graph.model.IgnoredArchiveModel;
 import org.jboss.windup.config.AnalyzeKnownLibrariesOption;
 import org.junit.After;
 import org.junit.Assert;

--- a/rules-java/api/src/main/java/org/jboss/windup/rules/apps/java/scan/operation/UnzipArchiveToOutputFolder.java
+++ b/rules-java/api/src/main/java/org/jboss/windup/rules/apps/java/scan/operation/UnzipArchiveToOutputFolder.java
@@ -28,7 +28,7 @@ import org.jboss.windup.graph.service.WindupConfigurationService;
 import org.jboss.windup.reporting.service.ClassificationService;
 import org.jboss.windup.rules.apps.java.archives.identify.ArchiveIdentificationService;
 import org.jboss.windup.rules.apps.java.archives.model.IdentifiedArchiveModel;
-import org.jboss.windup.rules.apps.java.archives.model.IgnoredArchiveModel;
+import org.jboss.windup.graph.model.IgnoredArchiveModel;
 import org.jboss.windup.rules.apps.java.service.WindupJavaConfigurationService;
 import org.jboss.windup.util.Logging;
 import org.jboss.windup.util.ZipUtil;
@@ -184,7 +184,6 @@ public class UnzipArchiveToOutputFolder extends AbstractIterationOperation<Archi
             LOG.info(String.format("Library will be ignored: %s", archiveModel.getArchiveName()));
             
             GraphService.addTypeToModel(event.getGraphContext(), archiveModel, IgnoredArchiveModel.class);
-            return;
         }
         LOG.log(Level.FINE, String.format("Library %s (coordinates %s) with hash %s will be inspected in sub folder %s", archiveModelFilePath, coordinate, hash, parentFileModel.getFilePath()));
 

--- a/rules-java/api/src/main/java/org/jboss/windup/rules/apps/java/scan/operation/packagemapping/ArchivePackageNameIdentificationGraphChangedListener.java
+++ b/rules-java/api/src/main/java/org/jboss/windup/rules/apps/java/scan/operation/packagemapping/ArchivePackageNameIdentificationGraphChangedListener.java
@@ -15,7 +15,7 @@ import org.jboss.windup.graph.service.ArchiveService;
 import org.jboss.windup.graph.service.GraphService;
 import org.jboss.windup.graph.service.WindupConfigurationService;
 import org.jboss.windup.rules.apps.java.archives.model.IdentifiedArchiveModel;
-import org.jboss.windup.rules.apps.java.archives.model.IgnoredArchiveModel;
+import org.jboss.windup.graph.model.IgnoredArchiveModel;
 
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.jboss.windup.util.Logging;

--- a/rules-java/api/src/main/java/org/jboss/windup/rules/apps/java/scan/provider/DiscoverMavenProjectsRuleProvider.java
+++ b/rules-java/api/src/main/java/org/jboss/windup/rules/apps/java/scan/provider/DiscoverMavenProjectsRuleProvider.java
@@ -21,7 +21,7 @@ import org.jboss.windup.reporting.model.TechnologyTagLevel;
 import org.jboss.windup.reporting.service.ClassificationService;
 import org.jboss.windup.reporting.service.TechnologyTagService;
 import org.jboss.windup.rules.apps.java.archives.model.IdentifiedArchiveModel;
-import org.jboss.windup.rules.apps.java.archives.model.IgnoredArchiveModel;
+import org.jboss.windup.graph.model.IgnoredArchiveModel;
 import org.jboss.windup.rules.apps.java.model.project.MavenProjectModel;
 import org.jboss.windup.rules.apps.java.scan.operation.packagemapping.PackageNameMapping;
 import org.jboss.windup.rules.apps.maven.dao.MavenProjectService;
@@ -45,6 +45,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.StringJoiner;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
@@ -92,9 +93,12 @@ public class DiscoverMavenProjectsRuleProvider extends AbstractRuleProvider
                 MavenProjectModel mavenProjectModel = extractMavenProjectModel(event, context, defaultName, payload);
                 if (mavenProjectModel != null)
                 {
-                    // add classification information to file.
-                    classificationService.attachClassification(event, context, payload, IssueCategoryRegistry.INFORMATION, "Maven POM (pom.xml)", "Maven Project Object Model (POM) File");
-                    technologyTagService.addTagToFileModel(payload, "Maven XML", TechnologyTagLevel.INFORMATIONAL);
+                    // Do not classify POM files if they are part of an ignored archive, to keep them from appearing in the Issues report
+                    if (!(payload.getArchive() instanceof IgnoredArchiveModel)) {
+                        LOG.log(Level.INFO, "Entering ignored");
+                        classificationService.attachClassification(event, context, payload, IssueCategoryRegistry.INFORMATION, "Maven POM (pom.xml)", "Maven Project Object Model (POM) File");
+                        technologyTagService.addTagToFileModel(payload, "Maven XML", TechnologyTagLevel.INFORMATIONAL);
+                    }
 
                     ArchiveModel archiveModel = payload.getArchive();
                     if (archiveModel != null && !isAlreadyMavenProject(archiveModel))

--- a/rules-java/api/src/main/java/org/jboss/windup/rules/apps/java/scan/provider/DiscoverMavenProjectsRuleProvider.java
+++ b/rules-java/api/src/main/java/org/jboss/windup/rules/apps/java/scan/provider/DiscoverMavenProjectsRuleProvider.java
@@ -45,7 +45,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.StringJoiner;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**

--- a/rules-java/api/src/main/java/org/jboss/windup/rules/apps/java/scan/provider/DiscoverMavenProjectsRuleProvider.java
+++ b/rules-java/api/src/main/java/org/jboss/windup/rules/apps/java/scan/provider/DiscoverMavenProjectsRuleProvider.java
@@ -95,7 +95,6 @@ public class DiscoverMavenProjectsRuleProvider extends AbstractRuleProvider
                 {
                     // Do not classify POM files if they are part of an ignored archive, to keep them from appearing in the Issues report
                     if (!(payload.getArchive() instanceof IgnoredArchiveModel)) {
-                        LOG.log(Level.INFO, "Entering ignored");
                         classificationService.attachClassification(event, context, payload, IssueCategoryRegistry.INFORMATION, "Maven POM (pom.xml)", "Maven Project Object Model (POM) File");
                         technologyTagService.addTagToFileModel(payload, "Maven XML", TechnologyTagLevel.INFORMATIONAL);
                     }

--- a/rules-java/api/src/main/java/org/jboss/windup/rules/apps/java/scan/provider/UnzipArchivesToOutputRuleProvider.java
+++ b/rules-java/api/src/main/java/org/jboss/windup/rules/apps/java/scan/provider/UnzipArchivesToOutputRuleProvider.java
@@ -14,7 +14,7 @@ import org.jboss.windup.graph.model.DuplicateArchiveModel;
 import org.jboss.windup.graph.model.resource.FileModel;
 import org.jboss.windup.graph.service.Service;
 import org.jboss.windup.rules.apps.java.archives.identify.CompositeArchiveIdentificationService;
-import org.jboss.windup.rules.apps.java.archives.model.IgnoredArchiveModel;
+import org.jboss.windup.graph.model.IgnoredArchiveModel;
 import org.jboss.windup.rules.apps.java.scan.operation.UnzipArchiveToOutputFolder;
 import org.ocpsoft.rewrite.config.Configuration;
 import org.ocpsoft.rewrite.config.ConfigurationBuilder;


### PR DESCRIPTION
This PR modifies the behaviour of the POM processing. If an archive is known and has been set to be ignored, now it will still be added to the graph. This is so that its information is available at a later stage for the Dependencies report to be filled. Otherwise, the Dependencies report will be missing most of the information, which comes from the POMs. Also, moved `IgnoreArchiveModel` to be along `ArchiveModel`.

See [Jira ticket](https://issues.redhat.com/browse/WINDUP-3388).