### PR TITLE
Divided 'tests' module testing from other modules testing

### DIFF
--- a/.github/workflows/pr_build_jdk11.yml
+++ b/.github/workflows/pr_build_jdk11.yml
@@ -22,7 +22,7 @@ jobs:
       run: |
         echo "CHROMEWEBDRIVER=${CHROMEWEBDRIVER}" >> "$GITHUB_ENV"
     - name: Build on JDK 11
-      run: mvn clean install -DskipTests -B -U && mvn -B test -pl '!tests,!rules-java/tests,!rules-xml/tests,!config/tests' -Dwebdriver.chrome.driver=${{ env.CHROMEWEBDRIVER }}/chromedriver
+      run: mvn clean install -DskipTests -B -U && mvn -B clean install -pl '!tests,!rules-java/tests,!rules-xml/tests,!config/tests' -Dwebdriver.chrome.driver=${{ env.CHROMEWEBDRIVER }}/chromedriver
 
   windup-build-with-unit-tests-2:
     runs-on: ubuntu-latest
@@ -39,7 +39,7 @@ jobs:
       run: |
         echo "CHROMEWEBDRIVER=${CHROMEWEBDRIVER}" >> "$GITHUB_ENV"
     - name: Build on JDK 11
-      run: mvn clean install -DskipTests -B -U && mvn -B test -pl 'rules-java/tests,rules-xml/tests,config/tests' -Dwebdriver.chrome.driver=${{ env.CHROMEWEBDRIVER }}/chromedriver
+      run: mvn clean install -DskipTests -B -U && mvn -B clean install -pl 'rules-java/tests,rules-xml/tests,config/tests' -Dwebdriver.chrome.driver=${{ env.CHROMEWEBDRIVER }}/chromedriver
 
   windup-tests:
     runs-on: ubuntu-latest
@@ -56,4 +56,4 @@ jobs:
       run: |
         echo "CHROMEWEBDRIVER=${CHROMEWEBDRIVER}" >> "$GITHUB_ENV"
     - name: Build on JDK 11
-      run: mvn clean install -DskipTests -B -U && mvn -B test -Dwebdriver.chrome.driver=${{ env.CHROMEWEBDRIVER }}/chromedriver -f tests
+      run: mvn clean install -DskipTests -B -U && mvn -B clean install -Dwebdriver.chrome.driver=${{ env.CHROMEWEBDRIVER }}/chromedriver -f tests

--- a/.github/workflows/pr_build_jdk11.yml
+++ b/.github/workflows/pr_build_jdk11.yml
@@ -22,7 +22,7 @@ jobs:
       run: |
         echo "CHROMEWEBDRIVER=${CHROMEWEBDRIVER}" >> "$GITHUB_ENV"
     - name: Build on JDK 11
-      run: mvn clean install -DskipTests -B -U && mvn -B clean install -pl '!tests,!rules-java/tests,!rules-xml/tests,!config/tests' -Dwebdriver.chrome.driver=${{ env.CHROMEWEBDRIVER }}/chromedriver
+      run: mvn clean install -DskipTests -B -U && mvn -B test -pl '!tests,!rules-java/tests,!rules-xml/tests,!config/tests' -Dwebdriver.chrome.driver=${{ env.CHROMEWEBDRIVER }}/chromedriver
 
   windup-build-with-unit-tests-2:
     runs-on: ubuntu-latest
@@ -39,7 +39,7 @@ jobs:
       run: |
         echo "CHROMEWEBDRIVER=${CHROMEWEBDRIVER}" >> "$GITHUB_ENV"
     - name: Build on JDK 11
-      run: mvn clean install -DskipTests -B -U && mvn -B clean install -pl 'rules-java/tests,rules-xml/tests,config/tests' -Dwebdriver.chrome.driver=${{ env.CHROMEWEBDRIVER }}/chromedriver
+      run: mvn clean install -DskipTests -B -U && mvn -B test -pl 'rules-java/tests,rules-xml/tests,config/tests' -Dwebdriver.chrome.driver=${{ env.CHROMEWEBDRIVER }}/chromedriver
 
   windup-tests:
     runs-on: ubuntu-latest
