### PR TITLE
Revert "🏁 Releasing version 6.3.9.Final"

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>org.jboss.windup</groupId>
     <artifactId>windup-bom</artifactId>
-    <version>6.3.9.Final</version>
+    <version>6.3.9-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Windup BOM</name>

--- a/bootstrap/pom.xml
+++ b/bootstrap/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jboss.windup</groupId>
         <artifactId>windup-parent</artifactId>
-        <version>6.3.9.Final</version>
+        <version>6.3.9-SNAPSHOT</version>
     </parent>
 
     <artifactId>windup-bootstrap</artifactId>

--- a/bootstraps-themed/bootstrap-mta/pom.xml
+++ b/bootstraps-themed/bootstrap-mta/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jboss.windup</groupId>
         <artifactId>windup-bootstraps-themed</artifactId>
-        <version>6.3.9.Final</version>
+        <version>6.3.9-SNAPSHOT</version>
     </parent>
 
     <artifactId>windup-bootstrap-mta</artifactId>

--- a/bootstraps-themed/bootstrap-mtr/pom.xml
+++ b/bootstraps-themed/bootstrap-mtr/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jboss.windup</groupId>
         <artifactId>windup-bootstraps-themed</artifactId>
-        <version>6.3.9.Final</version>
+        <version>6.3.9-SNAPSHOT</version>
     </parent>
 
     <artifactId>windup-bootstrap-mtr</artifactId>

--- a/bootstraps-themed/bootstrap-tackle/pom.xml
+++ b/bootstraps-themed/bootstrap-tackle/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jboss.windup</groupId>
         <artifactId>windup-bootstraps-themed</artifactId>
-        <version>6.3.9.Final</version>
+        <version>6.3.9-SNAPSHOT</version>
     </parent>
 
     <artifactId>windup-bootstrap-tackle</artifactId>

--- a/bootstraps-themed/bootstrap-windup/pom.xml
+++ b/bootstraps-themed/bootstrap-windup/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jboss.windup</groupId>
         <artifactId>windup-bootstraps-themed</artifactId>
-        <version>6.3.9.Final</version>
+        <version>6.3.9-SNAPSHOT</version>
     </parent>
 
     <artifactId>windup-bootstrap-windup</artifactId>

--- a/bootstraps-themed/pom.xml
+++ b/bootstraps-themed/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jboss.windup</groupId>
         <artifactId>windup-parent</artifactId>
-        <version>6.3.9.Final</version>
+        <version>6.3.9-SNAPSHOT</version>
     </parent>
 
     <artifactId>windup-bootstraps-themed</artifactId>

--- a/config-groovy/addon/pom.xml
+++ b/config-groovy/addon/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jboss.windup.config</groupId>
         <artifactId>windup-config-groovy-parent</artifactId>
-        <version>6.3.9.Final</version>
+        <version>6.3.9-SNAPSHOT</version>
     </parent>
 
     <artifactId>windup-config-groovy</artifactId>

--- a/config-groovy/pom.xml
+++ b/config-groovy/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jboss.windup</groupId>
         <artifactId>windup-parent</artifactId>
-        <version>6.3.9.Final</version>
+        <version>6.3.9-SNAPSHOT</version>
     </parent>
 
     <groupId>org.jboss.windup.config</groupId>

--- a/config-groovy/tests/pom.xml
+++ b/config-groovy/tests/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jboss.windup.config</groupId>
         <artifactId>windup-config-groovy-parent</artifactId>
-        <version>6.3.9.Final</version>
+        <version>6.3.9-SNAPSHOT</version>
     </parent>
 
     <artifactId>windup-config-groovy-tests</artifactId>

--- a/config-xml/addon/pom.xml
+++ b/config-xml/addon/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jboss.windup.config</groupId>
         <artifactId>windup-config-xml-parent</artifactId>
-        <version>6.3.9.Final</version>
+        <version>6.3.9-SNAPSHOT</version>
     </parent>
 
     <artifactId>windup-config-xml</artifactId>

--- a/config-xml/pom.xml
+++ b/config-xml/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jboss.windup</groupId>
         <artifactId>windup-parent</artifactId>
-        <version>6.3.9.Final</version>
+        <version>6.3.9-SNAPSHOT</version>
     </parent>
 
     <groupId>org.jboss.windup.config</groupId>

--- a/config-xml/tests/pom.xml
+++ b/config-xml/tests/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jboss.windup.config</groupId>
         <artifactId>windup-config-xml-parent</artifactId>
