### PR TITLE
WINDUP-4114 fix for HtmlUnit CVE

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -411,11 +411,11 @@
                 <artifactId>org.eclipse.core.resources</artifactId>
                 <version>[3.14.0,3.19.0)</version>
             </dependency>
-            <dependency>
+            <!--dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-all</artifactId>
                 <version>4.1.86.Final</version>
-            </dependency>
+            </dependency-->
             <dependency>
                 <groupId>org.jsoup</groupId>
                 <artifactId>jsoup</artifactId>
@@ -549,12 +549,17 @@
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-all</artifactId>
-                <version>4.1.100.Final</version>
+                <version>4.1.104.Final</version>
             </dependency>
             <dependency>
                 <groupId>io.vertx</groupId>
                 <artifactId>vertx-core</artifactId>
                 <version>4.4.6</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jboss.modules</groupId>
+                <artifactId>jboss-modules</artifactId>
+                <version>1.9.2.Final</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -219,7 +219,6 @@
                 <artifactId>zip4j</artifactId>
                 <version>2.11.5</version>
             </dependency>
-
         </dependencies>
     </dependencyManagement>
 

--- a/test-util/pom.xml
+++ b/test-util/pom.xml
@@ -17,8 +17,8 @@
         <!-- Local Dependencies -->
         <dependency>
             <groupId>org.seleniumhq.selenium</groupId>
-            <artifactId>htmlunit-driver</artifactId>
-            <version>4.8.0</version>
+            <artifactId>htmlunit3-driver</artifactId>
+            <version>4.16.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.google.guava</groupId>
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>org.seleniumhq.selenium</groupId>
             <artifactId>selenium-chrome-driver</artifactId>
-            <version>4.8.1</version>
+            <version>4.16.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.google.guava</groupId>

--- a/test-util/src/main/java/org/jboss/windup/testutil/html/TestChromeDriverReportUtil.java
+++ b/test-util/src/main/java/org/jboss/windup/testutil/html/TestChromeDriverReportUtil.java
@@ -17,8 +17,8 @@ public class TestChromeDriverReportUtil extends TestReportUtil {
         // but it generated a ClassNotFoundException: java.net.http.HttpTimeoutException from JBoss Modules
         // due to https://issues.redhat.com/browse/MODULES-392 and
         // org.jboss.forge.furnace:furnace:2.29.1.Final using org.jboss.modules:jboss-modules:1.9.1.Final
-//        System.setProperty("webdriver.http.factory", "jdk-http-client");
-        System.setProperty("webdriver.http.factory", "netty");
+        System.setProperty("webdriver.http.factory", "jdk-http-client");
+//        System.setProperty("webdriver.http.factory", "netty");
         ChromeOptions chromeOptions = new ChromeOptions();
         chromeOptions.addArguments("--headless=new");
         chromeOptions.addArguments("--remote-allow-origins=*");

--- a/test-util/src/main/java/org/jboss/windup/testutil/html/TestReportUtil.java
+++ b/test-util/src/main/java/org/jboss/windup/testutil/html/TestReportUtil.java
@@ -9,9 +9,9 @@ import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.htmlunit.HtmlUnitDriver;
 
-import com.gargoylesoftware.htmlunit.BrowserVersion;
-import com.gargoylesoftware.htmlunit.SilentCssErrorHandler;
-import com.gargoylesoftware.htmlunit.WebClient;
+import org.htmlunit.BrowserVersion;
+import org.htmlunit.SilentCssErrorHandler;
+import org.htmlunit.WebClient;
 
 /**
  * Contains utility methods for assisting tests in interacting with the generated reports.


### PR DESCRIPTION
https://issues.redhat.com/browse/WINDUP-4114
https://bugzilla.redhat.com/show_bug.cgi?id=2252942
https://access.redhat.com/security/cve/CVE-2023-49093

as agreed with @mrizzi I've opened this PR so we can decide if we want to make these changes to fix this CVE

Selenium versions updated in test-util/pom.xml as `v14.6.0` brings the correct htmlunit version, `v3.9.0`.
However this requires code changes because of htmlunit migration from v2->3, where pacvkage names change.
Even with this change, running tests brought a failure of `java.lang.IllegalArgumentException: Unknown HttpClient factory netty` wihen using test-util classes.
The code was using netty as html client only as a workaround for a bug in `jboss-modules:1.9.1.Final` affecting selenium, used by the latest version of furnace, https://issues.redhat.com/browse/MODULES-392.
So I overrode the version of jboss-modules to the fixed version, `v1,9,2,Final` which alowed us to use the selenium recommended http client,` jdk-http-client`