### PR TITLE
Fix some memory leaks in windup-rulesets testing

### DIFF
--- a/config/api/src/main/java/org/jboss/windup/config/projecttraversal/ProjectTraversalCache.java
+++ b/config/api/src/main/java/org/jboss/windup/config/projecttraversal/ProjectTraversalCache.java
@@ -71,6 +71,11 @@ public class ProjectTraversalCache extends AbstractRuleLifecycleListener {
         return results;
     }
 
+    public static void clear() {
+        moduleToApplicationCache.clear();
+        applicationToProjectCache.clear();
+    }
+
     private static Set<ProjectModel> getFromCache(ProjectModel project) {
         if (project == null)
             return null;

--- a/reporting-data/addon/src/main/java/org/jboss/windup/reporting/data/rules/DataGatheringRuleProvider.java
+++ b/reporting-data/addon/src/main/java/org/jboss/windup/reporting/data/rules/DataGatheringRuleProvider.java
@@ -33,6 +33,8 @@ public class DataGatheringRuleProvider extends AbstractRuleProvider {
                             executorService.awaitTermination(2, TimeUnit.DAYS);
                         } catch (InterruptedException e) {
                             throw new WindupException("Failed to render reports due to a timeout: " + e.getMessage(), e);
+                        } finally {
+                            AbstractApiRuleProvider.executorServiceMap.remove(event.getGraphContext());
                         }
                     }
                 });

--- a/rules-java/api/src/main/java/org/jboss/windup/rules/apps/java/scan/provider/ClearProjectTraversalCacheRuleProvider.java
+++ b/rules-java/api/src/main/java/org/jboss/windup/rules/apps/java/scan/provider/ClearProjectTraversalCacheRuleProvider.java
@@ -1,0 +1,30 @@
+package org.jboss.windup.rules.apps.java.scan.provider;
+
+import org.jboss.windup.config.AbstractRuleProvider;
+import org.jboss.windup.config.GraphRewrite;
+import org.jboss.windup.config.loader.RuleLoaderContext;
+import org.jboss.windup.config.metadata.RuleMetadata;
+import org.jboss.windup.config.operation.GraphOperation;
+import org.jboss.windup.config.phase.FinalizePhase;
+import org.jboss.windup.config.projecttraversal.ProjectTraversalCache;
+import org.ocpsoft.rewrite.config.Configuration;
+import org.ocpsoft.rewrite.config.ConfigurationBuilder;
+import org.ocpsoft.rewrite.context.EvaluationContext;
+
+/**
+ * Clear the caches used in the {@link ProjectTraversalCache}
+ */
+@RuleMetadata(phase = FinalizePhase.class)
+public class ClearProjectTraversalCacheRuleProvider extends AbstractRuleProvider {
+    @Override
+    public Configuration getConfiguration(RuleLoaderContext ruleLoaderContext) {
+        return ConfigurationBuilder.begin()
+                .addRule()
+                .perform(new GraphOperation() {
+                    @Override
+                    public void perform(GraphRewrite event, EvaluationContext context) {
+                        ProjectTraversalCache.clear();
+                    }
+                });
+    }
+}


### PR DESCRIPTION
Analyzing the JVM's memory while running the test for the windup-rulesets project, it turned out:
1. 59.93% of memory used for GraphRewrite instances referenced in the static AbstractApiRuleProvider.executorServiceMap map
2. Once fixed previous, 22.88% of memory for GraphRewrite instances referenced in the static ProjectTraversalCache.applicationToProjectCache map
