### PR TITLE
Added DiskLimitException management to provide better log

### DIFF
--- a/bootstrap/src/main/java/org/jboss/windup/bootstrap/commands/windup/RunWindupCommand.java
+++ b/bootstrap/src/main/java/org/jboss/windup/bootstrap/commands/windup/RunWindupCommand.java
@@ -2,7 +2,10 @@ package org.jboss.windup.bootstrap.commands.windup;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.janusgraph.core.JanusGraphException;
 import org.jboss.forge.furnace.Furnace;
+import org.jboss.forge.furnace.proxy.Proxies;
 import org.jboss.windup.bootstrap.Bootstrap;
 import org.jboss.windup.bootstrap.ConsoleProgressMonitor;
 import org.jboss.windup.bootstrap.commands.Command;
@@ -286,7 +289,16 @@ public class RunWindupCommand implements Command, FurnaceDependent {
                 System.out.println("If using that option was unintentional, please run Windup again to generate reports.");
             }
         } catch (Exception e) {
-            System.err.println("Execution failed due to: " + e.getMessage());
+            // Due to different classloaders involved in loading these exceptions,
+            // the comparison must be based on exceptions' fully qualified names
+            final Throwable rootCause = ExceptionUtils.getRootCause(e);
+            if (rootCause != null &&
+                    JanusGraphException.class.getName().equals(Proxies.unwrap(e).getClass().getName()) &&
+                    "com.sleepycat.je.DiskLimitException".equals(rootCause.getClass().getName())) {
+                System.err.printf("Execution failed due to disk space issue in the output path. Please check the field 'freeDiskLimit' in the next message: it represents the minimum free space required (in bytes)%n%s%n", ExceptionUtils.getRootCause(e).getMessage());
+            } else {
+                System.err.println("Execution failed due to: " + e.getMessage());
+            }
             e.printStackTrace();
         }
 


### PR DESCRIPTION
https://issues.redhat.com/browse/WINDUP-3596

The console log looks like:
```
Execution failed due to disk space issue in the output path. Please check the field 'freeDiskLimit' in the next message: it represents the minimum free space required (in bytes)
(JE 18.3.12) Disk usage is not within je.maxDisk or je.freeDisk limits and write operations are prohibited: maxDiskLimit=0 freeDiskLimit=107,374,182,400 adjustedMaxDiskLimit=-107,374,182,400 maxDiskOverage=0 freeDiskShortage=97,035,079,680 diskFreeSpace=10,339,102,720 availableLogSize=-97,035,079,680 totalLogSize=1,427 activeLogSize=1,427 reservedLogSize=0 protectedLogSize=0 protectedLogSizeMap={}
org.janusgraph.core.JanusGraphException: Could not execute operation due to backend exception
    at org.jboss.windup.graph.windup-graph:6.2.0-SNAPSHOT_ed498270-5f4c-4b43-9438-9bb181639402//org.janusgraph.diskstorage.util.BackendOperation.execute(BackendOperation.java:54)
    at org.jboss.windup.graph.windup-graph:6.2.0-SNAPSHOT_ed498270-5f4c-4b43-9438-9bb181639402//org.janusgraph.diskstorage.util.BackendOperation.execute(BackendOperation.java:117)
```