-        <version>6.3.9.Final</version>
+        <version>6.3.9-SNAPSHOT</version>
     </parent>
 
     <artifactId>windup-config-xml-tests</artifactId>

--- a/config/addon/pom.xml
+++ b/config/addon/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jboss.windup.config</groupId>
         <artifactId>windup-config-parent</artifactId>
-        <version>6.3.9.Final</version>
+        <version>6.3.9-SNAPSHOT</version>
     </parent>
 
     <artifactId>windup-config</artifactId>

--- a/config/api/pom.xml
+++ b/config/api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jboss.windup.config</groupId>
         <artifactId>windup-config-parent</artifactId>
-        <version>6.3.9.Final</version>
+        <version>6.3.9-SNAPSHOT</version>
     </parent>
 
     <artifactId>windup-config-api</artifactId>

--- a/config/impl/pom.xml
+++ b/config/impl/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jboss.windup.config</groupId>
         <artifactId>windup-config-parent</artifactId>
-        <version>6.3.9.Final</version>
+        <version>6.3.9-SNAPSHOT</version>
     </parent>
 
     <artifactId>windup-config-impl</artifactId>

--- a/config/pom.xml
+++ b/config/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jboss.windup</groupId>
         <artifactId>windup-parent</artifactId>
-        <version>6.3.9.Final</version>
+        <version>6.3.9-SNAPSHOT</version>
     </parent>
 
     <groupId>org.jboss.windup.config</groupId>

--- a/config/tests/pom.xml
+++ b/config/tests/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jboss.windup.config</groupId>
         <artifactId>windup-config-parent</artifactId>
-        <version>6.3.9.Final</version>
+        <version>6.3.9-SNAPSHOT</version>
     </parent>
 
     <artifactId>windup-config-tests</artifactId>

--- a/coverage-report/pom.xml
+++ b/coverage-report/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jboss.windup</groupId>
         <artifactId>windup-parent</artifactId>
-        <version>6.3.9.Final</version>
+        <version>6.3.9-SNAPSHOT</version>
     </parent>
 
     <artifactId>windup-coverage-report</artifactId>

--- a/decompiler/api/pom.xml
+++ b/decompiler/api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jboss.windup.decompiler</groupId>
         <artifactId>decompiler-parent</artifactId>
-        <version>6.3.9.Final</version>
+        <version>6.3.9-SNAPSHOT</version>
     </parent>
 
     <!-- TODO Donate this addon to Forge. -->

--- a/decompiler/impl-fernflower/pom.xml
+++ b/decompiler/impl-fernflower/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jboss.windup.decompiler</groupId>
         <artifactId>decompiler-parent</artifactId>
-        <version>6.3.9.Final</version>
+        <version>6.3.9-SNAPSHOT</version>
     </parent>
 
     <artifactId>decompiler-fernflower</artifactId>

--- a/decompiler/impl-procyon/pom.xml
+++ b/decompiler/impl-procyon/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jboss.windup.decompiler</groupId>
         <artifactId>decompiler-parent</artifactId>
-        <version>6.3.9.Final</version>
+        <version>6.3.9-SNAPSHOT</version>
     </parent>
 
     <!-- TODO Donate this addon to Forge. -->

--- a/decompiler/pom.xml
+++ b/decompiler/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jboss.windup</groupId>
         <artifactId>windup-parent</artifactId>
-        <version>6.3.9.Final</version>
+        <version>6.3.9-SNAPSHOT</version>
     </parent>
 
     <groupId>org.jboss.windup.decompiler</groupId>

--- a/exec/addon/pom.xml
+++ b/exec/addon/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jboss.windup.exec</groupId>
         <artifactId>windup-exec-parent</artifactId>
-        <version>6.3.9.Final</version>
+        <version>6.3.9-SNAPSHOT</version>
     </parent>
 
     <artifactId>windup-exec</artifactId>

--- a/exec/api/pom.xml
+++ b/exec/api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jboss.windup.exec</groupId>
         <artifactId>windup-exec-parent</artifactId>
-        <version>6.3.9.Final</version>
+        <version>6.3.9-SNAPSHOT</version>
     </parent>
 
     <artifactId>windup-exec-api</artifactId>

--- a/exec/impl/pom.xml
+++ b/exec/impl/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jboss.windup.exec</groupId>
         <artifactId>windup-exec-parent</artifactId>
