### PR TITLE
Fix 'windup-tests' job

### DIFF
--- a/test-util/pom.xml
+++ b/test-util/pom.xml
@@ -18,7 +18,7 @@
         <dependency>
             <groupId>org.seleniumhq.selenium</groupId>
             <artifactId>htmlunit-driver</artifactId>
-            <version>3.58.0</version>
+            <version>4.8.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.google.guava</groupId>
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>org.seleniumhq.selenium</groupId>
             <artifactId>selenium-chrome-driver</artifactId>
-            <version>4.1.2</version>
+            <version>4.8.1</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.google.guava</groupId>

--- a/test-util/src/main/java/org/jboss/windup/testutil/html/TestChromeDriverReportUtil.java
+++ b/test-util/src/main/java/org/jboss/windup/testutil/html/TestChromeDriverReportUtil.java
@@ -1,7 +1,7 @@
 package org.jboss.windup.testutil.html;
 
 import java.nio.file.Path;
-import java.util.concurrent.TimeUnit;
+import java.time.Duration;
 
 import org.openqa.selenium.chrome.ChromeDriver;
 import org.openqa.selenium.chrome.ChromeOptions;
@@ -13,8 +13,15 @@ import org.openqa.selenium.chrome.ChromeOptions;
  */
 public class TestChromeDriverReportUtil extends TestReportUtil {
     public TestChromeDriverReportUtil() {
+        // This is the "right" solution https://www.selenium.dev/blog/2022/using-java11-httpclient/
+        // but it generated a ClassNotFoundException: java.net.http.HttpTimeoutException from JBoss Modules
+        // due to https://issues.redhat.com/browse/MODULES-392 and
+        // org.jboss.forge.furnace:furnace:2.29.1.Final using org.jboss.modules:jboss-modules:1.9.1.Final
+//        System.setProperty("webdriver.http.factory", "jdk-http-client");
+        System.setProperty("webdriver.http.factory", "netty");
         ChromeOptions chromeOptions = new ChromeOptions();
-        chromeOptions.addArguments("--headless");
+        chromeOptions.addArguments("--headless=new");
+        chromeOptions.addArguments("--remote-allow-origins=*");
         this.driver = new ChromeDriver(chromeOptions);
     }
 
@@ -23,7 +30,7 @@ public class TestChromeDriverReportUtil extends TestReportUtil {
         try {
             if (!filePath.toFile().exists())
                 throw new CheckFailedException("Requested page file does not exist: " + filePath);
-            driver.manage().timeouts().setScriptTimeout(30, TimeUnit.SECONDS);
+            driver.manage().timeouts().scriptTimeout(Duration.ofSeconds(30));
             driver.get(filePath.toUri().toString());
         } catch (Exception e) {
             e.printStackTrace();


### PR DESCRIPTION
The issue has been triggered by the [Ubuntu 22.04 (20230313) Image Update](https://github.com/actions/runner-images/releases/tag/ubuntu22%2F20230313.1) that adopted Chrome 111 with which Selenium has the issue https://github.com/SeleniumHQ/selenium/issues/11750.

To "properly" solve it, [Using Java 11+ HTTP Client in Selenium 4.5.0 and beyond](https://www.selenium.dev/blog/2022/using-java11-httpclient/) guide has been applied but it spotted another issue: it caused `java.lang.ClassNotFoundException: java.net.http.HttpTimeoutException` due to [MODULES-392](https://issues.redhat.com/browse/MODULES-392).
The latter issues was fixed in JBoss Modules `1.9.2` but Furnace `2.29.1.Final` is using `jboss-modules:1.9.1.Final`.
So the `netty` driver has been adopted.

Furthermore, changes from [Headless is Going Away!](https://www.selenium.dev/blog/2023/headless-is-going-away/) to prevent issues in the future together with Selenium dependencies updates.