@@ -56,4 +56,4 @@ jobs:
       run: |
         echo "CHROMEWEBDRIVER=${CHROMEWEBDRIVER}" >> "$GITHUB_ENV"
     - name: Build on JDK 11
-      run: mvn clean install -DskipTests -B -U && mvn -B clean install -Dwebdriver.chrome.driver=${{ env.CHROMEWEBDRIVER }}/chromedriver -f tests
+      run: mvn clean install -DskipTests -B -U && mvn -B test -Dwebdriver.chrome.driver=${{ env.CHROMEWEBDRIVER }}/chromedriver -f tests

--- a/.github/workflows/pr_build_jdk11.yml
+++ b/.github/workflows/pr_build_jdk11.yml
@@ -22,7 +22,7 @@ jobs:
       run: |
         echo "CHROMEWEBDRIVER=${CHROMEWEBDRIVER}" >> "$GITHUB_ENV"
     - name: Build on JDK 11
-      run: mvn clean install -DskipTests -B -U && mvn -B clean install -pl '!tests,!rules-java/tests,!rules-java-ee/tests,!rules-xml/tests,!config/tests' -Dwebdriver.chrome.driver=${{ env.CHROMEWEBDRIVER }}/chromedriver
+      run: mvn clean install -DskipTests -B -U && mvn -B clean install -pl '!tests,!rules-java/tests,!rules-xml/tests,!config/tests' -Dwebdriver.chrome.driver=${{ env.CHROMEWEBDRIVER }}/chromedriver
 
   windup-build-with-unit-tests-2:
     runs-on: ubuntu-latest
@@ -39,7 +39,7 @@ jobs:
       run: |
         echo "CHROMEWEBDRIVER=${CHROMEWEBDRIVER}" >> "$GITHUB_ENV"
     - name: Build on JDK 11
-      run: mvn clean install -DskipTests -B -U && mvn -B clean install -pl 'rules-java/tests,rules-java-ee/tests,rules-xml/tests,config/tests' -Dwebdriver.chrome.driver=${{ env.CHROMEWEBDRIVER }}/chromedriver
+      run: mvn clean install -DskipTests -B -U && mvn -B clean install -pl 'rules-java/tests,rules-xml/tests,config/tests' -Dwebdriver.chrome.driver=${{ env.CHROMEWEBDRIVER }}/chromedriver
 
   windup-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr_build_jdk11.yml
+++ b/.github/workflows/pr_build_jdk11.yml
@@ -6,10 +6,9 @@ on:
       - master
 
 jobs:
-  windup-build-with-unit-tests:
 
+  windup-build-with-unit-tests-1:
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v2.3.4
     - name: Set up JDK 11
@@ -23,7 +22,24 @@ jobs:
       run: |
         echo "CHROMEWEBDRIVER=${CHROMEWEBDRIVER}" >> "$GITHUB_ENV"
     - name: Build on JDK 11
-      run: mvn clean install -DskipTests -B -U && mvn -B clean install -pl '!tests' -Dwebdriver.chrome.driver=${{ env.CHROMEWEBDRIVER }}/chromedriver
+      run: mvn clean install -DskipTests -B -U && mvn -B clean install -pl '!tests,!rules-java,!rules-java-ee,!rules-xml,!config' -Dwebdriver.chrome.driver=${{ env.CHROMEWEBDRIVER }}/chromedriver
+
+  windup-build-with-unit-tests-2:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2.3.4
+    - name: Set up JDK 11
+      uses: actions/setup-java@v2
+      with:
+        java-version: '11'
+        distribution: 'adopt'
+        java-package: jdk
+        cache: 'maven'
+    - name: Set up chromedriver variable
+      run: |
+        echo "CHROMEWEBDRIVER=${CHROMEWEBDRIVER}" >> "$GITHUB_ENV"
+    - name: Build on JDK 11
+      run: mvn clean install -DskipTests -B -U && mvn -B clean install -pl 'rules-java,rules-java-ee,rules-xml,config' -Dwebdriver.chrome.driver=${{ env.CHROMEWEBDRIVER }}/chromedriver
 
   windup-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr_build_jdk11.yml