-        <version>6.3.9.Final</version>
+        <version>6.3.9-SNAPSHOT</version>
     </parent>
 
     <artifactId>windup-exec-impl</artifactId>

--- a/exec/pom.xml
+++ b/exec/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jboss.windup</groupId>
         <artifactId>windup-parent</artifactId>
-        <version>6.3.9.Final</version>
+        <version>6.3.9-SNAPSHOT</version>
     </parent>
 
     <groupId>org.jboss.windup.exec</groupId>

--- a/exec/tests/pom.xml
+++ b/exec/tests/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jboss.windup.exec</groupId>
         <artifactId>windup-exec-parent</artifactId>
-        <version>6.3.9.Final</version>
+        <version>6.3.9-SNAPSHOT</version>
     </parent>
 
     <artifactId>windup-exec-tests</artifactId>

--- a/forks/gremlin-shaded/pom.xml
+++ b/forks/gremlin-shaded/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jboss.windup</groupId>
         <artifactId>windup-parent</artifactId>
-        <version>6.3.9.Final</version>
+        <version>6.3.9-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/forks/jdt/pom.xml
+++ b/forks/jdt/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jboss.windup</groupId>
         <artifactId>windup-parent</artifactId>
-        <version>6.3.9.Final</version>
+        <version>6.3.9-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/graph/addon/pom.xml
+++ b/graph/addon/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jboss.windup.graph</groupId>
         <artifactId>windup-graph-parent</artifactId>
-        <version>6.3.9.Final</version>
+        <version>6.3.9-SNAPSHOT</version>
     </parent>
 
     <artifactId>windup-graph</artifactId>

--- a/graph/api/pom.xml
+++ b/graph/api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jboss.windup.graph</groupId>
         <artifactId>windup-graph-parent</artifactId>
-        <version>6.3.9.Final</version>
+        <version>6.3.9-SNAPSHOT</version>
     </parent>
 
     <artifactId>windup-graph-api</artifactId>

--- a/graph/impl/pom.xml
+++ b/graph/impl/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jboss.windup.graph</groupId>
         <artifactId>windup-graph-parent</artifactId>
-        <version>6.3.9.Final</version>
+        <version>6.3.9-SNAPSHOT</version>
     </parent>
 
     <artifactId>windup-graph-impl</artifactId>

--- a/graph/pom.xml
+++ b/graph/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jboss.windup</groupId>
         <artifactId>windup-parent</artifactId>
-        <version>6.3.9.Final</version>
+        <version>6.3.9-SNAPSHOT</version>
     </parent>
 
     <groupId>org.jboss.windup.graph</groupId>

--- a/graph/tests/pom.xml
+++ b/graph/tests/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jboss.windup.graph</groupId>
         <artifactId>windup-graph-parent</artifactId>
-        <version>6.3.9.Final</version>
+        <version>6.3.9-SNAPSHOT</version>
     </parent>
 
     <artifactId>windup-graph-tests</artifactId>

--- a/java-ast/addon/pom.xml
+++ b/java-ast/addon/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jboss.windup.ast</groupId>
         <artifactId>windup-java-ast-parent</artifactId>
-        <version>6.3.9.Final</version>
+        <version>6.3.9-SNAPSHOT</version>
     </parent>
 
     <artifactId>windup-java-ast</artifactId>

--- a/java-ast/pom.xml
+++ b/java-ast/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jboss.windup</groupId>
         <artifactId>windup-parent</artifactId>
-        <version>6.3.9.Final</version>
+        <version>6.3.9-SNAPSHOT</version>
     </parent>
 
     <groupId>org.jboss.windup.ast</groupId>

--- a/java-ast/tests/pom.xml
+++ b/java-ast/tests/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jboss.windup.ast</groupId>
         <artifactId>windup-java-ast-parent</artifactId>
-        <version>6.3.9.Final</version>
+        <version>6.3.9-SNAPSHOT</version>
     </parent>
     <artifactId>windup-java-ast-tests</artifactId>
     <name>Windup AST - Java - Tests</name>

--- a/module-spec/pom.xml
+++ b/module-spec/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jboss.windup</groupId>
         <artifactId>windup-parent</artifactId>
-        <version>6.3.9.Final</version>
+        <version>6.3.9-SNAPSHOT</version>
     </parent>
 
     <groupId>org.jboss.windup</groupId>

