### PR TITLE
[WINDUP-3903]-Graphs has wrong scales

### DIFF
--- a/pf-ui/src/main/webapp/src/pages/application-edit/pages/dashboard/components/efforts-section.tsx
+++ b/pf-ui/src/main/webapp/src/pages/application-edit/pages/dashboard/components/efforts-section.tsx
@@ -172,6 +172,14 @@ export const EffortsSection: React.FC<IEffortsSectionProps> = ({
           <CardBody>
             <Chart
               themeColor={ChartThemeColor.multiOrdered}
+              // Define a static domain only if no bar is expected to be rendered
+              domain={
+                incidents.every((e) => {
+                  return e.totalIncidents === 0 && e.totalStoryPoints === 0;
+                })
+                  ? { y: [0, 9] }
+                  : undefined
+              }
               domainPadding={{ x: 35 }}
               padding={{
                 bottom: 40,


### PR DESCRIPTION
https://issues.redhat.com/projects/WINDUP/issues/WINDUP-3903

The issue describes the scales in two sections of the `Dashboard` page:

### Incidents and Story Points
![Screenshot from 2023-06-07 13-45-44](https://github.com/windup/windup/assets/2582866/ed8abadb-ccdc-4f46-a2dc-0f261e249a24)

> Note from the ticket: `the upper one has decimals which are useless because SP are integers`

- The `Y` axis is generated automatically depending on the values set on the report. We are taking Patternfly as it is.
- If the max value of `Y` is too small it is expected to have decimals in the `Y` set of labels because the `Y` axis needs to have a minimum (around 6 or 7) labels to render. We must keep in mind that having decimal labels in the `y` axis has no impact on the accuracy of the values of each Bar in the Chart. The chart continues to be 100% valid.

in short words I don't think this specific point is bug neither I think that it will mislead any user in the correct interpretation of the Chart.

### Mandatory incidents and Story Points

![Screenshot from 2023-06-07 14-05-01](https://github.com/windup/windup/assets/2582866/8d6ef92c-f4c8-4eb1-a2bb-bcd486838242)

A fix to this issue is done in this current PR.
- If any of the bars has any value then the `Y` labels are going to be defined by Patternfly and its internal algorithm.
- If all bars are not going to be rendered, because their `Y` values are ZERO then a static `domain` is set to avoid odd `Y` labels that contain Zeros on the left