### PR TITLE
WINDUP-4200 Add org.eclipse.text runtime dependency

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -412,6 +412,11 @@
                 <version>[3.14.0,3.19.0)</version>
             </dependency>
             <dependency>
+                <groupId>org.eclipse.platform</groupId>
+                <artifactId>org.eclipse.text</artifactId>
+                <version>3.11.0</version>
+            </dependency>
+            <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-all</artifactId>
                 <version>4.1.86.Final</version>

--- a/java-ast/addon/pom.xml
+++ b/java-ast/addon/pom.xml
@@ -30,6 +30,10 @@
             <groupId>org.eclipse.platform</groupId>
             <artifactId>org.eclipse.core.resources</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.eclipse.platform</groupId>
+            <artifactId>org.eclipse.text</artifactId>
+        </dependency>
 
         <!-- Addon Dependencies -->
         <dependency>


### PR DESCRIPTION
https://issues.redhat.com/browse/WINDUP-4200

In this way, Windup will properly log from , i.e.
```
2024-08-02 10:58 [53/1683] InitialAnalysisPhase - AnalyzeJavaFilesRuleProvider - AnalyzeJavaFilesRuleProvider_1
Status ERROR: org.eclipse.jdt.core code=4 Could not retrieve interfaces org.eclipse.jdt.internal.compiler.problem.AbortCompilation: Pb(324) The type org.eclipse.swt.widgets.Composite cannot be resolved. It is indirectly referenced from required .class files
2024-08-02 11:02 [54/1683] InitialAnalysisPhase - DiscoverHibernateMappingRuleProvider - DiscoverHibernateMappingRuleProvider_1
```