--- a/pf-ui/pom.xml
+++ b/pf-ui/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.jboss.windup</groupId>
         <artifactId>windup-parent</artifactId>
-        <version>6.3.9.Final</version>
+        <version>6.3.9-SNAPSHOT</version>
     </parent>
 
     <groupId>org.jboss.windup.reporting</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>org.jboss.windup</groupId>
     <artifactId>windup-parent</artifactId>
-    <version>6.3.9.Final</version>
+    <version>6.3.9-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Windup Parent</name>

--- a/reporting-data/addon/pom.xml
+++ b/reporting-data/addon/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.jboss.windup.reporting</groupId>
         <artifactId>windup-reporting-data-parent</artifactId>
-        <version>6.3.9.Final</version>
+        <version>6.3.9-SNAPSHOT</version>
     </parent>
 
     <artifactId>windup-reporting-data</artifactId>

--- a/reporting-data/pom.xml
+++ b/reporting-data/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.jboss.windup</groupId>
         <artifactId>windup-parent</artifactId>
-        <version>6.3.9.Final</version>
+        <version>6.3.9-SNAPSHOT</version>
     </parent>
 
     <groupId>org.jboss.windup.reporting</groupId>

--- a/reporting/addon/pom.xml
+++ b/reporting/addon/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jboss.windup.reporting</groupId>
         <artifactId>windup-reporting-parent</artifactId>
-        <version>6.3.9.Final</version>
+        <version>6.3.9-SNAPSHOT</version>
     </parent>
 
     <artifactId>windup-reporting</artifactId>

--- a/reporting/api/pom.xml
+++ b/reporting/api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jboss.windup.reporting</groupId>
         <artifactId>windup-reporting-parent</artifactId>
-        <version>6.3.9.Final</version>
+        <version>6.3.9-SNAPSHOT</version>
     </parent>
 
     <artifactId>windup-reporting-api</artifactId>

--- a/reporting/impl/pom.xml
+++ b/reporting/impl/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jboss.windup.reporting</groupId>
         <artifactId>windup-reporting-parent</artifactId>
-        <version>6.3.9.Final</version>
+        <version>6.3.9-SNAPSHOT</version>
     </parent>
 
     <artifactId>windup-reporting-impl</artifactId>

--- a/reporting/pom.xml
+++ b/reporting/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jboss.windup</groupId>
         <artifactId>windup-parent</artifactId>
-        <version>6.3.9.Final</version>
+        <version>6.3.9-SNAPSHOT</version>
     </parent>
 
     <groupId>org.jboss.windup.reporting</groupId>

--- a/reporting/tests/pom.xml
+++ b/reporting/tests/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jboss.windup.reporting</groupId>
         <artifactId>windup-reporting-parent</artifactId>
-        <version>6.3.9.Final</version>
+        <version>6.3.9-SNAPSHOT</version>
     </parent>
 
     <artifactId>windup-reporting-tests</artifactId>

--- a/rules-base/addon/pom.xml
+++ b/rules-base/addon/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jboss.windup.rules.apps</groupId>
         <artifactId>windup-rules-base-parent</artifactId>
-        <version>6.3.9.Final</version>
+        <version>6.3.9-SNAPSHOT</version>
     </parent>
 
     <artifactId>windup-rules-base</artifactId>

--- a/rules-base/api/pom.xml
+++ b/rules-base/api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jboss.windup.rules.apps</groupId>
         <artifactId>windup-rules-base-parent</artifactId>
-        <version>6.3.9.Final</version>
+        <version>6.3.9-SNAPSHOT</version>
     </parent>
 
     <artifactId>windup-rules-base-api</artifactId>

--- a/rules-base/impl/pom.xml
+++ b/rules-base/impl/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jboss.windup.rules.apps</groupId>
         <artifactId>windup-rules-base-parent</artifactId>
-        <version>6.3.9.Final</version>
+        <version>6.3.9-SNAPSHOT</version>
     </parent>
 
     <artifactId>windup-rules-base-impl</artifactId>

--- a/rules-base/pom.xml
+++ b/rules-base/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jboss.windup</groupId>
         <artifactId>windup-parent</artifactId>
-        <version>6.3.9.Final</version>
+        <version>6.3.9-SNAPSHOT</version>
     </parent>
 
     <groupId>org.jboss.windup.rules.apps</groupId>

--- a/rules-base/tests/pom.xml
+++ b/rules-base/tests/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jboss.windup.rules.apps</groupId>
         <artifactId>windup-rules-base-parent</artifactId>
