### PR TITLE
[releases/6.3.z] WINDUP-4200 Add org.eclipse.text runtime dependency

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -417,6 +417,11 @@
                 <version>2.10.1</version>
             </dependency>
             <dependency>
+                <groupId>org.eclipse.platform</groupId>
+                <artifactId>org.eclipse.text</artifactId>
+                <version>3.11.0</version>
+            </dependency>
+            <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-all</artifactId>
                 <version>4.1.86.Final</version>

--- a/java-ast/addon/pom.xml
+++ b/java-ast/addon/pom.xml
@@ -30,6 +30,10 @@
             <groupId>org.eclipse.platform</groupId>
             <artifactId>org.eclipse.core.resources</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.eclipse.platform</groupId>
+            <artifactId>org.eclipse.text</artifactId>
+        </dependency>
 
         <!-- Addon Dependencies -->
         <dependency>


### PR DESCRIPTION
https://issues.redhat.com/browse/WINDUP-4200

Backport

- https://github.com/windup/windup/pull/1745