### PR TITLE
[WINDUP-4055], [WINDUP-4056] Upgrade io.netty:netty-codec-http2:jar to 4.1.100

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -546,6 +546,11 @@
                 <artifactId>commons-text</artifactId>
                 <version>1.10.0</version>
             </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-all</artifactId>
+                <version>4.1.100.Final</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 </project>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -551,6 +551,11 @@
                 <artifactId>netty-all</artifactId>
                 <version>4.1.100.Final</version>
             </dependency>
+            <dependency>
+                <groupId>io.vertx</groupId>
+                <artifactId>vertx-core</artifactId>
+                <version>4.4.6</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 </project>


### PR DESCRIPTION
https://issues.redhat.com/browse/WINDUP-4055
https://issues.redhat.com/browse/WINDUP-4056

Objective: to upgrade `io.netty:netty-codec-http2` to the latest version `4.1.100.Final`