### PR TITLE
WINDUP-3663 Fixed some Java EE tech tag version management

### DIFF
--- a/reporting/api/src/main/java/org/jboss/windup/reporting/model/DefaultTechnologyTagComparator.java
+++ b/reporting/api/src/main/java/org/jboss/windup/reporting/model/DefaultTechnologyTagComparator.java
@@ -1,5 +1,7 @@
 package org.jboss.windup.reporting.model;
 
+import org.apache.commons.lang3.StringUtils;
+
 import java.util.Comparator;
 
 /**
@@ -16,6 +18,9 @@ public class DefaultTechnologyTagComparator implements Comparator<TechnologyTagM
         int diff = level1.ordinal() - level2.ordinal();
         if (diff == 0) {
             diff = o1.getName().compareTo(o2.getName());
+            if (diff == 0) {
+                diff = StringUtils.compare(o1.getVersion(), o2.getVersion());
+            }
         }
         return diff;
     }

--- a/reporting/api/src/main/java/org/jboss/windup/reporting/service/TechnologyTagService.java
+++ b/reporting/api/src/main/java/org/jboss/windup/reporting/service/TechnologyTagService.java
@@ -41,11 +41,26 @@ public class TechnologyTagService extends GraphService<TechnologyTagModel> {
     public TechnologyTagModel addTagToFileModel(FileModel fileModel, String tagName, TechnologyTagLevel level) {
         Traversable<Vertex, Vertex> q = getGraphContext().getQuery(TechnologyTagModel.class)
                 .traverse(g -> g.has(TechnologyTagModel.NAME, tagName));
+        return getOrCreate(q, fileModel, tagName, level, null);
+    }
+    /**
+     *
+     * Adds the provided tag to the provided {@link FileModel}. If a {@link TechnologyTagModel} cannot be found with the provided name and version,
+     * then one will be created.
+     */
+    public TechnologyTagModel addTagToFileModel(FileModel fileModel, String tagName, TechnologyTagLevel level, String version) {
+        Traversable<Vertex, Vertex> q = getGraphContext().getQuery(TechnologyTagModel.class)
+                .traverse(g -> g.has(TechnologyTagModel.NAME, tagName).has(TechnologyTagModel.VERSION, version));
+        return getOrCreate(q, fileModel, tagName, level, version);
+    }
+
+    private TechnologyTagModel getOrCreate(Traversable<Vertex, Vertex> q, FileModel fileModel, String tagName, TechnologyTagLevel level, String version) {
         TechnologyTagModel technologyTag = super.getUnique(q.getRawTraversal());
         if (technologyTag == null) {
             technologyTag = create();
             technologyTag.setName(tagName);
             technologyTag.setLevel(level);
+            technologyTag.setVersion(version);
         }
         if (level == TechnologyTagLevel.IMPORTANT && fileModel instanceof SourceFileModel)
             ((SourceFileModel) fileModel).setGenerateSourceReport(true);

--- a/reporting/tests/src/test/java/org/jboss/windup/reporting/service/TechnologyTagServiceTest.java
+++ b/reporting/tests/src/test/java/org/jboss/windup/reporting/service/TechnologyTagServiceTest.java
@@ -81,7 +81,8 @@ public class TechnologyTagServiceTest {
             child3.setName("child3");
             child3.setParentProject(parent);
             FileModel fm5 = fileService.create();
-            TechnologyTagModel child3Tag = techTagService.addTagToFileModel(fm5, "Child3Tag", TechnologyTagLevel.INFORMATIONAL);
+            TechnologyTagModel child3TagVersion1 = techTagService.addTagToFileModel(fm5, "Child3Tag", TechnologyTagLevel.INFORMATIONAL, "1.0");
+            TechnologyTagModel child3TagVersion2 = techTagService.addTagToFileModel(fm5, "Child3Tag", TechnologyTagLevel.INFORMATIONAL, "2.0");
             child3.addFileModel(fm5);
 
             Set<TechnologyTagModel> foundTags = new HashSet<>();
@@ -94,7 +95,8 @@ public class TechnologyTagServiceTest {
             Assert.assertTrue(foundTags.contains(child1Tag));
             Assert.assertTrue(foundTags.contains(child2Tag));
             Assert.assertTrue(foundTags.contains(grandchild1Tag));
-            Assert.assertTrue(foundTags.contains(child3Tag));
+            Assert.assertTrue(foundTags.contains(child3TagVersion1));
+            Assert.assertTrue(foundTags.contains(child3TagVersion2));
         }
     }
 }

