### PR TITLE
Fixed Maven to version '3.8.7' for 'windup-quickstarts-build' job

### DIFF
--- a/.github/workflows/pr_build_jdk11_dependents.yml
+++ b/.github/workflows/pr_build_jdk11_dependents.yml
@@ -104,5 +104,9 @@ jobs:
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-windup-maven-plugin-build-${{ github.sha }}
+      - name: Set up Maven
+        uses: stCarolas/setup-maven@v4.5
+        with:
+          maven-version: 3.8.7
       - name: Build
         run: mvn clean install -s settings.xml -nsu


### PR DESCRIPTION
The scope of this change is to have the `windup-quickstarts-build` job to run again since it has been broken by the latest Ubuntu GitHub runner version (ref. https://github.com/actions/runner-images/issues/7216).
