### PR TITLE
Skip Forge addon installation if skipTests is provided

### DIFF
--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -176,6 +176,7 @@
                                 <!-- this will be used in the tests, see InstallRemoveAddonCommandTest -->
                                 <!--<addonId>org.jboss.windup.rules.apps:windup-rules-tattletale,${project.version}</addonId>-->
                             </addonIds>
+                            <skip>${skipTests}</skip>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
No need to run the "addon-install" goal if the tests are going to be skipped so better to skip it as well