-        <version>6.3.9.Final</version>
+        <version>6.3.9-SNAPSHOT</version>
     </parent>
 
     <artifactId>windup-rules-base-tests</artifactId>

--- a/rules-java-archives/addon/pom.xml
+++ b/rules-java-archives/addon/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jboss.windup.rules.apps</groupId>
         <artifactId>windup-rules-java-archives-parent</artifactId>
-        <version>6.3.9.Final</version>
+        <version>6.3.9-SNAPSHOT</version>
     </parent>
 
     <artifactId>windup-rules-java-archives</artifactId>

--- a/rules-java-archives/pom.xml
+++ b/rules-java-archives/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jboss.windup</groupId>
         <artifactId>windup-parent</artifactId>
-        <version>6.3.9.Final</version>
+        <version>6.3.9-SNAPSHOT</version>
     </parent>
 
     <groupId>org.jboss.windup.rules.apps</groupId>

--- a/rules-java-archives/tests/pom.xml
+++ b/rules-java-archives/tests/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jboss.windup.rules.apps</groupId>
         <artifactId>windup-rules-java-archives-parent</artifactId>
-        <version>6.3.9.Final</version>
+        <version>6.3.9-SNAPSHOT</version>
     </parent>
 
     <artifactId>windup-rules-java-archives-tests</artifactId>

--- a/rules-java-diva/addon/pom.xml
+++ b/rules-java-diva/addon/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.jboss.windup.rules.apps</groupId>
         <artifactId>windup-rules-java-diva-parent</artifactId>
-        <version>6.3.9.Final</version>
+        <version>6.3.9-SNAPSHOT</version>
     </parent>
     <artifactId>windup-rules-java-diva</artifactId>
 

--- a/rules-java-diva/pom.xml
+++ b/rules-java-diva/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.jboss.windup</groupId>
         <artifactId>windup-parent</artifactId>
-        <version>6.3.9.Final</version>
+        <version>6.3.9-SNAPSHOT</version>
     </parent>
 
     <groupId>org.jboss.windup.rules.apps</groupId>

--- a/rules-java-diva/tests/pom.xml
+++ b/rules-java-diva/tests/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.jboss.windup.rules.apps</groupId>
         <artifactId>windup-rules-java-diva-parent</artifactId>
-        <version>6.3.9.Final</version>
+        <version>6.3.9-SNAPSHOT</version>
     </parent>
     <artifactId>windup-rules-java-diva-tests</artifactId>
 

--- a/rules-java-ee/addon/pom.xml
+++ b/rules-java-ee/addon/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jboss.windup.rules.apps</groupId>
         <artifactId>windup-rules-java-ee-parent</artifactId>
-        <version>6.3.9.Final</version>
+        <version>6.3.9-SNAPSHOT</version>
     </parent>
     <artifactId>windup-rules-java-ee</artifactId>
 

--- a/rules-java-ee/pom.xml
+++ b/rules-java-ee/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jboss.windup</groupId>
         <artifactId>windup-parent</artifactId>
-        <version>6.3.9.Final</version>
+        <version>6.3.9-SNAPSHOT</version>
     </parent>
 
     <groupId>org.jboss.windup.rules.apps</groupId>

--- a/rules-java-ee/tests/pom.xml
+++ b/rules-java-ee/tests/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jboss.windup.rules.apps</groupId>
         <artifactId>windup-rules-java-ee-parent</artifactId>
-        <version>6.3.9.Final</version>
+        <version>6.3.9-SNAPSHOT</version>
     </parent>
     <artifactId>windup-rules-java-ee-tests</artifactId>
 

--- a/rules-java-project/addon/pom.xml
+++ b/rules-java-project/addon/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jboss.windup.rules.apps</groupId>
         <artifactId>windup-rules-java-project-parent</artifactId>
-        <version>6.3.9.Final</version>
+        <version>6.3.9-SNAPSHOT</version>
     </parent>
     <artifactId>windup-rules-java-project</artifactId>
 

--- a/rules-java-project/pom.xml
+++ b/rules-java-project/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jboss.windup</groupId>
         <artifactId>windup-parent</artifactId>
-        <version>6.3.9.Final</version>
+        <version>6.3.9-SNAPSHOT</version>
     </parent>
 
     <groupId>org.jboss.windup.rules.apps</groupId>