+++ b/.github/workflows/pr_build_jdk11.yml
@@ -22,7 +22,7 @@ jobs:
       run: |
         echo "CHROMEWEBDRIVER=${CHROMEWEBDRIVER}" >> "$GITHUB_ENV"
     - name: Build on JDK 11
-      run: mvn clean install -DskipTests -B -U && mvn -B clean install -pl '!tests,!rules-java,!rules-java-ee,!rules-xml,!config' -Dwebdriver.chrome.driver=${{ env.CHROMEWEBDRIVER }}/chromedriver
+      run: mvn clean install -DskipTests -B -U && mvn -B clean install -pl '!tests,!rules-java/tests,!rules-java-ee/tests,!rules-xml/tests,!config/tests' -Dwebdriver.chrome.driver=${{ env.CHROMEWEBDRIVER }}/chromedriver
 
   windup-build-with-unit-tests-2:
     runs-on: ubuntu-latest
@@ -39,7 +39,7 @@ jobs:
       run: |
         echo "CHROMEWEBDRIVER=${CHROMEWEBDRIVER}" >> "$GITHUB_ENV"
     - name: Build on JDK 11
-      run: mvn clean install -DskipTests -B -U && mvn -B clean install -pl 'rules-java,rules-java-ee,rules-xml,config' -Dwebdriver.chrome.driver=${{ env.CHROMEWEBDRIVER }}/chromedriver
+      run: mvn clean install -DskipTests -B -U && mvn -B clean install -pl 'rules-java/tests,rules-java-ee/tests,rules-xml/tests,config/tests' -Dwebdriver.chrome.driver=${{ env.CHROMEWEBDRIVER }}/chromedriver
 
   windup-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr_build_jdk11.yml
+++ b/.github/workflows/pr_build_jdk11.yml
@@ -6,7 +6,7 @@ on:
       - master
 
 jobs:
-  windup-build:
+  windup-build-with-unit-tests:
 
     runs-on: ubuntu-latest
 
@@ -23,4 +23,21 @@ jobs:
       run: |
         echo "CHROMEWEBDRIVER=${CHROMEWEBDRIVER}" >> "$GITHUB_ENV"
     - name: Build on JDK 11
-      run: mvn clean install -DskipTests -B -U && mvn -B clean install -Dwebdriver.chrome.driver=${{ env.CHROMEWEBDRIVER }}/chromedriver
+      run: mvn clean install -DskipTests -B -U && mvn -B clean install -pl '!tests' -Dwebdriver.chrome.driver=${{ env.CHROMEWEBDRIVER }}/chromedriver
+
+  windup-tests:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2.3.4
+    - name: Set up JDK 11
+      uses: actions/setup-java@v2
+      with:
+        java-version: '11'
+        distribution: 'adopt'
+        java-package: jdk
+        cache: 'maven'
+    - name: Set up chromedriver variable
+      run: |
+        echo "CHROMEWEBDRIVER=${CHROMEWEBDRIVER}" >> "$GITHUB_ENV"
+    - name: Build on JDK 11
+      run: mvn clean install -DskipTests -B -U && mvn -B clean install -Dwebdriver.chrome.driver=${{ env.CHROMEWEBDRIVER }}/chromedriver -f tests


### PR DESCRIPTION
divided `windup-build` into `windup-build-with-unit-tests-1`, `windup-build-with-unit-tests-2` and `windup-tests`.
`windup-tests` just tests the module the name reflects.
The other two job, `windup-build-with-unit-tests-X` are a way for dividing in a 1-hour each the jobs to cover the remaining tests.

In the end the waiting time for the tests will move from more than 3 hours to something about 1 hour.

PS: the failures in other builds are unrelated to this PR but caused by changes in https://github.com/windup/windup/pull/1515