--- a/rules-java-ee/addon/src/main/java/org/jboss/windup/rules/apps/javaee/rules/DiscoverEjbConfigurationXmlRuleProvider.java
+++ b/rules-java-ee/addon/src/main/java/org/jboss/windup/rules/apps/javaee/rules/DiscoverEjbConfigurationXmlRuleProvider.java
@@ -292,9 +292,9 @@ public class DiscoverEjbConfigurationXmlRuleProvider extends AbstractRuleProvide
     private void extractMetadata(GraphRewrite event, EvaluationContext context, XmlFileModel xmlModel, Document doc) {
         ClassificationService classificationService = new ClassificationService(event.getGraphContext());
         TechnologyTagService technologyTagService = new TechnologyTagService(event.getGraphContext());
-        TechnologyTagModel technologyTag = technologyTagService.addTagToFileModel(xmlModel, TECH_TAG, TECH_TAG_LEVEL);
         classificationService.attachClassification(event, context, xmlModel, IssueCategoryRegistry.INFORMATION, "EJB XML", "Enterprise Java Bean XML Descriptor.");
 
+        String version;
         // otherwise, it is a EJB-JAR XML.
         if (xmlModel.getDoctype() != null) {
             // check doctype.
@@ -302,15 +302,13 @@ public class DiscoverEjbConfigurationXmlRuleProvider extends AbstractRuleProvide
                 // move to next document.
                 return;
             }
-            String version = processDoctypeVersion(xmlModel.getDoctype());
-            extractMetadata(event, context, xmlModel, doc, version);
+            version = processDoctypeVersion(xmlModel.getDoctype());
         } else {
             String namespace = $(doc).find("ejb-jar").namespaceURI();
             if (StringUtils.isBlank(namespace)) {
                 namespace = doc.getFirstChild().getNamespaceURI();
             }
-
-            String version = $(doc).attr("version");
+            version = $(doc).attr("version");
 
             // if the version attribute isn't found, then grab it from the XSD name if we can.
             if (StringUtils.isBlank(version)) {
@@ -321,12 +319,9 @@ public class DiscoverEjbConfigurationXmlRuleProvider extends AbstractRuleProvide
                 }
             }
 
-            if (StringUtils.isNotBlank(version)) {
-                technologyTag.setVersion(version);
-            }
-
-            extractMetadata(event, context, xmlModel, doc, version);
         }
