### PR TITLE
[releases/6.1.z] Exclude v3.27.0+ for org.eclipse.core.runtime artifact ()

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -385,12 +385,12 @@
             <dependency>
                 <groupId>org.eclipse.platform</groupId>
                 <artifactId>org.eclipse.core.runtime</artifactId>
-                <version>[3.13.0,4.0.0)</version>
+                <version>[3.13.0,3.27.0)</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.platform</groupId>
                 <artifactId>org.eclipse.core.resources</artifactId>
-                <version>[3.14.0,4.0.0)</version>
+                <version>[3.14.0,3.19.0)</version>
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>


### PR DESCRIPTION
backport

- #1678

Changes
* Exclude v3.27.0+ for org.eclipse.core.runtime artifact
* Exclude v3.19.0+ for org.eclipse.core.resources artifact

Depends on

- https://github.com/windup/windup-maven-plugin/pull/48