### PR TITLE
Exclude v3.27.0+ for org.eclipse.core.runtime artifact

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -409,7 +409,7 @@
             <dependency>
                 <groupId>org.eclipse.platform</groupId>
                 <artifactId>org.eclipse.core.resources</artifactId>
-                <version>[3.14.0,4.0.0)</version>
+                <version>[3.14.0,3.19.0)</version>
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -404,7 +404,7 @@
             <dependency>
                 <groupId>org.eclipse.platform</groupId>
                 <artifactId>org.eclipse.core.runtime</artifactId>
-                <version>[3.13.0,4.0.0)</version>
+                <version>[3.13.0,3.27.0)</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.platform</groupId>


### PR DESCRIPTION
This fixes
```
bad class file: /home/mrizzi/.m2/repository/org/eclipse/platform/org.eclipse.core.runtime/3.27.0/org.eclipse.core.runtime-3.27.0.jar(/org/eclipse/core/runtime/Plugin.class)
    class file has wrong version 61.0, should be 55.0
[...]
[ERROR] /home/mrizzi/git/forked/windup/java-ast/addon/src/main/java/org/eclipse/jdt/core/dom/WindupASTParser.java:[257,46] error: cannot access Plugin
```
and 

```
 java.lang.UnsupportedClassVersionError: Failed to link org/eclipse/core/resources/IResource (Module "org.jboss.windup.ast.windup-java-ast:6.3.0-SNAPSHOT_1a55c2ab-4120-40ba-b0b1-28f7e76e919d" from AddonModuleLoader): org/eclipse/core/resources/IResource has been compiled by a more recent version of the Java Runtime (class file version 61.0), this version of the Java Runtime only recognizes class file versions up to 55.0
```