### PR TITLE
WINDUP-3664 Added 'version' attribute to both 'technology-tag' and 'technology-tag-exists' tags

### DIFF
--- a/config-xml/schema/windup-jboss-ruleset.xsd
+++ b/config-xml/schema/windup-jboss-ruleset.xsd
@@ -295,6 +295,7 @@
         <xs:complexType>
             <xs:attribute type="xs:string" name="technology-tag" use="required"/>
             <xs:attribute type="xs:string" name="in"/>
+            <xs:attribute type="xs:string" name="version"/>
         </xs:complexType>
     </xs:element>
 
@@ -490,6 +491,7 @@
             <xs:simpleContent>
                 <xs:extension base="xs:string">
                     <xs:attribute name="level" type="technology-tag-level" />
+                    <xs:attribute name="version" type="xs:string" />
                 </xs:extension>
             </xs:simpleContent>
         </xs:complexType>

--- a/reporting/api/src/main/java/org/jboss/windup/reporting/config/TechnologyTagExists.java
+++ b/reporting/api/src/main/java/org/jboss/windup/reporting/config/TechnologyTagExists.java
@@ -18,6 +18,7 @@ import org.ocpsoft.rewrite.context.EvaluationContext;
  */
 public class TechnologyTagExists extends GraphCondition {
     private String namePattern;
+    private String versionPattern;
     private String filename;
 
     private TechnologyTagExists(String namePattern) {
@@ -29,6 +30,14 @@ public class TechnologyTagExists extends GraphCondition {
      */
     public static TechnologyTagExists withName(String namePattern) {
         return new TechnologyTagExists(namePattern);
+    }
+
+    /**
+     * Specifies the regular expression for the version to use when searching {@link TechnologyTagModel} entries.
+     */
+    public TechnologyTagExists withVersion(String versionPattern) {
+        this.versionPattern = "[\\s\\S]*" + versionPattern + "[\\s\\S]*";
+        return this;
     }
 
     /**
@@ -57,6 +66,7 @@ public class TechnologyTagExists extends GraphCondition {
             });
         }
         q.withProperty(TechnologyTagModel.NAME, QueryPropertyComparisonType.REGEX, namePattern);
+        if (versionPattern != null) q.withProperty(TechnologyTagModel.VERSION, QueryPropertyComparisonType.REGEX, versionPattern);
         return q.evaluate(event, context);
     }
 

--- a/reporting/impl/src/main/java/org/jboss/windup/reporting/xml/TechnologyTagExistsHandler.java
+++ b/reporting/impl/src/main/java/org/jboss/windup/reporting/xml/TechnologyTagExistsHandler.java
@@ -1,6 +1,6 @@
 package org.jboss.windup.reporting.xml;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.jboss.windup.config.exception.ConfigurationException;
 import org.jboss.windup.config.parser.ElementHandler;
 import org.jboss.windup.config.parser.NamespaceElementHandler;
@@ -33,6 +33,7 @@ import static org.joox.JOOX.$;
 public class TechnologyTagExistsHandler implements ElementHandler<TechnologyTagExists> {
     static final String ELEMENT_NAME = "technology-tag-exists";
     private static final String NAME = "technology-tag";
+    private static final String VERSION = "version";
 
     @Override
     public TechnologyTagExists processElement(ParserContext handlerManager, Element element) throws ConfigurationException {
@@ -42,7 +43,9 @@ public class TechnologyTagExistsHandler implements ElementHandler<TechnologyTagE
         if (StringUtils.isBlank(technologyTagPattern)) {
             throw new WindupException("Error, '" + ELEMENT_NAME + "' element must have a non-empty '" + NAME + "' attribute");
         }
-
-        return TechnologyTagExists.withName(technologyTagPattern).in(in);
+        final TechnologyTagExists technologyTagExists = TechnologyTagExists.withName(technologyTagPattern).in(in);
+        final String versionPattern = $(element).attr(VERSION);
+        if (StringUtils.isNotBlank(versionPattern)) technologyTagExists.withVersion(versionPattern);
+        return technologyTagExists;
     }
 }

--- a/reporting/impl/src/main/java/org/jboss/windup/reporting/xml/TechnologyTagHandler.java
+++ b/reporting/impl/src/main/java/org/jboss/windup/reporting/xml/TechnologyTagHandler.java
@@ -15,6 +15,7 @@ import org.w3c.dom.Element;
 public class TechnologyTagHandler implements ElementHandler<Object> {
     public static final String TECHNOLOGY_TAG = "technology-tag";
     private static final String LEVEL = "level";
+    private static final String VERSION = "version";
 
     @Override
     public TechnologyTag processElement(ParserContext handlerManager, Element element) throws ConfigurationException {
@@ -29,6 +30,9 @@ public class TechnologyTagHandler implements ElementHandler<Object> {
         if (StringUtils.isNotBlank(category)) {
             issueCategory = TechnologyTagLevel.valueOf(category);
         }
-        return TechnologyTag.withName(tag).withTechnologyTagLevel(issueCategory);
+        final TechnologyTag technologyTag = TechnologyTag.withName(tag).withTechnologyTagLevel(issueCategory);
+        final String version = element.getAttribute(TechnologyTagHandler.VERSION);
+        if (!StringUtils.isBlank(version)) technologyTag.withVersion(version);
+        return technologyTag;
     }
 }

--- a/tests/src/test/java/org/jboss/windup/tests/application/WindupArchitectureJEEExampleTest.java
+++ b/tests/src/test/java/org/jboss/windup/tests/application/WindupArchitectureJEEExampleTest.java
@@ -285,7 +285,8 @@ public class WindupArchitectureJEEExampleTest extends WindupArchitectureTest {
         boxesExpected.add(new TestTechReportUtil.BoxInfo("Embedded", "Connect", "WebService", "CXF", 1, 1));
         boxesExpected.add(new TestTechReportUtil.BoxInfo("Embedded", "Connect", "WebService", "XFire", 1, 1));
         boxesExpected.add(new TestTechReportUtil.BoxInfo("Embedded", "Connect", "WebService", "Axis2", 1, 1));
-        //boxesExpected.add(new TestTechReportUtil.BoxInfo("Embedded", "Connect", "WebService", "Axis", 2, 2));
+        boxesExpected.add(new TestTechReportUtil.BoxInfo("Embedded", "Connect", "WebService", "Axis2-technology-tag", 1, 1));
+        boxesExpected.add(new TestTechReportUtil.BoxInfo("Embedded", "Connect", "WebService", "Axis", 2, 2));
         boxesExpected.add(new TestTechReportUtil.BoxInfo("Embedded", "Store", "Object Mapping", "Hibernate OGM", 1, 1));
         boxesExpected.add(new TestTechReportUtil.BoxInfo("Embedded", "Store", "Object Mapping", "Hibernate", 2, 2));
         boxesExpected.add(new TestTechReportUtil.BoxInfo("Embedded", "Store", "Object Mapping", "EclipseLink", 1, 1));

--- a/tests/src/test/xml/rules/technology-usage/embedded-framework-technology-usage.windup.xml
+++ b/tests/src/test/xml/rules/technology-usage/embedded-framework-technology-usage.windup.xml
@@ -16,6 +16,7 @@
             <when>
                 <graph-query discriminator="TechnologyTagModel">
                     <property name="name">Apache Axis (embedded)</property>
+                    <property name="version">1</property>
                 </graph-query>
             </when>
             <perform>
@@ -29,11 +30,30 @@
         <rule id="technology-usage-embedded-framework-01010">
             <when>
                 <graph-query discriminator="TechnologyTagModel">
-                    <property name="name">Apache Axis2 (embedded)</property>
+                    <property name="name">Apache Axis (embedded)</property>
+                    <property name="version">2</property>
                 </graph-query>
             </when>
             <perform>
                 <technology-identified name="Axis2">
+                    <tag name="Connect"/>
+                    <tag name="Embedded"/>
+                    <tag name="Web Service"/>
+                </technology-identified>
+            </perform>
+        </rule>
+        <rule id="technology-usage-embedded-framework-01011">
+            <when>
+                <technology-tag-exists technology-tag="Apache Axis \(embedded\)" version="2"/>
+            </when>
+            <perform>
+                <!--
+                this adds a placeholder technology-identified that will be checked later on
+                in org.jboss.windup.tests.application.WindupArchitectureJEEExampleTest.validateTechReportFrameworksWar
+                in order to validate the above when condition is evaluated true
+                to test the 'version' attribute works fine
+                -->
+                <technology-identified name="Axis2-technology-tag">
                     <tag name="Connect"/>
                     <tag name="Embedded"/>
                     <tag name="Web Service"/>

--- a/tests/src/test/xml/rules/technology-usage/embedded-framework.windup.xml
+++ b/tests/src/test/xml/rules/technology-usage/embedded-framework.windup.xml
@@ -20,19 +20,22 @@
                 <classification title="Embedded framework - Apache Axis" category-id="optional" effort="0">
                     <description>The application embeds the Apache Axis framework.</description>
                 </classification>
-                <technology-tag level="INFORMATIONAL">Apache Axis (embedded)</technology-tag>
+                <technology-tag level="INFORMATIONAL" version="1">Apache Axis (embedded)</technology-tag>
             </perform>
         </rule>
         <rule id="embedded-framework-01010">
             <when>
-                <file filename="axis2{*}.jar"/>
+                <file filename="axis{version}{*}.jar"/>
             </when>
             <perform>
                 <classification title="Embedded framework - Apache Axis2" category-id="optional" effort="0">
                     <description>The application embeds the Apache Axis2 framework.</description>
                 </classification>
-                <technology-tag level="INFORMATIONAL">Apache Axis2 (embedded)</technology-tag>
+                <technology-tag level="INFORMATIONAL" version="{version}">Apache Axis (embedded)</technology-tag>
             </perform>
+            <where param="version">
+                <matches pattern="(2|3)" />
+            </where>
         </rule>
         <rule id="embedded-framework-01100">
             <when>


### PR DESCRIPTION
https://issues.redhat.com/browse/WINDUP-3664

- added `version` attribute to `technology-tag` tag that works also with `where` parameters
- added `version` attribute (evaluated as a regexp) to `technology-tag-exists` tag in order to be able to test the above new attribute in XML rules and tests
- enhanced integration tests to cover these new attributes