--- a/rules-java-project/tests/pom.xml
+++ b/rules-java-project/tests/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jboss.windup.rules.apps</groupId>
         <artifactId>windup-rules-java-project-parent</artifactId>
-        <version>6.3.9.Final</version>
+        <version>6.3.9-SNAPSHOT</version>
     </parent>
     <artifactId>windup-rules-java-project-tests</artifactId>
 

--- a/rules-java/addon/pom.xml
+++ b/rules-java/addon/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jboss.windup.rules.apps</groupId>
         <artifactId>windup-rules-java-parent</artifactId>
-        <version>6.3.9.Final</version>
+        <version>6.3.9-SNAPSHOT</version>
     </parent>
 
     <artifactId>windup-rules-java</artifactId>
@@ -35,7 +35,7 @@
         <dependency>
             <groupId>org.jboss.windup.decompiler</groupId>
             <artifactId>decompiler-fernflower</artifactId>
-            <version>6.3.9.Final</version>
+            <version>6.3.9-SNAPSHOT</version>
             <classifier>forge-addon</classifier>
             <scope>provided</scope>
         </dependency>

--- a/rules-java/api/pom.xml
+++ b/rules-java/api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jboss.windup.rules.apps</groupId>
         <artifactId>windup-rules-java-parent</artifactId>
-        <version>6.3.9.Final</version>
+        <version>6.3.9-SNAPSHOT</version>
     </parent>
 
     <artifactId>windup-rules-java-api</artifactId>
@@ -63,7 +63,7 @@
         <dependency>
             <groupId>org.jboss.windup.decompiler</groupId>
             <artifactId>decompiler-fernflower</artifactId>
-            <version>6.3.9.Final</version>
+            <version>6.3.9-SNAPSHOT</version>
             <classifier>forge-addon</classifier>
             <scope>provided</scope>
         </dependency>

--- a/rules-java/impl/pom.xml
+++ b/rules-java/impl/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jboss.windup.rules.apps</groupId>
         <artifactId>windup-rules-java-parent</artifactId>
-        <version>6.3.9.Final</version>
+        <version>6.3.9-SNAPSHOT</version>
     </parent>
 
     <artifactId>windup-rules-java-impl</artifactId>

--- a/rules-java/pom.xml
+++ b/rules-java/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jboss.windup</groupId>
         <artifactId>windup-parent</artifactId>
-        <version>6.3.9.Final</version>
+        <version>6.3.9-SNAPSHOT</version>
     </parent>
 
     <groupId>org.jboss.windup.rules.apps</groupId>

--- a/rules-java/tests/pom.xml
+++ b/rules-java/tests/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jboss.windup.rules.apps</groupId>
         <artifactId>windup-rules-java-parent</artifactId>
-        <version>6.3.9.Final</version>
+        <version>6.3.9-SNAPSHOT</version>
     </parent>
 
     <artifactId>windup-rules-java-tests</artifactId>

--- a/rules-tattletale/addon/pom.xml
+++ b/rules-tattletale/addon/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jboss.windup.rules.apps</groupId>
         <artifactId>windup-rules-tattletale-parent</artifactId>
-        <version>6.3.9.Final</version>
+        <version>6.3.9-SNAPSHOT</version>
     </parent>
     <artifactId>windup-rules-tattletale</artifactId>
     <name>Windup Rules - Tattletale</name>

--- a/rules-tattletale/pom.xml
+++ b/rules-tattletale/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jboss.windup</groupId>
         <artifactId>windup-parent</artifactId>
-        <version>6.3.9.Final</version>
+        <version>6.3.9-SNAPSHOT</version>
     </parent>
 
     <groupId>org.jboss.windup.rules.apps</groupId>

--- a/rules-tattletale/tests/pom.xml
+++ b/rules-tattletale/tests/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jboss.windup.rules.apps</groupId>
         <artifactId>windup-rules-tattletale-parent</artifactId>
-        <version>6.3.9.Final</version>
+        <version>6.3.9-SNAPSHOT</version>
     </parent>
     <artifactId>windup-rules-tattletale-tests</artifactId>
     <name>Windup Rules - Tattletale Tests</name>

--- a/rules-xml/addon/pom.xml
+++ b/rules-xml/addon/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jboss.windup.rules.apps</groupId>
         <artifactId>windup-rules-xml-parent</artifactId>
-        <version>6.3.9.Final</version>
+        <version>6.3.9-SNAPSHOT</version>
     </parent>
     <artifactId>windup-rules-xml</artifactId>
 

