### PR TITLE
Excluded 'org.eclipse.core.runtime' artifact from 'diva-core' dependency

### DIFF
--- a/rules-java-diva/addon/pom.xml
+++ b/rules-java-diva/addon/pom.xml
@@ -19,6 +19,12 @@
             <groupId>com.github.konveyor.tackle-diva</groupId>
             <artifactId>diva-core</artifactId>
             <version>0.1.11</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.eclipse.platform</groupId>
+                    <artifactId>org.eclipse.core.runtime</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- Addon Dependencies -->


### PR DESCRIPTION
Backport #1575 