### PR TITLE
[releases/6.1.z] Topology graph fix backport 6.1.z

### DIFF
--- a/reporting/impl/src/main/resources/reports/resources/css/topology-graph.css
+++ b/reporting/impl/src/main/resources/reports/resources/css/topology-graph.css
@@ -81,6 +81,7 @@ kubernetes-topology-graph {
 
 .app-topology line.ExternalJarEar,
 .app-topology line.ExternalJarWar,
+.app-topology line.ExternalJarJarApp,
 .app-topology line.ExternalJarWarApp {
     stroke-linecap: round;
 }

--- a/reporting/impl/src/main/resources/reports/resources/js/app-dependency-graph.js
+++ b/reporting/impl/src/main/resources/reports/resources/js/app-dependency-graph.js
@@ -7,6 +7,7 @@ var kinds = {
   Ear: '#vertex-Ear',
   War: '#vertex-War',
   WarApp: '#vertex-WarApp',
+  JarApp: '#vertex-JarApp',
   Jar: '#vertex-Jar',
 }
 if (typeof showExternalJars !== 'undefined' && showExternalJars !== null && showExternalJars == true) {

--- a/reporting/impl/src/main/resources/reports/templates/dependency_graph.ftl
+++ b/reporting/impl/src/main/resources/reports/templates/dependency_graph.ftl
@@ -80,6 +80,13 @@
                     </svg>
                 </kubernetes-topology-icon>
                 <label>WARs</label>
+                <kubernetes-topology-icon kind="JarApp">
+                    <svg class="app-topology">
+                        <use xlink:href="#vertex-JarApp" x="15" y="15"></use>
+                    </svg>
+                </kubernetes-topology-icon>
+                <label>JARs</label>
+
                 <br/>
                 <label class="legend">Embedded: </label>
                 <kubernetes-topology-icon kind="War">
@@ -115,6 +122,10 @@
                     <g class="WarApp" id="vertex-WarApp">
                         <circle r="15" fill="#fff" stroke="#aaa"></circle>
                         <text y="5" x="0.5" fill="#0B3C5D" font-family="FontAwesome" font-size="16px" text-anchor="middle">&#xf1b3;</text>
+                    </g>
+                    <g class="JarApp" id="vertex-JarApp">
+                        <circle r="15" fill="#fff" stroke="#aaa"></circle>
+                        <text y="5" x="0.5" fill="#0B3C5D" font-family="FontAwesome" font-size="16px" text-anchor="middle">&#xf1b2;</text>
                     </g>
                     <g class="War" id="vertex-War">
                         <circle r="15" fill="#fff" stroke="#aaa"></circle>

--- a/rules-java/api/src/main/java/org/jboss/windup/rules/apps/java/reporting/freemarker/dto/DependencyGraphItem.java
+++ b/rules-java/api/src/main/java/org/jboss/windup/rules/apps/java/reporting/freemarker/dto/DependencyGraphItem.java
@@ -37,7 +37,7 @@ public class DependencyGraphItem {
 
     enum Kind {
 
-        EAR("Ear"), WAR_APP("WarApp"), WAR("War"), JAR("Jar"), EXTERNAL_JAR("ExternalJar"), UNKNOWN("unknown");
+        EAR("Ear"), WAR_APP("WarApp"), JAR_APP("JarApp"), WAR("War"), JAR("Jar"), EXTERNAL_JAR("ExternalJar"), UNKNOWN("unknown");
 
         private String value;
 
@@ -66,7 +66,7 @@ public class DependencyGraphItem {
             boolean isSkipped = projectModel.getRootFileModel() instanceof IdentifiedArchiveModel;
             switch (projectType.toLowerCase()) {
                 case "jar":
-                    return isSkipped ? EXTERNAL_JAR : JAR;
+                    return isChildren ? (isSkipped ? EXTERNAL_JAR : JAR) : JAR_APP;
                 case "war":
                     return isChildren ? WAR : WAR_APP;
                 case "ear":

--- a/tests/src/test/java/org/jboss/windup/tests/application/WindupArchitectureDuplicateTest.java
+++ b/tests/src/test/java/org/jboss/windup/tests/application/WindupArchitectureDuplicateTest.java
@@ -205,7 +205,7 @@ public class WindupArchitectureDuplicateTest extends WindupArchitectureTest {
         Assert.assertNotNull(dependencyReport);
         TestDependencyGraphReportUtil dependencyGraphReportUtil = new TestDependencyGraphReportUtil();
         dependencyGraphReportUtil.loadPage(dependencyReport);
-        Assert.assertEquals(18, dependencyGraphReportUtil.getNumberOfArchivesInTheGraph());
+        Assert.assertEquals(19, dependencyGraphReportUtil.getNumberOfArchivesInTheGraph());
         Assert.assertEquals(1, dependencyGraphReportUtil.getNumberOfArchivesInTheGraphByName("duplicate-ear-test-3.ear"));
         Assert.assertEquals(1, dependencyGraphReportUtil.getNumberOfArchivesInTheGraphByName("log4j-1.2.6.jar"));
         Assert.assertEquals(1, dependencyGraphReportUtil.getNumberOfArchivesInTheGraphByName("jee-example-services2.jar"));

--- a/tests/src/test/java/org/jboss/windup/tests/application/WindupArchitectureExplodedAppTest.java
+++ b/tests/src/test/java/org/jboss/windup/tests/application/WindupArchitectureExplodedAppTest.java
@@ -73,7 +73,7 @@ public class WindupArchitectureExplodedAppTest extends WindupArchitectureTest {
         Assert.assertNotNull(dependencyReport);
         TestDependencyGraphReportUtil dependencyGraphReportUtil = new TestDependencyGraphReportUtil();
         dependencyGraphReportUtil.loadPage(dependencyReport);
-        Assert.assertEquals(21, dependencyGraphReportUtil.getNumberOfArchivesInTheGraph());
+        Assert.assertEquals(22, dependencyGraphReportUtil.getNumberOfArchivesInTheGraph());
         Assert.assertEquals(1, dependencyGraphReportUtil.getNumberOfArchivesInTheGraphByName(EXPLODED_APP_DIR));
         Assert.assertEquals(1, dependencyGraphReportUtil.getNumberOfArchivesInTheGraphByName("commons-logging-1.1.1.jar"));
         Assert.assertEquals(1, dependencyGraphReportUtil.getNumberOfArchivesInTheGraphByName("standard-1.1.2.jar"));


### PR DESCRIPTION
backport https://github.com/windup/windup/pull/1632

* Fix for the topology graph to be able to display "Jar" apps and "Jar" containing other "Jar" libraries.
* Updating tests to match the new number of archives in the graph