+        technologyTagService.addTagToFileModel(xmlModel, TECH_TAG, TECH_TAG_LEVEL, version);
+        extractMetadata(event, context, xmlModel, doc, version);
     }
 
     private void extractMetadata(GraphRewrite event, EvaluationContext context, XmlFileModel xml, Document doc, String versionInformation) {

--- a/rules-java-ee/addon/src/main/java/org/jboss/windup/rules/apps/javaee/rules/DiscoverJpaConfigurationXmlRuleProvider.java
+++ b/rules-java-ee/addon/src/main/java/org/jboss/windup/rules/apps/javaee/rules/DiscoverJpaConfigurationXmlRuleProvider.java
@@ -74,12 +74,8 @@ public class DiscoverJpaConfigurationXmlRuleProvider extends IteratingRuleProvid
         JPAEntityService jpaEntityService = new JPAEntityService(graphContext);
 
         TechnologyTagService technologyTagService = new TechnologyTagService(graphContext);
-        TechnologyTagModel technologyTag = technologyTagService.addTagToFileModel(xmlFileModel, TECH_TAG, TECH_TAG_LEVEL);
-
         String version = $(doc).attr("version");
-        if (StringUtils.isNotBlank(version)) {
-            technologyTag.setVersion(version);
-        }
+        technologyTagService.addTagToFileModel(xmlFileModel, TECH_TAG, TECH_TAG_LEVEL, version);
 
         // check the root XML node.
         JPAConfigurationFileModel jpaConfigurationModel = jpaConfigurationFileService.addTypeToModel(xmlFileModel);

--- a/rules-java-ee/addon/src/main/java/org/jboss/windup/rules/apps/javaee/rules/DiscoverWebXmlRuleProvider.java
+++ b/rules-java-ee/addon/src/main/java/org/jboss/windup/rules/apps/javaee/rules/DiscoverWebXmlRuleProvider.java
@@ -106,7 +106,6 @@ public class DiscoverWebXmlRuleProvider extends IteratingRuleProvider<XmlFileMod
         TechnologyTagService technologyTagService = new TechnologyTagService(context);
 
         classificationService.attachClassification(event, evaluationContext, xml, IssueCategoryRegistry.INFORMATION, "Web XML", " Web Application Deployment Descriptors");
-        TechnologyTagModel technologyTag = technologyTagService.addTagToFileModel(xml, TECH_TAG, TECH_TAG_LEVEL);
         WebXmlService webXmlService = new WebXmlService(context);
 
         String webXmlVersion = getVersion(xml, doc);
@@ -118,9 +117,7 @@ public class DiscoverWebXmlRuleProvider extends IteratingRuleProvider<XmlFileMod
         if (StringUtils.isNotBlank(webXmlVersion)) {
             webXmlVersion = StringUtils.replace(webXmlVersion, "_", ".");
             webXml.setSpecificationVersion(webXmlVersion);
-
-            // set the tag version
-            technologyTag.setVersion(webXmlVersion);
+            technologyTagService.addTagToFileModel(xml, TECH_TAG, TECH_TAG_LEVEL, webXmlVersion);
         }
 
         String displayName = $(doc).child("display-name").text();

--- a/rules-java-ee/addon/src/main/java/org/jboss/windup/rules/apps/javaee/rules/DiscoverWebXmlRuleProvider.java
+++ b/rules-java-ee/addon/src/main/java/org/jboss/windup/rules/apps/javaee/rules/DiscoverWebXmlRuleProvider.java
@@ -118,6 +118,8 @@ public class DiscoverWebXmlRuleProvider extends IteratingRuleProvider<XmlFileMod
             webXmlVersion = StringUtils.replace(webXmlVersion, "_", ".");
             webXml.setSpecificationVersion(webXmlVersion);
             technologyTagService.addTagToFileModel(xml, TECH_TAG, TECH_TAG_LEVEL, webXmlVersion);
+        } else {
+            technologyTagService.addTagToFileModel(xml, TECH_TAG, TECH_TAG_LEVEL);
         }
 
         String displayName = $(doc).child("display-name").text();

--- a/rules-java-ee/addon/src/main/java/org/jboss/windup/rules/apps/javaee/rules/jboss/jbpm3/DiscoverJBossJbpmProcessFilesRuleProvider.java
+++ b/rules-java-ee/addon/src/main/java/org/jboss/windup/rules/apps/javaee/rules/jboss/jbpm3/DiscoverJBossJbpmProcessFilesRuleProvider.java
@@ -115,8 +115,7 @@ public class DiscoverJBossJbpmProcessFilesRuleProvider extends IteratingRuleProv
             classificationService.attachClassification(event, context, processDefinitionImage, "JBPM Process Image", "JBPM 3 Process Image.");
 
             TechnologyTagService technologyTagService = new TechnologyTagService(event.getGraphContext());
