### PR TITLE
WINDUP-3227: only rules in MigrationRulesPhase and PostMigrationRules…

### DIFF
--- a/config/api/src/main/java/org/jboss/windup/config/builder/RuleProviderBuilder.java
+++ b/config/api/src/main/java/org/jboss/windup/config/builder/RuleProviderBuilder.java
@@ -60,6 +60,11 @@ public final class RuleProviderBuilder extends AbstractRuleProvider implements R
         return this;
     }
 
+    public RuleProviderBuilderAddDependencies addTag(String tag) {
+        metadata.addTag(tag);
+        return this;
+    }
+
     @Override
     public RuleProviderBuilderAddDependencies addExecuteAfter(String id) {
         metadata.addExecuteAfterId(id);

--- a/exec/api/src/main/java/org/jboss/windup/exec/rulefilters/TaggedRuleProviderPredicate.java
+++ b/exec/api/src/main/java/org/jboss/windup/exec/rulefilters/TaggedRuleProviderPredicate.java
@@ -8,6 +8,8 @@ import java.util.Set;
 import org.apache.commons.collections.CollectionUtils;
 import org.jboss.forge.furnace.util.Predicate;
 import org.jboss.windup.config.RuleProvider;
+import org.jboss.windup.config.phase.MigrationRulesPhase;
+import org.jboss.windup.config.phase.PostMigrationRulesPhase;
 
 /**
  * Accepts the given provider if it has any or all of requested include tags, or has not all or any of the requested
@@ -59,6 +61,11 @@ public class TaggedRuleProviderPredicate implements Predicate<RuleProvider> {
     @Override
     public boolean accept(RuleProvider provider) {
         Set<String> tags = provider.getMetadata().getTags();
+
+        if (!(provider.getMetadata().getPhase().isInstance(new MigrationRulesPhase()) ||
+                provider.getMetadata().getPhase().isInstance(new PostMigrationRulesPhase()))){
+            return true;
+        }
 
         boolean result = true;
         if (!includeTags.isEmpty()) {


### PR DESCRIPTION
…Phase are subject to being filtered by tag

https://issues.redhat.com/browse/WINDUP-3227

https://github.com/windup/windup-rulesets/pull/737 makes more tags available in the metadata section and so can be filtered using this PR by specifying desired tags with --includeTags. 

NB specifying a target incompatible with a rule will prevent that rule running even if its tag is specified with --includeTags - ie both target and tag must match for a rule to be run in this way.