### PR TITLE
WINDUP-3363: changed default tool label to be just 'Windup'

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -579,7 +579,7 @@
                 </property>
             </activation>
             <properties>
-                <distribution.brand.name>Windup Migration Toolkit for Applications</distribution.brand.name>
+                <distribution.brand.name>Windup</distribution.brand.name>
                 <distribution.brand.name-acronym>WINDUP</distribution.brand.name-acronym>
                 <distribution.brand.documentation.url>https://github.com/windup/windup</distribution.brand.documentation.url>
                 <distribution.brand.cli-name>windup-cli</distribution.brand.cli-name>


### PR DESCRIPTION
https://issues.redhat.com/browse/WINDUP-3363