--- a/rules-xml/api/pom.xml
+++ b/rules-xml/api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jboss.windup.rules.apps</groupId>
         <artifactId>windup-rules-xml-parent</artifactId>
-        <version>6.3.9.Final</version>
+        <version>6.3.9-SNAPSHOT</version>
     </parent>
 
     <artifactId>windup-rules-xml-api</artifactId>
@@ -40,7 +40,7 @@
         <dependency>
             <groupId>org.jboss.windup.decompiler</groupId>
             <artifactId>decompiler-fernflower</artifactId>
-            <version>6.3.9.Final</version>
+            <version>6.3.9-SNAPSHOT</version>
             <classifier>forge-addon</classifier>
             <scope>provided</scope>
         </dependency>

--- a/rules-xml/impl/pom.xml
+++ b/rules-xml/impl/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jboss.windup.rules.apps</groupId>
         <artifactId>windup-rules-xml-parent</artifactId>
-        <version>6.3.9.Final</version>
+        <version>6.3.9-SNAPSHOT</version>
     </parent>
 
     <artifactId>windup-rules-xml-impl</artifactId>

--- a/rules-xml/pom.xml
+++ b/rules-xml/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jboss.windup</groupId>
         <artifactId>windup-parent</artifactId>
-        <version>6.3.9.Final</version>
+        <version>6.3.9-SNAPSHOT</version>
     </parent>
 
     <groupId>org.jboss.windup.rules.apps</groupId>

--- a/rules-xml/tests/pom.xml
+++ b/rules-xml/tests/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jboss.windup.rules.apps</groupId>
         <artifactId>windup-rules-xml-parent</artifactId>
-        <version>6.3.9.Final</version>
+        <version>6.3.9-SNAPSHOT</version>
     </parent>
     <artifactId>windup-rules-xml-tests</artifactId>
 

--- a/rules-yaml/addon/pom.xml
+++ b/rules-yaml/addon/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jboss.windup.rules.apps</groupId>
         <artifactId>windup-rules-yaml-parent</artifactId>
-        <version>6.3.9.Final</version>
+        <version>6.3.9-SNAPSHOT</version>
     </parent>
 
     <artifactId>windup-rules-yaml</artifactId>
@@ -17,7 +17,7 @@
         <dependency>
             <groupId>org.jboss.windup.rules.apps</groupId>
             <artifactId>windup-rules-yaml-api</artifactId>
-            <version>6.3.9.Final</version>
+            <version>6.3.9-SNAPSHOT</version>
         </dependency>
 
         <!-- Addon Dependencies -->

--- a/rules-yaml/api/pom.xml
+++ b/rules-yaml/api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jboss.windup.rules.apps</groupId>
         <artifactId>windup-rules-yaml-parent</artifactId>
-        <version>6.3.9.Final</version>
+        <version>6.3.9-SNAPSHOT</version>
     </parent>
 
     <artifactId>windup-rules-yaml-api</artifactId>
@@ -40,7 +40,7 @@
         <dependency>
             <groupId>org.jboss.windup.decompiler</groupId>
             <artifactId>decompiler-fernflower</artifactId>
-            <version>6.3.9.Final</version>
+            <version>6.3.9-SNAPSHOT</version>
             <classifier>forge-addon</classifier>
             <scope>provided</scope>
         </dependency>

--- a/rules-yaml/pom.xml
+++ b/rules-yaml/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jboss.windup</groupId>
         <artifactId>windup-parent</artifactId>
-        <version>6.3.9.Final</version>
+        <version>6.3.9-SNAPSHOT</version>
     </parent>
 
     <groupId>org.jboss.windup.rules.apps</groupId>

--- a/server-provider-spi/addon/pom.xml
+++ b/server-provider-spi/addon/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jboss.windup</groupId>
         <artifactId>windup-server-provider-spi-parent</artifactId>
-        <version>6.3.9.Final</version>
+        <version>6.3.9-SNAPSHOT</version>
     </parent>
     <artifactId>windup-server-provider-spi</artifactId>
 

--- a/server-provider-spi/pom.xml
+++ b/server-provider-spi/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jboss.windup</groupId>
         <artifactId>windup-parent</artifactId>
-        <version>6.3.9.Final</version>
+        <version>6.3.9-SNAPSHOT</version>
     </parent>
 
     <artifactId>windup-server-provider-spi-parent</artifactId>

