### PR TITLE
Enabled GH Jobs execution for 'releases/**' branches, both PR and push events

### DIFF
--- a/.github/workflows/pr_build_jdk11.yml
+++ b/.github/workflows/pr_build_jdk11.yml
@@ -1,9 +1,14 @@
-name: Windup PR builder for JDK11
+name: Windup PR/Push builder for JDK11
 
 on:
   pull_request:
     branches: 
       - master
+      - 'releases/**'
+  push:
+    branches:
+      - master
+      - 'releases/**'
 
 jobs:
 

--- a/.github/workflows/pr_build_jdk11_dependents.yml
+++ b/.github/workflows/pr_build_jdk11_dependents.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - master
+      - 'releases/**'
 
 jobs:
   windup-build:
@@ -39,6 +40,7 @@ jobs:
         uses: actions/checkout@v2.3.4
         with:
           repository: windup/windup-rulesets
+          ref: ${{ github.base_ref }}
       - name: Set up JDK 11
         uses: actions/setup-java@v2
         with:
@@ -65,6 +67,7 @@ jobs:
         uses: actions/checkout@v2.3.4
         with:
           repository: windup/windup-maven-plugin
+          ref: ${{ github.base_ref }}
       - name: Set up JDK 11
         uses: actions/setup-java@v2
         with:


### PR DESCRIPTION
backport #1558 