### PR TITLE
WINDUP-3720 Decoupled JSON extract generation from reports rendering

### DIFF
--- a/rules-java/api/src/main/java/org/jboss/windup/rules/apps/java/reporting/rules/CreateIssueSummaryDataRuleProvider.java
+++ b/rules-java/api/src/main/java/org/jboss/windup/rules/apps/java/reporting/rules/CreateIssueSummaryDataRuleProvider.java
@@ -2,12 +2,9 @@ package org.jboss.windup.rules.apps.java.reporting.rules;
 
 import java.io.FileWriter;
 import java.nio.file.Path;
-import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.jboss.forge.furnace.util.OperatingSystemUtils;
@@ -52,7 +49,6 @@ import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
 @RuleMetadata(phase = ReportRenderingPhase.class)
 public class CreateIssueSummaryDataRuleProvider extends AbstractRuleProvider {
     public static final String ISSUE_SUMMARIES_JS = "issue_summaries.js";
-    private static final Set<String> DISCARDED_TAGS = new HashSet<>(Arrays.asList("Java EE", "Embedded", "View", "Connect", "Store", "Sustain", "Execute"));
 
     @Override
     public Configuration getConfiguration(RuleLoaderContext ruleLoaderContext) {

--- a/rules-java/api/src/main/java/org/jboss/windup/rules/apps/java/reporting/rules/CreateIssueSummaryDataRuleProvider.java
+++ b/rules-java/api/src/main/java/org/jboss/windup/rules/apps/java/reporting/rules/CreateIssueSummaryDataRuleProvider.java
@@ -1,50 +1,48 @@
 package org.jboss.windup.rules.apps.java.reporting.rules;
 
-import java.io.File;
 import java.io.FileWriter;
-import java.io.IOException;
 import java.nio.file.Path;
-import java.text.SimpleDateFormat;
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
-import com.fasterxml.jackson.annotation.JsonFilter;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.databind.ser.FilterProvider;
-import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter;
-import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
 import org.jboss.forge.furnace.util.OperatingSystemUtils;
 import org.jboss.windup.config.AbstractRuleProvider;
 import org.jboss.windup.config.GraphRewrite;
 import org.jboss.windup.config.loader.RuleLoaderContext;
+import org.jboss.windup.config.metadata.RuleMetadata;
 import org.jboss.windup.config.operation.GraphOperation;
 import org.jboss.windup.config.phase.ReportRenderingPhase;
-import org.jboss.windup.graph.GraphContext;
 import org.jboss.windup.graph.model.ProjectModel;
 import org.jboss.windup.graph.model.WindupConfigurationModel;
 import org.jboss.windup.graph.model.resource.FileModel;
-import org.jboss.windup.graph.service.GraphService;
 import org.jboss.windup.graph.service.WindupConfigurationService;
 import org.jboss.windup.graph.traversal.OnlyOnceTraversalStrategy;
 import org.jboss.windup.graph.traversal.ProjectModelTraversal;
-import org.jboss.windup.reporting.freemarker.problemsummary.ProblemSummary;
-import org.jboss.windup.reporting.freemarker.problemsummary.ProblemSummaryService;
-import org.jboss.windup.reporting.model.TechnologyUsageStatisticsModel;
-import org.jboss.windup.reporting.service.EffortReportService;
-import org.jboss.windup.reporting.service.ReportService;
 import org.jboss.windup.reporting.category.IssueCategory;
 import org.jboss.windup.reporting.category.IssueCategoryRegistry;
+import org.jboss.windup.reporting.freemarker.problemsummary.ProblemSummary;
+import org.jboss.windup.reporting.freemarker.problemsummary.ProblemSummaryService;
+import org.jboss.windup.reporting.service.EffortReportService;
+import org.jboss.windup.reporting.service.EffortReportService.EffortLevel;
+import org.jboss.windup.reporting.service.ReportService;
 import org.jboss.windup.util.exception.WindupException;
 import org.ocpsoft.rewrite.config.Configuration;
 import org.ocpsoft.rewrite.config.ConfigurationBuilder;
 import org.ocpsoft.rewrite.context.EvaluationContext;
 
+import com.fasterxml.jackson.annotation.JsonFilter;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.MappingJsonFactory;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.jboss.windup.config.metadata.RuleMetadata;
-import org.jboss.windup.reporting.service.EffortReportService.EffortLevel;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.ser.FilterProvider;
+import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter;
+import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
 
 /**
  * Generates a .js (javascript) file in the reports directory with detailed issue summary information.
@@ -80,7 +78,6 @@ public class CreateIssueSummaryDataRuleProvider extends AbstractRuleProvider {
 
                 issueSummaryWriter.write("var WINDUP_ISSUE_SUMMARIES = [];" + NEWLINE);
                 issueSummaryWriter.write("var WINDUP_TECHNOLOGIES = [];" + NEWLINE);
-                List<Object> analysisSummaryList = new ArrayList<>();
                 for (FileModel inputApplicationFile : windupConfiguration.getInputPaths()) {
                     ProjectModel inputApplication = inputApplicationFile.getProjectModel();
                     ProjectModelTraversal projectModelTraversal = new ProjectModelTraversal(inputApplication, new OnlyOnceTraversalStrategy());
@@ -103,14 +100,6 @@ public class CreateIssueSummaryDataRuleProvider extends AbstractRuleProvider {
                     issueSummaryWriter.write("WINDUP_ISSUE_SUMMARIES['" + inputApplication.getId() + "'] = ");
                     objectMapper.writer(filters).writeValue(issueSummaryWriter, summariesBySeverity);
                     issueSummaryWriter.write(";" + NEWLINE);
-                    if (windupConfiguration.isExportingSummary()) {
-                        analysisSummaryList.add(writeApplicationExportSummary(summariesBySeverity, inputApplicationFile, event.getGraphContext()));
-                    }
-                }
-
-                if (windupConfiguration.isExportingSummary())
-                {
-                    writeJsonOutputFile(analysisSummaryList, windupConfiguration);
                 }
 
                 issueSummaryWriter.write("var effortToDescription = [];" + NEWLINE);
@@ -148,114 +137,5 @@ public class CreateIssueSummaryDataRuleProvider extends AbstractRuleProvider {
     @JsonFilter("graphFilter")
     public static class PropertyFilterMixin {
 
-    }
-
-    private Map<String, Object> writeApplicationExportSummary(Map<String, List<ProblemSummary>> summariesBySeverity, FileModel application, GraphContext context) {
-
-        Map<String, Map<String, Integer>> translatedResults = new HashMap<>();
-
-        summariesBySeverity.forEach((k, v) -> {
-            int incidents = 0;
-            int effortPoints = 0;
-            for (ProblemSummary summary : v) {
-                incidents += summary.getNumberFound();
-                effortPoints += summary.getNumberFound() * summary.getEffortPerIncident();
-            }
-            HashMap<String, Integer> results = new HashMap<>();
-            results.put("incidents", incidents);
-            results.put("totalStoryPoints", effortPoints);
-            translatedResults.put(k, results);
-        });
-
-
-        Map<String, Object> resultsWithTitle = new LinkedHashMap<>();
-        resultsWithTitle.put("application", application.getFileName());
-        resultsWithTitle.put("incidentsByCategory", translatedResults);
-
-        List<ProblemSummary> mandatorySummaries = summariesBySeverity.get("mandatory");
-        Map<Integer, Integer> incidentsByEffort = new HashMap<>();
-        if (mandatorySummaries != null) {
-            mandatorySummaries.forEach(ps -> {
-                if (!incidentsByEffort.containsKey(ps.getEffortPerIncident())) {
-                    incidentsByEffort.put(ps.getEffortPerIncident(), ps.getNumberFound());
-                } else {
-                    incidentsByEffort.replace(ps.getEffortPerIncident(), incidentsByEffort.get(ps.getEffortPerIncident()) + ps.getNumberFound());
-                }
-            });
-        }
-        Map<String, Map<String, Integer>> translatedEffortResults = new HashMap<>();
-
-        incidentsByEffort.forEach((k, v) -> {
-            HashMap<String, Integer> results = new HashMap<>();
-
-            results.put("incidents", v);
-            results.put("totalStoryPoints", k * v);
-            translatedEffortResults.put(getEffortDescription(k), results);
-        });
-
-        resultsWithTitle.put("mandatoryIncidentsByType", translatedEffortResults);
-        resultsWithTitle.put("technologyTags", getTechnologyTagsForApplication(application, context));
-        return resultsWithTitle;
-    }
-
-    private void writeJsonOutputFile(List analysisSummary, WindupConfigurationModel windupConfig){
-        String outputFolderPath = windupConfig.getOutputPath().getFilePath() + File.separator;
-
-        ObjectMapper mapper = new ObjectMapper();
-        String json;
-
-        FileWriter writer = null;
-        try {
-            json = mapper.writeValueAsString(analysisSummary);
-            String filename = "analysisSummary.json";
-            writer = new FileWriter(outputFolderPath + filename);
-            writer.write(json);
-        } catch (JsonProcessingException e) {
-            throw new RuntimeException("Couldn't convert given map to JSON: " + e.getMessage());
-        } catch (IOException ioe) {
-            throw new RuntimeException("Couldn't write summary to file: " + ioe.getMessage());
-        } finally {
-            try {
-                writer.close();
-            } catch (IOException e) {
-                e.printStackTrace();
-            }
-        }
-
-    }
-
-    private Set<Map<String, String>> getTechnologyTagsForApplication(FileModel application, GraphContext context) {
-        final GraphService<TechnologyUsageStatisticsModel> service = new GraphService<>(context, TechnologyUsageStatisticsModel.class);
-        return service.findAll()
-                .stream()
-                .filter(technologyUsageStatisticsModel -> application.getProjectModel().equals(technologyUsageStatisticsModel.getProjectModel().getRootProjectModel()))
-                .map(technologyUsageStatisticsModel -> {
-                    final Map<String, String> techTag = new HashMap<>(2);
-                    techTag.put("name", technologyUsageStatisticsModel.getName());
-                    techTag.put("category", technologyUsageStatisticsModel.getTags()
-                                                .stream()
-                                                .filter(technologyName -> !DISCARDED_TAGS.contains(technologyName))
-                                                .findFirst()
-                                                .orElse("Other"));
-                    return techTag;
-                })
-                .collect(Collectors.toCollection(() -> new TreeSet<>(Comparator.comparing(stringStringMap -> stringStringMap.get("name")))));
-    }
-
-    private String getEffortDescription(Integer effort){
-        switch (effort) {
-            case 0:
-                return "Info";
-            case 1:
-                return "Trivial";
-            case 3:
-                return "Complex";
-            case 5:
-                return "Redesign";
-            case 7:
-                return "Architectural";
-            default:
-                return "Unknown";
-        }
     }
 }

--- a/rules-java/api/src/main/java/org/jboss/windup/rules/apps/java/reporting/rules/CreateJsonSummaryRuleProvider.java
+++ b/rules-java/api/src/main/java/org/jboss/windup/rules/apps/java/reporting/rules/CreateJsonSummaryRuleProvider.java
@@ -1,0 +1,185 @@
+package org.jboss.windup.rules.apps.java.reporting.rules;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
+
+import org.jboss.windup.config.AbstractRuleProvider;
+import org.jboss.windup.config.GraphRewrite;
+import org.jboss.windup.config.loader.RuleLoaderContext;
+import org.jboss.windup.config.metadata.RuleMetadata;
+import org.jboss.windup.config.operation.GraphOperation;
+import org.jboss.windup.config.phase.DependentPhase;
+import org.jboss.windup.config.phase.PostReportGenerationPhase;
+import org.jboss.windup.config.query.Query;
+import org.jboss.windup.graph.GraphContext;
+import org.jboss.windup.graph.model.ProjectModel;
+import org.jboss.windup.graph.model.WindupConfigurationModel;
+import org.jboss.windup.graph.model.resource.FileModel;
+import org.jboss.windup.graph.service.GraphService;
+import org.jboss.windup.graph.service.WindupConfigurationService;
+import org.jboss.windup.graph.traversal.OnlyOnceTraversalStrategy;
+import org.jboss.windup.graph.traversal.ProjectModelTraversal;
+import org.jboss.windup.reporting.freemarker.problemsummary.ProblemSummary;
+import org.jboss.windup.reporting.freemarker.problemsummary.ProblemSummaryService;
+import org.jboss.windup.reporting.model.TechnologyUsageStatisticsModel;
+import org.jboss.windup.reporting.rules.AttachApplicationReportsToIndexRuleProvider;
+import org.jboss.windup.util.exception.WindupException;
+import org.ocpsoft.rewrite.config.Configuration;
+import org.ocpsoft.rewrite.config.ConfigurationBuilder;
+import org.ocpsoft.rewrite.context.EvaluationContext;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * Generates a JSON summary in the reports directory with issues and tags summary information.
+ */
+@RuleMetadata(phase = DependentPhase.class,
+        after = PostReportGenerationPhase.class,
+        before = AttachApplicationReportsToIndexRuleProvider.class,
+        haltOnException = true)
+public class CreateJsonSummaryRuleProvider extends AbstractRuleProvider {
+    private static final Set<String> DISCARDED_TAGS = new HashSet<>(Arrays.asList("Java EE", "Embedded", "View", "Connect", "Store", "Sustain", "Execute"));
+
+    @Override
+    public Configuration getConfiguration(RuleLoaderContext ruleLoaderContext) {
+        return ConfigurationBuilder.begin()
+                .addRule()
+                .when(Query.fromType(WindupConfigurationModel.class).withProperty(WindupConfigurationModel.SUMMARY_MODE, true))
+                .perform(new GraphOperation() {
+                    @Override
+                    public void perform(GraphRewrite event, EvaluationContext context) {
+                        generateDataSummary(event);
+                    }
+                });
+    }
+
+    private void generateDataSummary(GraphRewrite event) {
+        try {
+            final WindupConfigurationModel windupConfiguration = WindupConfigurationService.getConfigurationModel(event.getGraphContext());
+            final List<Object> analysisSummaryList = new ArrayList<>();
+            for (FileModel inputApplicationFile : windupConfiguration.getInputPaths()) {
+                final ProjectModel inputApplication = inputApplicationFile.getProjectModel();
+                final ProjectModelTraversal projectModelTraversal = new ProjectModelTraversal(inputApplication, new OnlyOnceTraversalStrategy());
+                final Map<String, List<ProblemSummary>> summariesBySeverity =
+                        ProblemSummaryService.getProblemSummaries(
+                                        event.getGraphContext(), projectModelTraversal.getAllProjects(true), Collections.emptySet(), Collections.emptySet())
+                                .entrySet().stream().collect(Collectors.toMap((e) -> e.getKey().getCategoryID(), Map.Entry::getValue));
+
+                analysisSummaryList.add(writeApplicationExportSummary(summariesBySeverity, inputApplicationFile, event.getGraphContext()));
+            }
+            writeJsonOutputFile(analysisSummaryList, windupConfiguration);
+        } catch (Exception e) {
+            throw new WindupException("Error serializing problem details due to: " + e.getMessage(), e);
+        }
+    }
+
+    private Map<String, Object> writeApplicationExportSummary(Map<String, List<ProblemSummary>> summariesBySeverity, FileModel application, GraphContext context) {
+
+        final Map<String, Map<String, Integer>> translatedResults = new HashMap<>();
+
+        summariesBySeverity.forEach((k, v) -> {
+            int incidents = 0;
+            int effortPoints = 0;
+            for (ProblemSummary summary : v) {
+                incidents += summary.getNumberFound();
+                effortPoints += summary.getNumberFound() * summary.getEffortPerIncident();
+            }
+            HashMap<String, Integer> results = new HashMap<>();
+            results.put("incidents", incidents);
+            results.put("totalStoryPoints", effortPoints);
+            translatedResults.put(k, results);
+        });
+
+
+        final Map<String, Object> resultsWithTitle = new LinkedHashMap<>();
+        resultsWithTitle.put("application", application.getFileName());
+        resultsWithTitle.put("incidentsByCategory", translatedResults);
+
+        final List<ProblemSummary> mandatorySummaries = summariesBySeverity.get("mandatory");
+        final Map<Integer, Integer> incidentsByEffort = new HashMap<>();
+        if (mandatorySummaries != null) {
+            mandatorySummaries.forEach(ps -> {
+                if (!incidentsByEffort.containsKey(ps.getEffortPerIncident())) {
+                    incidentsByEffort.put(ps.getEffortPerIncident(), ps.getNumberFound());
+                } else {
+                    incidentsByEffort.replace(ps.getEffortPerIncident(), incidentsByEffort.get(ps.getEffortPerIncident()) + ps.getNumberFound());
+                }
+            });
+        }
+        final Map<String, Map<String, Integer>> translatedEffortResults = new HashMap<>();
+
+        incidentsByEffort.forEach((k, v) -> {
+            HashMap<String, Integer> results = new HashMap<>();
+
+            results.put("incidents", v);
+            results.put("totalStoryPoints", k * v);
+            translatedEffortResults.put(getEffortDescription(k), results);
+        });
+
+        resultsWithTitle.put("mandatoryIncidentsByType", translatedEffortResults);
+        resultsWithTitle.put("technologyTags", getTechnologyTagsForApplication(application, context));
+        return resultsWithTitle;
+    }
+
+    private void writeJsonOutputFile(List<Object> analysisSummary, WindupConfigurationModel windupConfig){
+        final String outputFolderPath = windupConfig.getOutputPath().getFilePath() + File.separator + "analysisSummary.json";
+        final ObjectMapper mapper = new ObjectMapper();
+        try (FileWriter writer = new FileWriter(outputFolderPath)) {
+            String json = mapper.writeValueAsString(analysisSummary);
+            writer.write(json);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("Couldn't convert given map to JSON: " + e.getMessage());
+        } catch (IOException ioe) {
+            throw new RuntimeException("Couldn't write summary to file: " + ioe.getMessage());
+        }
+    }
+
+    private Set<Map<String, String>> getTechnologyTagsForApplication(FileModel application, GraphContext context) {
+        final GraphService<TechnologyUsageStatisticsModel> service = new GraphService<>(context, TechnologyUsageStatisticsModel.class);
+        return service.findAll()
+                .stream()
+                .filter(technologyUsageStatisticsModel -> application.getProjectModel().equals(technologyUsageStatisticsModel.getProjectModel().getRootProjectModel()))
+                .map(technologyUsageStatisticsModel -> {
+                    final Map<String, String> techTag = new HashMap<>(2);
+                    techTag.put("name", technologyUsageStatisticsModel.getName());
+                    techTag.put("category", technologyUsageStatisticsModel.getTags()
+                                                .stream()
+                                                .filter(technologyName -> !DISCARDED_TAGS.contains(technologyName))
+                                                .findFirst()
+                                                .orElse("Other"));
+                    return techTag;
+                })
+                .collect(Collectors.toCollection(() -> new TreeSet<>(Comparator.comparing(stringStringMap -> stringStringMap.get("name")))));
+    }
+
+    private String getEffortDescription(Integer effort){
+        switch (effort) {
+            case 0:
+                return "Info";
+            case 1:
+                return "Trivial";
+            case 3:
+                return "Complex";
+            case 5:
+                return "Redesign";
+            case 7:
+                return "Architectural";
+            default:
+                return "Unknown";
+        }
+    }
+}

--- a/rules-java/tests/src/test/java/org/jboss/windup/rules/apps/java/reporting/rules/CreateIssueSummaryDataRuleProviderTest.java
+++ b/rules-java/tests/src/test/java/org/jboss/windup/rules/apps/java/reporting/rules/CreateIssueSummaryDataRuleProviderTest.java
@@ -20,17 +20,14 @@ import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.forge.arquillian.AddonDependencies;
 import org.jboss.forge.arquillian.AddonDependency;
 import org.jboss.forge.arquillian.archive.AddonArchive;
-import org.jboss.forge.furnace.util.Predicate;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.windup.config.AbstractRuleProvider;
 import org.jboss.windup.config.GraphRewrite;
-import org.jboss.windup.config.RuleProvider;
 import org.jboss.windup.config.SkipReportsRenderingOption;
 import org.jboss.windup.config.loader.RuleLoaderContext;
 import org.jboss.windup.config.metadata.RuleMetadata;
 import org.jboss.windup.config.operation.iteration.AbstractIterationOperation;
 import org.jboss.windup.config.query.Query;
-import org.jboss.windup.engine.predicates.RuleProviderWithDependenciesPredicate;
 import org.jboss.windup.exec.WindupProcessor;
 import org.jboss.windup.exec.configuration.WindupConfiguration;
 import org.jboss.windup.exec.configuration.options.ExportSummaryOption;
@@ -52,7 +49,6 @@ import org.jboss.windup.reporting.service.TagSetService;
 import org.jboss.windup.rules.apps.java.config.ScanPackagesOption;
 import org.jboss.windup.util.exception.WindupException;
 import org.junit.Assert;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ocpsoft.rewrite.config.Configuration;
@@ -91,6 +87,7 @@ public class CreateIssueSummaryDataRuleProviderTest {
     public void testExportSummaryGeneration() {
         exportTest(true, false);
     }
+
     @Test
     public void testSkipExportSummaryGeneration() {
         exportTest(false, false);
@@ -145,7 +142,7 @@ public class CreateIssueSummaryDataRuleProviderTest {
         }
     }
 
-    @RuleMetadata (before = CreateIssueSummaryDataRuleProvider.class)
+    @RuleMetadata(before = CreateIssueSummaryDataRuleProvider.class)
     public static class TechTagTestRuleProvider extends AbstractRuleProvider {
         @Override
         public Configuration getConfiguration(RuleLoaderContext ruleLoaderContext) {
@@ -153,40 +150,40 @@ public class CreateIssueSummaryDataRuleProviderTest {
                     .addRule()
                     .when(Query.fromType(ProjectModel.class))
                     .perform(new AbstractIterationOperation<ProjectModel>() {
-                            @Override
-                            public void perform(GraphRewrite event, EvaluationContext context, ProjectModel payload) {
-                                final TagSetService tagSetService = new TagSetService(event.getGraphContext());
-                                final GraphService<TechnologyUsageStatisticsModel> service = new GraphService<>(event.getGraphContext(), TechnologyUsageStatisticsModel.class);
+                                 @Override
+                                 public void perform(GraphRewrite event, EvaluationContext context, ProjectModel payload) {
+                                     final TagSetService tagSetService = new TagSetService(event.getGraphContext());
+                                     final GraphService<TechnologyUsageStatisticsModel> service = new GraphService<>(event.getGraphContext(), TechnologyUsageStatisticsModel.class);
 
-                                if ("app1".equals(payload.getName())) {
-                                    final TagSetModel tagSetModel1 = tagSetService.getOrCreate(event, new HashSet<>(Arrays.asList("Java EE", "Connect", "HTTP")));
-                                    final TechnologyUsageStatisticsModel techTag1 = service.create();
-                                    techTag1.setName("Servlet");
-                                    techTag1.setTagModel(tagSetModel1);
-                                    techTag1.setOccurrenceCount(1);
-                                    techTag1.setProjectModel(payload);
-                                } else {
-                                    final TagSetModel tagSetModel2 = tagSetService.getOrCreate(event, new HashSet<>(Arrays.asList("Embedded", "Store", "Object Mapping")));
-                                    final TechnologyUsageStatisticsModel techTag2 = service.create();
-                                    techTag2.setName("Hibernate");
-                                    techTag2.setTagModel(tagSetModel2);
-                                    techTag2.setProjectModel(payload);
-                                    techTag2.setOccurrenceCount(2);
+                                     if ("app1".equals(payload.getName())) {
+                                         final TagSetModel tagSetModel1 = tagSetService.getOrCreate(event, new HashSet<>(Arrays.asList("Java EE", "Connect", "HTTP")));
+                                         final TechnologyUsageStatisticsModel techTag1 = service.create();
+                                         techTag1.setName("Servlet");
+                                         techTag1.setTagModel(tagSetModel1);
+                                         techTag1.setOccurrenceCount(1);
+                                         techTag1.setProjectModel(payload);
+                                     } else {
+                                         final TagSetModel tagSetModel2 = tagSetService.getOrCreate(event, new HashSet<>(Arrays.asList("Embedded", "Store", "Object Mapping")));
+                                         final TechnologyUsageStatisticsModel techTag2 = service.create();
+                                         techTag2.setName("Hibernate");
+                                         techTag2.setTagModel(tagSetModel2);
+                                         techTag2.setProjectModel(payload);
+                                         techTag2.setOccurrenceCount(2);
 
-                                    final TagSetModel tagSetModel3 = tagSetService.getOrCreate(event, new HashSet<>(Arrays.asList("Embedded", "Sustain", "Security")));
-                                    final TechnologyUsageStatisticsModel techTag3 = service.create();
-                                    techTag3.setName("Bouncy Castle");
-                                    techTag3.setTagModel(tagSetModel3);
-                                    techTag3.setProjectModel(payload);
-                                    techTag3.setOccurrenceCount(3);
-                                }
-                            }
-                        }
+                                         final TagSetModel tagSetModel3 = tagSetService.getOrCreate(event, new HashSet<>(Arrays.asList("Embedded", "Sustain", "Security")));
+                                         final TechnologyUsageStatisticsModel techTag3 = service.create();
+                                         techTag3.setName("Bouncy Castle");
+                                         techTag3.setTagModel(tagSetModel3);
+                                         techTag3.setProjectModel(payload);
+                                         techTag3.setOccurrenceCount(3);
+                                     }
+                                 }
+                             }
                     );
         }
     }
 
-    @RuleMetadata (before = CreateIssueSummaryDataRuleProvider.class)
+    @RuleMetadata(before = CreateIssueSummaryDataRuleProvider.class)
     public static class IssuesTestRuleProvider extends AbstractRuleProvider {
         @Override
         public Configuration getConfiguration(RuleLoaderContext ruleLoaderContext) {
@@ -194,62 +191,62 @@ public class CreateIssueSummaryDataRuleProviderTest {
                     .addRule()
                     .when(Query.fromType(ProjectModel.class))
                     .perform(new AbstractIterationOperation<ProjectModel>() {
-                            @Override
-                            public void perform(GraphRewrite event, EvaluationContext context, ProjectModel payload) {
-                                final InlineHintService inlineHintService = new InlineHintService(event.getGraphContext());
-                                final ClassificationService classificationService = new ClassificationService(event.getGraphContext());
-                                final LinkService linkService = new LinkService(event.getGraphContext());
+                                 @Override
+                                 public void perform(GraphRewrite event, EvaluationContext context, ProjectModel payload) {
+                                     final InlineHintService inlineHintService = new InlineHintService(event.getGraphContext());
+                                     final ClassificationService classificationService = new ClassificationService(event.getGraphContext());
+                                     final LinkService linkService = new LinkService(event.getGraphContext());
 
-                                GraphService<IssueCategoryModel> issueCategoryModelService = new GraphService<>(event.getGraphContext(), IssueCategoryModel.class);
+                                     GraphService<IssueCategoryModel> issueCategoryModelService = new GraphService<>(event.getGraphContext(), IssueCategoryModel.class);
 
-                                IssueCategoryModel mandatoryCategory = issueCategoryModelService.findAll()
-                                        .stream().filter(ic -> ic.getCategoryID().equals(IssueCategoryRegistry.MANDATORY)).findAny().get();
+                                     IssueCategoryModel mandatoryCategory = issueCategoryModelService.findAll()
+                                             .stream().filter(ic -> ic.getCategoryID().equals(IssueCategoryRegistry.MANDATORY)).findAny().get();
 
-                                if ("app1".equals(payload.getName())) {
-                                    final InlineHintModel b1 = inlineHintService.create();
-                                    b1.setRuleID("rule1");
-                                    b1.setSourceSnippit("source1");
-                                    b1.setLineNumber(0);
-                                    b1.setTitle("hint1-text");
-                                    b1.setEffort(50);
-                                    b1.addLink(linkService.getOrCreate("description", "link"));
+                                     if ("app1".equals(payload.getName())) {
+                                         final InlineHintModel b1 = inlineHintService.create();
+                                         b1.setRuleID("rule1");
+                                         b1.setSourceSnippit("source1");
+                                         b1.setLineNumber(0);
+                                         b1.setTitle("hint1-text");
+                                         b1.setEffort(50);
+                                         b1.addLink(linkService.getOrCreate("description", "link"));
 
-                                    final InlineHintModel b1b = inlineHintService.create();
-                                    b1b.setRuleID("rule1");
-                                    b1b.setLineNumber(0);
-                                    b1b.setTitle("hint1b-text");
-                                    b1b.setEffort(3);
-                                    b1b.setIssueCategory(mandatoryCategory);
+                                         final InlineHintModel b1b = inlineHintService.create();
+                                         b1b.setRuleID("rule1");
+                                         b1b.setLineNumber(0);
+                                         b1b.setTitle("hint1b-text");
+                                         b1b.setEffort(3);
+                                         b1b.setIssueCategory(mandatoryCategory);
 
-                                    final ClassificationModel c1 = classificationService.create();
-                                    c1.setRuleID("classification1");
-                                    c1.addLink(linkService.getOrCreate("description", "link"));
-                                    c1.setDescription("description-classification");
-                                    c1.setClassification("classification1-text");
-                                    c1.setEffort(30);
-                                    
-                                    final FileModel helloWorld = payload.getFileModels().get(0);
-                                    b1.setFile(helloWorld);
-                                    b1b.setFile(helloWorld);
-                                    c1.addFileModel(helloWorld);
-                                } else {
-                                    final InlineHintModel b2 = inlineHintService.create();
-                                    b2.setEffort(3);
-                                    b2.setRuleID("rule2");
-                                    b2.setTitle("hint2;\"\"\"\"-te\"xt");
-                                    b2.setLineNumber(0);
+                                         final ClassificationModel c1 = classificationService.create();
+                                         c1.setRuleID("classification1");
+                                         c1.addLink(linkService.getOrCreate("description", "link"));
+                                         c1.setDescription("description-classification");
+                                         c1.setClassification("classification1-text");
+                                         c1.setEffort(30);
 
-                                    final ClassificationModel c2 = classificationService.create();
-                                    c2.setRuleID("classification2");
-                                    c2.setClassification("classification2-text");
-                                    c2.setEffort(300);
+                                         final FileModel helloWorld = payload.getFileModels().get(0);
+                                         b1.setFile(helloWorld);
+                                         b1b.setFile(helloWorld);
+                                         c1.addFileModel(helloWorld);
+                                     } else {
+                                         final InlineHintModel b2 = inlineHintService.create();
+                                         b2.setEffort(3);
+                                         b2.setRuleID("rule2");
+                                         b2.setTitle("hint2;\"\"\"\"-te\"xt");
+                                         b2.setLineNumber(0);
 
-                                    final FileModel helloWorld = payload.getFileModels().get(0);
-                                    b2.setFile(helloWorld);
-                                    c2.addFileModel(helloWorld);
-                                }
-                            }
-                        }
+                                         final ClassificationModel c2 = classificationService.create();
+                                         c2.setRuleID("classification2");
+                                         c2.setClassification("classification2-text");
+                                         c2.setEffort(300);
+
+                                         final FileModel helloWorld = payload.getFileModels().get(0);
+                                         b2.setFile(helloWorld);
+                                         c2.addFileModel(helloWorld);
+                                     }
+                                 }
+                             }
                     );
         }
     }


### PR DESCRIPTION
https://issues.redhat.com/browse/WINDUP-3720

closes #1603 

Changes:

- reverted changes in `CreateIssueSummaryDataRuleProvider` introduced with #1518 
- created a dedicate rule for creating the JSON summary, i.e. `CreateJsonSummaryRuleProvider`
- enhanced tests to cover the "skipReports" use case