-            TechnologyTagModel techTag = technologyTagService.addTagToFileModel(processDefinitionImage, "JBoss Process Image", TechnologyTagLevel.IMPORTANT);
-            techTag.setVersion("3");
+            technologyTagService.addTagToFileModel(processDefinitionImage, "JBoss Process Image", TechnologyTagLevel.IMPORTANT, "3");
         }
     }
 }

--- a/rules-java-ee/addon/src/main/java/org/jboss/windup/rules/apps/javaee/rules/orion/ResolveOrionWebXmlRuleProvider.java
+++ b/rules-java-ee/addon/src/main/java/org/jboss/windup/rules/apps/javaee/rules/orion/ResolveOrionWebXmlRuleProvider.java
@@ -55,18 +55,20 @@ public class ResolveOrionWebXmlRuleProvider extends IteratingRuleProvider<XmlFil
         vendorSpecificationService.associateAsVendorExtension(payload, "web.xml");
 
         Set<ProjectModel> applications = ProjectTraversalCache.getApplicationsForProject(event.getGraphContext(), payload.getProjectModel());
+        String version = null;
         for (Element orionWeb : $(doc).child("orion-web-app")) {
             String majorVersion = $(orionWeb).attr("schema-major-version");
             String minorVersion = $(orionWeb).attr("schema-minor-version");
 
             if (StringUtils.isNotBlank(majorVersion)) {
-                String version = majorVersion;
+                version = majorVersion;
                 if (StringUtils.isNotBlank(minorVersion)) {
                     version = version + "." + minorVersion;
                 }
-                technologyTagService.addTagToFileModel(payload, "Orion Web XML", TechnologyTagLevel.IMPORTANT, version);
             }
         }
+        if (!StringUtils.isBlank(version)) technologyTagService.addTagToFileModel(payload, "Orion Web XML", TechnologyTagLevel.IMPORTANT, version);
+        else technologyTagService.addTagToFileModel(payload, "Orion Web XML", TechnologyTagLevel.IMPORTANT);
 
         for (Element resourceRef : $(doc).find("resource-ref-mapping").get()) {
             String jndiLocation = $(resourceRef).attr("location");

--- a/rules-java-ee/addon/src/main/java/org/jboss/windup/rules/apps/javaee/rules/orion/ResolveOrionWebXmlRuleProvider.java
+++ b/rules-java-ee/addon/src/main/java/org/jboss/windup/rules/apps/javaee/rules/orion/ResolveOrionWebXmlRuleProvider.java
@@ -54,7 +54,6 @@ public class ResolveOrionWebXmlRuleProvider extends IteratingRuleProvider<XmlFil
         //mark as vendor extension; create reference to web.xml
         vendorSpecificationService.associateAsVendorExtension(payload, "web.xml");
 
-        TechnologyTagModel technologyTag = technologyTagService.addTagToFileModel(payload, "Orion Web XML", TechnologyTagLevel.IMPORTANT);
         Set<ProjectModel> applications = ProjectTraversalCache.getApplicationsForProject(event.getGraphContext(), payload.getProjectModel());
         for (Element orionWeb : $(doc).child("orion-web-app")) {
             String majorVersion = $(orionWeb).attr("schema-major-version");
@@ -65,7 +64,7 @@ public class ResolveOrionWebXmlRuleProvider extends IteratingRuleProvider<XmlFil
                 if (StringUtils.isNotBlank(minorVersion)) {
                     version = version + "." + minorVersion;
                 }
-                technologyTag.setVersion(version);
+                technologyTagService.addTagToFileModel(payload, "Orion Web XML", TechnologyTagLevel.IMPORTANT, version);
             }
         }
 

--- a/tests/src/test/java/org/jboss/windup/tests/application/WindupArchitectureSeamBookingSourceTest.java
+++ b/tests/src/test/java/org/jboss/windup/tests/application/WindupArchitectureSeamBookingSourceTest.java
@@ -7,8 +7,14 @@ import org.jboss.forge.arquillian.AddonDependency;
 import org.jboss.forge.arquillian.archive.AddonArchive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.windup.graph.GraphContext;
