### PR TITLE
RuleSubset: enhanced the 'matched and will be performed' log entry

### DIFF
--- a/config/api/src/main/java/org/jboss/windup/config/RuleSubset.java
+++ b/config/api/src/main/java/org/jboss/windup/config/RuleSubset.java
@@ -237,7 +237,7 @@ public class RuleSubset extends DefaultOperationBuilder implements CompositeOper
                         // Start executing rule
                         subContext.setState(RewriteState.PERFORMING);
                         final Object ruleProviderDesc = ((RuleBuilder) rule).get(RuleMetadataType.RULE_PROVIDER);
-                        log.info("Rule [" + ruleProviderDesc + "] matched and will be performed.");
+                        log.info("Rule [" + ruleProviderDesc + " - " + rule.getId() + "] matched and will be performed.");
 
                         // Run "before rule operations performed" listeners
                         for (RuleLifecycleListener listener : listeners) {


### PR DESCRIPTION
When developing rules, there's a log entry which can be repeated many times: 
```
INFO: Rule [javaee-pom-to-quarkus from file:/home/mrizzi/git/forked/windup-rulesets/rules/rules-reviewed/quarkus/javaee/javaee-pom-to-quarkus.windup.xml] matched and will be performed.
```
But this adds (almost) no value to rule's developer because it refers to ruleset without specifying the rules and hence no helping debugging issues letting the user to understand which rule failed.

With this change the log now looks like
```
INFO: Rule [javaee-pom-to-quarkus from file:/home/mrizzi/git/forked/windup-rulesets/rules/rules-reviewed/quarkus/javaee/javaee-pom-to-quarkus.windup.xml - javaee-pom-to-quarkus-00030] matched and will be performed.
```
which makes it clear the rule `javaee-pom-to-quarkus-00030` (from the `javaee-pom-to-quarkus` ruleset) will be executed.