--- a/test-files/pom.xml
+++ b/test-files/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jboss.windup</groupId>
         <artifactId>windup-parent</artifactId>
-        <version>6.3.9.Final</version>
+        <version>6.3.9-SNAPSHOT</version>
     </parent>
 
     <groupId>org.jboss.windup.tests</groupId>

--- a/test-util/pom.xml
+++ b/test-util/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jboss.windup</groupId>
         <artifactId>windup-parent</artifactId>
-        <version>6.3.9.Final</version>
+        <version>6.3.9-SNAPSHOT</version>
     </parent>
 
     <groupId>org.jboss.windup.tests</groupId>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jboss.windup</groupId>
         <artifactId>windup-parent</artifactId>
-        <version>6.3.9.Final</version>
+        <version>6.3.9-SNAPSHOT</version>
     </parent>
 
     <groupId>org.jboss.windup.tests</groupId>

--- a/tooling/addon/pom.xml
+++ b/tooling/addon/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jboss.windup</groupId>
         <artifactId>windup-tooling-parent</artifactId>
-        <version>6.3.9.Final</version>
+        <version>6.3.9-SNAPSHOT</version>
     </parent>
 
     <artifactId>windup-tooling</artifactId>

--- a/tooling/api/pom.xml
+++ b/tooling/api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jboss.windup</groupId>
         <artifactId>windup-tooling-parent</artifactId>
-        <version>6.3.9.Final</version>
+        <version>6.3.9-SNAPSHOT</version>
     </parent>
 
     <artifactId>windup-tooling-api</artifactId>

--- a/tooling/impl/pom.xml
+++ b/tooling/impl/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jboss.windup</groupId>
         <artifactId>windup-tooling-parent</artifactId>
-        <version>6.3.9.Final</version>
+        <version>6.3.9-SNAPSHOT</version>
     </parent>
 
     <artifactId>windup-tooling-impl</artifactId>

--- a/tooling/pom.xml
+++ b/tooling/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jboss.windup</groupId>
         <artifactId>windup-parent</artifactId>
-        <version>6.3.9.Final</version>
+        <version>6.3.9-SNAPSHOT</version>
     </parent>
 
     <artifactId>windup-tooling-parent</artifactId>

--- a/tooling/tests/pom.xml
+++ b/tooling/tests/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jboss.windup</groupId>
         <artifactId>windup-tooling-parent</artifactId>
-        <version>6.3.9.Final</version>
+        <version>6.3.9-SNAPSHOT</version>
     </parent>
 
     <artifactId>windup-tooling-tests</artifactId>

--- a/ui/addon/pom.xml
+++ b/ui/addon/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jboss.windup.ui</groupId>
         <artifactId>windup-ui-parent</artifactId>
-        <version>6.3.9.Final</version>
+        <version>6.3.9-SNAPSHOT</version>
     </parent>
     <artifactId>windup-ui</artifactId>
     <name>Windup Engine - UI</name>

--- a/ui/pom.xml
+++ b/ui/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jboss.windup</groupId>
         <artifactId>windup-parent</artifactId>
-        <version>6.3.9.Final</version>
+        <version>6.3.9-SNAPSHOT</version>
     </parent>
 
     <groupId>org.jboss.windup.ui</groupId>

--- a/ui/tests/pom.xml
+++ b/ui/tests/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jboss.windup.ui</groupId>
         <artifactId>windup-ui-parent</artifactId>
-        <version>6.3.9.Final</version>
+        <version>6.3.9-SNAPSHOT</version>
     </parent>
     <artifactId>windup-ui-tests</artifactId>
     <name>Windup Engine - UI Tests</name>

--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jboss.windup</groupId>
         <artifactId>windup-parent</artifactId>
-        <version>6.3.9.Final</version>
+        <version>6.3.9-SNAPSHOT</version>
     </parent>
 
     <groupId>org.jboss.windup.utils</groupId>

--- a/windup-test-harness/pom.xml
+++ b/windup-test-harness/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jboss.windup</groupId>
         <artifactId>windup-parent</artifactId>
-        <version>6.3.9.Final</version>
+        <version>6.3.9-SNAPSHOT</version>
     </parent>
     <artifactId>windup-test-harness</artifactId>
 


### PR DESCRIPTION
This reverts commit c051574c5e793ce885dd08dacd820408b865a150 due to failure in job https://github.com/windup/windup-pipelines/actions/runs/10280223480/job/28447099496