### PR TITLE
backport-github-action requires full version

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -15,7 +15,7 @@ jobs:
             )
         steps:
             - name: Backport Action
-              uses: sqren/backport-github-action@v8
+              uses: sqren/backport-github-action@v8.9.7
               with:
                   github_token: ${{ secrets.GITHUB_TOKEN }}
                   auto_backport_label_prefix: auto-backport-to-


### PR DESCRIPTION
Adds the full version missing in https://github.com/windup/windup/pull/1620