+import org.jboss.windup.reporting.model.TechnologyTagModel;
+import org.jboss.windup.reporting.service.TechnologyTagService;
+import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 @RunWith(Arquillian.class)
 public class WindupArchitectureSeamBookingSourceTest extends WindupArchitectureTest {
@@ -35,6 +41,33 @@ public class WindupArchitectureSeamBookingSourceTest extends WindupArchitectureT
         try (GraphContext context = createGraphContext()) {
             // The test-files folder in the project root dir.
             super.runTest(context, "../test-files/seam-booking-5.2", true);
+
+            TechnologyTagService technologyTagService = new TechnologyTagService(context);
+            List<TechnologyTagModel> technologyTagModels = technologyTagService.findAll();
+            Assert.assertEquals("size", 7, technologyTagModels.size());
+            AtomicBoolean foundEjbJar = new AtomicBoolean(false);
+            AtomicBoolean foundJpaJar = new AtomicBoolean(false);
+            AtomicBoolean foundWebXMLJar = new AtomicBoolean(false);
+            AtomicBoolean foundProperties = new AtomicBoolean(false);
+            AtomicBoolean foundJBossEJBXML = new AtomicBoolean(false);
+            AtomicBoolean foundJavaSource = new AtomicBoolean(false);
+            AtomicBoolean foundMavenXML = new AtomicBoolean(false);
+            technologyTagModels.forEach(technologyTagModel -> {
+                if ("EJB XML".equals(technologyTagModel.getName()) && "3.0".equals(technologyTagModel.getVersion())) foundEjbJar.set(true);
+                if ("JPA XML".equals(technologyTagModel.getName()) && "1.0".equals(technologyTagModel.getVersion())) foundJpaJar.set(true);
+                if ("Web XML".equals(technologyTagModel.getName()) && "2.5".equals(technologyTagModel.getVersion())) foundWebXMLJar.set(true);
+                if ("Properties".equals(technologyTagModel.getName()) && technologyTagModel.getVersion() == null) foundProperties.set(true);
+                if ("JBoss EJB XML".equals(technologyTagModel.getName()) && technologyTagModel.getVersion() == null) foundJBossEJBXML.set(true);
+                if ("Java Source".equals(technologyTagModel.getName()) && technologyTagModel.getVersion() == null) foundJavaSource.set(true);
+                if ("Maven XML".equals(technologyTagModel.getName()) && technologyTagModel.getVersion() == null) foundMavenXML.set(true);
+            });
+            Assert.assertTrue("Not found EJB XML tag", foundEjbJar.get());
+            Assert.assertTrue("Not found JPA XML tag", foundJpaJar.get());
+            Assert.assertTrue("Not found Web XML tag", foundJpaJar.get());
+            Assert.assertTrue("Not found Properties tag", foundProperties.get());
+            Assert.assertTrue("Not found JBoss EJB XML tag", foundJBossEJBXML.get());
+            Assert.assertTrue("Not found Java Source tag", foundJavaSource.get());
+            Assert.assertTrue("Not found Maven XML tag", foundProperties.get());
         }
     }
 

--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.4</version>
+            <version>3.12.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
https://issues.redhat.com/browse/WINDUP-3663

Technology tags fixed (with their tests) :

- `EJB XML` from `DiscoverEjbConfigurationXmlRuleProvider`
- `JPA XML` from `DiscoverJpaConfigurationXmlRuleProvider` 
- `Web XML` from `DiscoverWebXmlRuleProvider`
- `JBoss Process Image` from `DiscoverJBossJbpmProcessFilesRuleProvider`
- `Orion Web XML` from `ResolveOrionWebXmlRuleProvider`

Fixed also the `DefaultTechnologyTagComparator` with a new test added in `TechnologyTagServiceTest#testFindTechnologyTagsByProject`

