### PR TITLE
WINDUP-4136: upgrade commons-compress to v1.26.0

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -534,7 +534,7 @@
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-compress</artifactId>
-                <version>1.21</version>
+                <version>1.26.0</version>
             </dependency>
             <dependency>
                 <groupId>org.freemarker</groupId>


### PR DESCRIPTION
[WINDUP-4136](https://issues.redhat.com/browse/WINDUP-4136)
[WINDUP-4137](https://issues.redhat.com/browse/WINDUP-4137)
[WINDUP-4138](https://issues.redhat.com/browse/WINDUP-4138)