### PR TITLE
Added 'ref' value for windup-quickstarts build

### DIFF
--- a/.github/workflows/pr_build_jdk11_dependents.yml
+++ b/.github/workflows/pr_build_jdk11_dependents.yml
@@ -90,6 +90,7 @@ jobs:
         uses: actions/checkout@v2.3.4
         with:
           repository: windup/windup-quickstarts
+          ref: ${{ github.base_ref }}
       - name: Set up JDK 11
         uses: actions/setup-java@v2
         with:


### PR DESCRIPTION
It fixes the failure in `windup-quickstarts-build` execution in #1565 