### PR TITLE
ParameterizedGraphCondition: added var name into warning log

### DIFF
--- a/config/api/src/main/java/org/jboss/windup/config/parameters/ParameterizedGraphCondition.java
+++ b/config/api/src/main/java/org/jboss/windup/config/parameters/ParameterizedGraphCondition.java
@@ -91,18 +91,19 @@ public abstract class ParameterizedGraphCondition extends GraphCondition impleme
                             throw new WindupException("Value store with no associated variables frame. This should not happen");
                         }
 
-                        Iterable<? extends WindupVertexFrame> variable = layer.get(getVarname());
+                        final String varname = getVarname();
+                        Iterable<? extends WindupVertexFrame> variable = layer.get(varname);
                         if (variable != null) {
                             for (WindupVertexFrame frame : variable) {
                                 ParameterValueStore last = resultSetStores.put(frame, valueStore);
                                 if (last != null) {
                                     // FIXME: WHY DOES THIS HAPPEN? WINDUP-1549
                                     LOG.log(paramValueStoreOverwritten ? Level.FINER : Level.WARNING,
-                                            () -> String.format("resultSetStores already had a ParameterValueStore for frame:"
+                                            () -> String.format("resultSetStores already had a ParameterValueStore for frame (varname '%s'):"
                                                             + System.lineSeparator() + "    %s"
                                                             + System.lineSeparator() + "    Old: %s"
                                                             + System.lineSeparator() + "    New: %s"
-                                                            + "%s", frame.toPrettyString(), last, frame,
+                                                            + "%s", varname, frame.toPrettyString(), last, frame,
                                                     paramValueStoreOverwritten ? "" : System.lineSeparator() + "Further incidents will be logged at FINER level as it may occur millions of times."));
                                     paramValueStoreOverwritten = true;
                                 }


### PR DESCRIPTION
Enhanced log when "double frame" is added to know which is the variable accountable for the situation.
For example, while developing [rule `cdi-to-quarkus-groovy-00010`](https://github.com/windup/windup-rulesets/pull/946/files#diff-3b93765efad2246fdcb7d256a6909256c2db7e37a3c0236719aaaf9118ec97d8R70-R114) with multiple `as` fields, this helped a lot providing a log entry like `resultSetStores already had a ParameterValueStore for frame (varname 'injectClassDeclaration')`